### PR TITLE
fix(global): RuntimeException 핸들러가 Security 예외를 가로채지 않도록 수정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/exception/ExceptionController.java
@@ -5,6 +5,8 @@ import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -82,6 +84,10 @@ public class ExceptionController {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponseDto<Void>> handleRuntimeException(RuntimeException ex) {
+        if (ex instanceof AuthenticationException || ex instanceof AccessDeniedException) {
+            throw ex; // 다시 던져서 Security FilterChain이 처리하게
+        }
+
         log.error("Internal Server Error (RuntimeException): {}", ex.getMessage(), ex);
         return ApiResponseEntity.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 예상치 못한 오류가 발생했습니다.");
     }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
이전에 전역 ```RuntimeException``` 핸들러를 추가하면서
스프링 시큐리티가 인증/인가 실패 시 던지는 예외까지 전부 가로채버렸고,
그로 인해 Security filter chain의 예외 처리기가 호출되지 못해 JWT 누락/만료 시 401 Unauthorized Error가 아니라
의도치 않은 500 Internal Server Error가 발생했습니다.

따라서 ```@ExceptionHandler(RuntimeException.class)``` 내부에서
```AuthenticationException```, ```AccessDeniedException``` 발생 시 다시 throw하도록 변경하여
Spring Security의 기본 예외 처리 흐름 (```JwtAuthenticationEntryPoint```, ```JwtAccessDeniedHandler```)이 정상적으로 작동하도록 복구하였습니다.

결과적으로 이제 JWT 누락/만료 상태에서 401 Unauthorized, 접근 권한이 없는 경우 403 Forbidden이 정상 동작합니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ v ] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.