### PR TITLE
feat(user): 나의 프로필 수정 API 구현

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/user/api/UserController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/api/UserController.java
@@ -1,7 +1,9 @@
 package com.devkor.ifive.nadab.domain.user.api;
 
 import com.devkor.ifive.nadab.domain.user.api.dto.request.CreateProfileImageUploadUrlRequest;
+import com.devkor.ifive.nadab.domain.user.api.dto.request.UpdateUserProfileRequest;
 import com.devkor.ifive.nadab.domain.user.api.dto.response.CreateProfileImageUploadUrlResponse;
+import com.devkor.ifive.nadab.domain.user.api.dto.response.UpdateUserProfileResponse;
 import com.devkor.ifive.nadab.domain.user.api.dto.response.UserProfileResponse;
 import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
 import com.devkor.ifive.nadab.domain.user.application.UserCommandService;
@@ -31,8 +33,6 @@ public class UserController {
 
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
-    private final ProfileImageService profileImageService;
-    private final UserProfileUpdateService userProfileUpdateService;
 
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
@@ -96,7 +96,7 @@ public class UserController {
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody CreateProfileImageUploadUrlRequest request) {
         CreateProfileImageUploadUrlResponse response =
-                profileImageService.createUploadUrl(principal.getId(), request);
+                userCommandService.createUploadUrl(principal.getId(), request);
         return ApiResponseEntity.ok(response);
     }
 
@@ -121,8 +121,51 @@ public class UserController {
     )
     public ResponseEntity<ApiResponseDto<Void>> deleteProfileImage(
             @AuthenticationPrincipal UserPrincipal principal) {
-        userProfileUpdateService.deleteProfileImage(principal.getId());
+        userCommandService.deleteProfileImage(principal.getId());
         return ApiResponseEntity.noContent();
     }
 
+    @PatchMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "나의 프로필 수정",
+            description = """
+                    로그인한 사용자의 프로필 정보를 수정합니다.
+                    닉네임과 프로필 이미지를 하나씩만, 또는 둘 다 수정할 수 있습니다.
+                    **적어도 하나의 필드를 포함해야 합니다.**
+                    **5MB 이하의 이미지 파일만 허용됩니다.**
+                    
+                    (예) 프로필 이미지만 수정 시 nickname은 null
+                   
+                    프로필 이미지 수정의 경우,
+                    POST /user/me/profile-image/upload-url 엔드포인트로
+                    미리 발급받은 PresignedURL을 통해 이미지를 업로드한 후,
+                    해당 엔드포인트에서 반환된 objectKey를 이 요청에 포함시켜야 합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "프로필 수정 성공",
+                            content = @Content(schema = @Schema(implementation = UpdateUserProfileResponse.class), mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청 (예: 닉네임 중복)",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패",
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<UpdateUserProfileResponse>> updateUserProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UpdateUserProfileRequest request) {
+        UpdateUserProfileResponse response =
+                userCommandService.updateUserProfile(principal.getId(), request);
+        return ApiResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/request/UpdateUserProfileRequest.java
@@ -1,0 +1,18 @@
+package com.devkor.ifive.nadab.domain.user.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 프로필 업데이트 요청")
+public record UpdateUserProfileRequest(
+        @Schema(
+                description = "유저가 설정하고자 하는 새로운 닉네임입니다.",
+                example = "코딩하는개발자"
+        )
+        String nickname,
+        @Schema(
+                description = "이 값은 presignedURL 생성 API의 응답에서 받은 objectKey여야 합니다. ",
+                example = "dev/profiles/original/12345/092f7ab2-c845-4bdf-8458-e2897135d4e7.png"
+        )
+        String objectKey
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/response/CreateProfileImageUploadUrlResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/response/CreateProfileImageUploadUrlResponse.java
@@ -7,7 +7,7 @@ public record CreateProfileImageUploadUrlResponse(
         @Schema(description = "프로필 이미지 업로드 PresignedURL", example = "https://nadab-profile-images.s3.amazonaws.com/...")
         String uploadUrl,
 
-        @Schema(description = "프로필 이미지 Object Key. 프로필 업데이트에 사용됩니다.", example = "dev/profiles/12345/092f7ab2-c845-4bdf-8458-e2897135d4e7.png")
+        @Schema(description = "프로필 이미지 Object Key. 프로필 업데이트에 사용됩니다.", example = "dev/profiles/original/12345/092f7ab2-c845-4bdf-8458-e2897135d4e7.png")
         String objectKey
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/response/UpdateUserProfileResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/api/dto/response/UpdateUserProfileResponse.java
@@ -1,0 +1,11 @@
+package com.devkor.ifive.nadab.domain.user.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 프로필 수정 응답")
+public record UpdateUserProfileResponse(
+        String nickname,
+        String email,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/application/UserCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/application/UserCommandService.java
@@ -1,12 +1,25 @@
 package com.devkor.ifive.nadab.domain.user.application;
 
+import com.devkor.ifive.nadab.domain.user.api.dto.request.CreateProfileImageUploadUrlRequest;
+import com.devkor.ifive.nadab.domain.user.api.dto.request.UpdateUserProfileRequest;
+import com.devkor.ifive.nadab.domain.user.api.dto.response.CreateProfileImageUploadUrlResponse;
+import com.devkor.ifive.nadab.domain.user.api.dto.response.UpdateUserProfileResponse;
 import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
+import com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
+import com.devkor.ifive.nadab.domain.user.core.service.UserProfileUpdateService;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -14,4 +27,70 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserCommandService {
 
     private final UserRepository userRepository;
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
+    private final ProfileImageService profileImageService;
+    private final UserProfileUpdateService userProfileUpdateService;
+
+    @Value("${profile-image.env}")
+    private String env;
+
+    public CreateProfileImageUploadUrlResponse createUploadUrl(
+            Long userId,
+            CreateProfileImageUploadUrlRequest request) {
+
+        // content type / 확장자 검증
+        String contentType = request.contentType();
+        if (!"image/jpeg".equalsIgnoreCase(contentType)
+                && !"image/png".equalsIgnoreCase(contentType)) {
+            throw new BadRequestException("지원하지 않는 이미지 형식입니다. (jpg, png만 허용)");
+        }
+
+        String extension = switch (contentType) {
+            case "image/jpeg" -> "jpg";
+            case "image/png" -> "png";
+            default -> throw new BadRequestException("지원하지 않는 이미지 형식입니다.");
+        };
+
+        String uuid = UUID.randomUUID().toString();
+        String objectKey = "%s/profiles/original/%d/%s.%s"
+                .formatted(env, userId, uuid, extension);
+
+        String uploadUrl = profileImageService.generatePresignedUploadUrl(objectKey, contentType);
+
+        return new CreateProfileImageUploadUrlResponse(objectKey, uploadUrl);
+    }
+
+    public void deleteProfileImage(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다. id: " + id));
+
+        userProfileUpdateService.deleteProfileImage(user);
+    }
+
+    public UpdateUserProfileResponse updateUserProfile(Long id, @Valid UpdateUserProfileRequest request) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다. id: " + id));
+
+        if (request.nickname() == null && request.objectKey() == null) {
+            throw new BadRequestException("수정할 프로필 정보가 없습니다.");
+        }
+
+        if (request.nickname() != null) {
+            userProfileUpdateService.updateNickname(user, request.nickname());
+        }
+        if (request.objectKey() != null) {
+            userProfileUpdateService.updateProfileImage(user, request.objectKey());
+        }
+
+        // 온보딩인 경우 완료 처리
+        if (user.getSignupStatus().name().equals(SignupStatusType.PROFILE_INCOMPLETE.name())) {
+            user.updateSignupStatus(SignupStatusType.COMPLETED);
+        }
+
+        return new UpdateUserProfileResponse(
+                user.getNickname(),
+                user.getEmail(),
+                profileImageUrlBuilder.buildUserProfileUrl(user)
+        );
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/core/service/ProfileImageService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/core/service/ProfileImageService.java
@@ -1,19 +1,16 @@
 package com.devkor.ifive.nadab.domain.user.core.service;
 
-import com.devkor.ifive.nadab.domain.user.api.dto.request.CreateProfileImageUploadUrlRequest;
-import com.devkor.ifive.nadab.domain.user.api.dto.response.CreateProfileImageUploadUrlResponse;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 import java.time.Duration;
-import java.util.UUID;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,24 +26,7 @@ public class ProfileImageService {
     private String env;
 
     // 프로필 이미지 업로드 presigned URL 발급
-    public CreateProfileImageUploadUrlResponse createUploadUrl(Long userId,
-                                                               CreateProfileImageUploadUrlRequest request) {
-        // content type / 확장자 검증
-        String contentType = request.contentType();
-        if (!"image/jpeg".equalsIgnoreCase(contentType)
-                && !"image/png".equalsIgnoreCase(contentType)) {
-            throw new BadRequestException("지원하지 않는 이미지 형식입니다. (jpg, png만 허용)");
-        }
-
-        String extension = switch (contentType) {
-            case "image/jpeg" -> "jpg";
-            case "image/png"  -> "png";
-            default -> throw new BadRequestException("지원하지 않는 이미지 형식입니다.");
-        };
-
-        String uuid = UUID.randomUUID().toString();
-        String objectKey = "%s/profiles/original/%d/%s.%s"
-                .formatted(env, userId, uuid, extension);
+    public String generatePresignedUploadUrl(String objectKey, String contentType) {
 
         // PutObjectRequest 생성
         PutObjectRequest objectRequest = PutObjectRequest.builder()
@@ -62,8 +42,7 @@ public class ProfileImageService {
                         .putObjectRequest(objectRequest));
 
         String url = presignedRequest.url().toString();
-
-        return new CreateProfileImageUploadUrlResponse(url, objectKey);
+        return url;
     }
 
     /**
@@ -80,6 +59,29 @@ public class ProfileImageService {
                 .build();
 
         s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    /**
+     * 업로드된 이미지의 유효성 검사
+     */
+    public void checkImageValidity(String objectKey) {
+        HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .build();
+
+        HeadObjectResponse metadata = s3Client.headObject(headObjectRequest);
+
+        String contentType = metadata.contentType();
+        Long size = metadata.contentLength();
+
+        if (size == null || contentType == null || !List.of("image/jpeg", "image/png", "image/webp").contains(contentType)) {
+            throw new BadRequestException("지원하지 않는 이미지 형식 또는 메타데이터가 누락되었습니다.");
+        }
+        if (size > 5 * 1024 * 1024) {
+            this.deleteProfileImage(objectKey);
+            throw new BadRequestException("이미지 용량이 너무 큽니다. (최대 5MB)");
+        }
     }
 }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/core/service/UserProfileUpdateService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/core/service/UserProfileUpdateService.java
@@ -3,7 +3,6 @@ package com.devkor.ifive.nadab.domain.user.core.service;
 import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
-import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +15,24 @@ public class UserProfileUpdateService {
     private final UserRepository userRepository;
     private final ProfileImageService profileImageService;
 
-    public void deleteProfileImage(Long id) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다. id: " + id));
+    public void deleteProfileImage(User user) {
         String oldProfileImageKey = user.getProfileImageKey();
 
         user.updateToDefaultProfile(DefaultProfileType.DEFAULT);
+        profileImageService.deleteProfileImage(oldProfileImageKey);
+    }
+
+    public void updateNickname(User user, String nickname) {
+        // 닉네임 유효성 검사 추가 예정
+        user.updateNickname(nickname);
+    }
+
+    public void updateProfileImage(User user, String objectKey) {
+        profileImageService.checkImageValidity(objectKey);
+
+        String oldProfileImageKey = user.getProfileImageKey();
+
+        user.updateToCustomProfile(objectKey);
         profileImageService.deleteProfileImage(oldProfileImageKey);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 @RestControllerAdvice
 @Slf4j
@@ -42,5 +43,18 @@ public class ExceptionController {
 
         HttpStatus status = HttpStatus.valueOf(ex.getStatusCode());
         return ApiResponseEntity.error(status, ex.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchKeyException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleNoSuchKeyException(NoSuchKeyException ex) {
+        log.warn("NoSuchKeyException: {}", ex.getMessage(), ex);
+        // S3에서 객체를 찾을 수 없을 때 404 NOT_FOUND 응답
+        return ApiResponseEntity.error(HttpStatus.NOT_FOUND, "S3에서 요청된 파일을 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleRuntimeException(RuntimeException ex) {
+        log.error("Internal Server Error (RuntimeException): {}", ex.getMessage(), ex);
+        return ApiResponseEntity.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 예상치 못한 오류가 발생했습니다.");
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
로그인한 사용자의 프로필 정보를 수정하는 API를 구현했습니다.
닉네임과 프로필 이미지를 하나씩만, 또는 둘 다 수정할 수 있습니다.
**적어도 하나의 필드를 포함해야 합니다.**
**5MB 이하의 이미지 파일만 허용됩니다.**

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
닉네임의 유효성을 검사하는 로직 및 API를 구현할 예정입니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.