### PR TITLE
chore(infra): Flyway 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     // Swagger
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13"
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core:11.7.1'
+    implementation 'org.flywaydb:flyway-database-postgresql:11.7.1'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,6 +16,11 @@ spring:
         ddl-auto: validate
     show-sql: false
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
 springdoc:
   api-docs:
     enabled: true


### PR DESCRIPTION
## 📝 요약(Summary)
Morae 프로젝트에 Flyway 마이그레이션을 도입했습니다.
DB 스키마 버전 관리를 코드 기반으로 일관성 있게 유지하기 위함이며,
모든 환경(local, dev, prod)에서 동일한 마이그레이션 이력을 추적할 수 있습니다.

## 🔗 Related Issue

## 💬 공유사항
### 1️⃣ 마이그레이션 파일 추가
1. 새 SQL 스키마 변경이 있을 때, `src/main/resources/db/migration` 경로에 새 파일을 "직접" 생성합니다.
> 예: V3__add_interest_table.sql
2. 버전(`V3`)은 이전 버전보다 1 증가시키고, `__`(언더스코어 2개) 뒤에는 변경 내용을 간결히 기술합니다.
3. 예시
```
-- V3__add_interest_table.sql
CREATE TABLE interest (
    id SERIAL PRIMARY KEY,
    name VARCHAR(100) UNIQUE NOT NULL,
    description TEXT
);
```

### 2️⃣ 마이그레이션 실행
Flyway는 `enabled: true`일 때 Spring Boot 애플리케이션 시작 시 자동으로 실행됩니다.
마이그레이션이 실패하면 애플리케이션이 부팅 실패합니다.
(즉, DB 스키마 불일치 시 즉시 감지가 가능합니다)

### 🔗️ 참고
Flyway가 처음 실행될 때, DB에 `flyway_schema_history`라는 테이블을 만듭니다.
이 테이블은 “어떤 마이그레이션이 이미 실행되었는지” 기록합니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.