### PR TITLE
fix(auth): Cross-Site 환경을 위한 쿠키 SameSite 설정 개선

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/cookie/CookieManager.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/cookie/CookieManager.java
@@ -21,6 +21,9 @@ public class CookieManager {
     @Value("${app.cookie.secure}")
     private boolean isCookieSecure;
 
+    @Value("${app.cookie.same-site}")
+    private String cookieSameSite;
+
     private static final String COOKIE_NAME = "refreshToken";
 
     private final TokenProperties tokenProperties;
@@ -32,7 +35,7 @@ public class CookieManager {
         return ResponseCookie.from(COOKIE_NAME, refreshToken)
                 .httpOnly(true)
                 .secure(isCookieSecure)
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .path("/api/v1/auth")
                 .maxAge(maxAge)
                 .build();
@@ -43,7 +46,7 @@ public class CookieManager {
         return ResponseCookie.from(COOKIE_NAME, "")
                 .httpOnly(true)
                 .secure(isCookieSecure)
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .path("/api/v1/auth")
                 .maxAge(0) // 즉시 만료
                 .build();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,7 @@ oauth:
 app:
   cookie:
     secure: true
+    same-site: None  # Cross-Site 허용 (프론트/백 도메인 분리된 상태)
 
 cors:
   allowed-origins:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,6 +35,7 @@ oauth:
 app:
   cookie:
     secure: false
+    same-site: Lax
 
 cors:
   allowed-origins: []

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,5 +31,6 @@ token:
 app:
   cookie:
     secure: false
+    same-site: Lax
 
 api_prefix: /api/v1


### PR DESCRIPTION
## 📝 요약(Summary)
개발 단계에서 프론트엔드와 백엔드 도메인이 달라 refresh token을 담은 쿠키에 same-site Lax 설정을 부여할 수 없는 문제가 있었습니다. 따라서 환경 별로 same-site를 공통은 Lax, local은 Lax, dev는 None으로 설정, CookieManager에서 이 값을 받아서 사용할 수 있도록 수정하였습니다.

## 🔗 Related Issue
- Closes: 

## 💬 공유사항
추후에 프로덕션 레벨에서 프론트엔드와 백엔드 도메인을 일치시키면 Lax를 쓸 수 있어서 그 때 application-prod.yml을 만들게 된다면
```
app:
  cookie:
    secure: true
    same-site: Lax
``` 
추가하면 됩니다!

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.