### PR TITLE
refactor(global): 예외 클래스 정리 및 목적별로 분리

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/global/exception/BadRequestException.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.global.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/exception/ErrorResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/ErrorResponse.java
@@ -1,12 +1,7 @@
 package com.devkor.ifive.nadab.global.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class ErrorResponse {
-
-    private final int status;
-    private final String message;
+public record ErrorResponse(
+        int status,
+        String message
+) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
@@ -1,0 +1,48 @@
+package com.devkor.ifive.nadab.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        log.warn("error", ex);
+        return ResponseEntity.
+                badRequest().
+                body(error);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage());
+        log.warn("error", ex);
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(error);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        log.warn("error", ex);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(error);
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage());
+        log.warn("error", ex);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(error);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/exception/ForbiddenException.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/exception/NotFoundException.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.global.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
전역 예외 처리 구조를 개선하고, API 오류 응답을 일관되게 반환하도록 리팩토링했습니다.
기존 산재한 예외 클래스들을 정리하고 목적별 커스텀 예외를 추가했으며, ExceptionController에서 공통 포맷(ErrorResponse)으로 에러 응답을 처리하도록 변경했습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
### BadRequestException (400)
잘못된 요청이거나 입력값이 비즈니스 규칙을 위반할 때 사용합니다.
- 유효하지 않은 파라미터
- 허용 범위를 벗어난 값
- 필수 값 누락
- 잘못된 Enum 값

### UnauthorizedException (401)
인증 정보가 없거나 유효하지 않을 때 사용합니다.
- Authorization 헤더 미포함
- 만료되었거나 조작된 액세스 토큰
- 로그인하지 않은 사용자가 인증이 필요한 API 호출

### ForbiddenException (403)
인증은 되었지만 권한이 부족할 때 사용합니다.
- 일반 사용자가 관리자 전용 API 요청
- 다른 사용자의 리소스에 접근 시도

### NotFoundException (404)
요청한 리소스를 찾을 수 없을 때 사용합니다.
- 존재하지 않는 사용자/모임/게시글 조회
- 이미 삭제된 리소스 접근

### JwtAuthException
JWT 처리 과정에서 발생하는 인증 관련 내부 에러를 표현합니다.
(파싱, 서명 검증, 만료, claim 오류 등)
- 서명이 올바르지 않은 토큰
- 만료된 JWT
- 예상되지 않은 JWT 형식
- 잘못된 claim 값

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.