### PR TITLE
chore(infra): Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/devkor/ifive/morae/global/core/config/OpenApiConfig.java
+++ b/src/main/java/com/devkor/ifive/morae/global/core/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.devkor.ifive.morae.global.core.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("!prod")
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Morae API")
+                        .description("Morae API 문서")
+                        .version("v1.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/devkor/ifive/morae/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/devkor/ifive/morae/global/security/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.devkor.ifive.morae.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // springdoc / swagger-ui 경로는 모두 허용
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        // 그 외는 기존 정책대로
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,9 @@ spring:
       hibernate:
         ddl-auto: validate
     show-sql: false
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,9 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+
+springdoc:
+  api-docs:
+    enabled: false   # 공통: 기본 꺼두기
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## 📝 요약(Summary)

- Springdoc OpenAPI(Swagger UI) 설정을 추가하여 Morae 프로젝트의 API 문서를 자동 생성 및 시각화할 수 있도록 했습니다.
- 개발 환경에서 /swagger-ui.html 경로를 통해 API 엔드포인트를 쉽게 확인하고 테스트할 수 있습니다.

## 🔗 Related Issue

## 💬 공유사항
- 로컬에서 애플리케이션을 실행한 후 `http://localhost:8080/swagger-ui/index.html`에 접속하여 Morae API 문서에 접근할 수 있습니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.