### PR TITLE
fix(auth): 소셜 계정 매핑되지 않은 사용자 정리

### DIFF
--- a/src/main/resources/db/migration/V20251129_0213__CH_cleanup_orphaned_users.sql
+++ b/src/main/resources/db/migration/V20251129_0213__CH_cleanup_orphaned_users.sql
@@ -1,0 +1,14 @@
+-- 이전 마이그레이션에서 provider/provider_id 정보가 손실된 사용자들을 정리
+
+-- refresh_tokens 먼저 삭제 (FK 제약 조건)
+DELETE FROM refresh_tokens
+WHERE user_id IN (
+    SELECT u.id
+    FROM users u
+    LEFT JOIN social_account sa ON u.id = sa.user_id
+    WHERE sa.id IS NULL
+);
+
+-- social_account에 매핑되어 있지 않은 사용자 모두 삭제
+DELETE FROM users
+WHERE id NOT IN (SELECT user_id FROM social_account);


### PR DESCRIPTION
## 📝 요약(Summary)
User 테이블에서 소셜 정보를 다른 테이블로 분리하는 마이그레이션을 진행하면서 provider와 provider_id 칼럼이 제거되어 프론트엔드에서 기존처럼 로그인 시도 시 409 에러가 발생했습니다. 따라서 social_account에 연관관계가 없는 user는 모두 삭제하여 해결하였습니다.

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.