### PR TITLE
fix(infra): 개발 서버 배포 시 JAR 파일 경로 문제 해결

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -45,30 +45,32 @@ jobs:
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           script: |
             set -euxo pipefail
-
+            
             cd ~/nadab
             echo "🔎 현재 서버 디렉토리: $(pwd)"
-
+            
             echo "📄 현재 파일 목록"
             ls -al
-
-            # 최근 JAR 선택
-            JAR_NAME=$(ls -1t *.jar | head -n1)
-            [ -n "$JAR_NAME" ] || { echo "❌ JAR 파일이 존재하지 않습니다"; exit 1; }
-
-            echo "📌 배포할 JAR 선택됨: $JAR_NAME"
-
+            
+            # 최근 JAR 선택 (build/libs 아래에서 찾기)
+            JAR_PATH=$(ls -1t build/libs/*.jar | head -n1 || true)
+            [ -n "$JAR_PATH" ] || { echo "❌ JAR 파일이 존재하지 않습니다"; exit 1; }
+            
+            JAR_NAME=$(basename "$JAR_PATH")
+            
+            echo "📌 배포할 JAR 선택됨: $JAR_PATH"
+            
             # 실행중인 프로세스 종료
             echo "🛑 기존 애플리케이션 종료 중..."
             pkill -f "$JAR_NAME" || true
-
+            
             echo "🚀 새 버전 실행..."
             DB_URL="${{ secrets.DB_URL }}" \
             DB_USERNAME="${{ secrets.DB_USERNAME }}" \
             DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             JWT_SECRET="${{ secrets.JWT_SECRET }}" \
             SWAGGER_SERVER_URL="${{ secrets.SWAGGER_SERVER_URL }}" \
-            nohup java -jar "$JAR_NAME" \
+            nohup java -jar "$JAR_PATH" \
               --spring.profiles.active=dev > app.log 2>&1 &
-
+            
             echo "✅ 배포 완료!"


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
GitHub Actions에서 EC2로 업로드된 JAR 파일이
`~/nadab/build/libs/` 경로에 위치하지만,
배포 스크립트는 `~/nadab/*.jar`만 조회하여 파일을 찾지 못하는 문제가 발생하였습니다.

따라서 배포 스크립트에서 JAR 검색 경로를 `build/libs/*.jar` 로 수정하고,
실제 실행 시에도 `JAR_PATH`(풀 경로)를 사용하도록 변경했습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.