### PR TITLE
fix(infra): 프롬프트 Secret 로딩 오류 해결 및 base64 인코딩 방식으로 전환

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -65,6 +65,11 @@ jobs:
             pkill -f "$JAR_NAME" || true
             
             echo "🚀 새 버전 실행..."
+            
+            # ✅ base64로 인코딩된 프롬프트를 환경 변수에 디코딩해서 넣기
+            INSIGHT_PROMPT_B64="${{ secrets.INSIGHT_PROMPT_B64 }}"
+            INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d)"
+            
             DB_URL="${{ secrets.DB_URL }}" \
             DB_USERNAME="${{ secrets.DB_USERNAME }}" \
             DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/SecretDailyReportPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/SecretDailyReportPromptLoader.java
@@ -23,7 +23,6 @@ public class SecretDailyReportPromptLoader implements DailyReportPromptLoader{
             throw new BadRequestException("INSIGHT_PROMPT 환경 변수에 프롬프트가 설정되어 있지 않습니다.");
         }
 
-        // GitHub Secret에는 "\n"으로 저장 → 실제 줄바꿈으로 복원
-        return rawPrompt.replace("\\n", "\n");
+        return rawPrompt;
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
프롬프트가 GitHub Secrets → EC2 환경 변수로 전달되는 과정에서
쉘에서 문자열이 잘려 실행 오류가 발생하는 문제가 있었습니다.
이는 프롬프트 내부의 더블 쿼트(```"message": "..."```) 및 공백이 쉘에서 문자열 분리로 해석되며 발생한 문제입니다.

이를 해결하기 위해 GitHub Secrets에 base64로 인코딩된 프롬프트를 저장하고,
EC2에서 디코딩하여 환경 변수로 주입하는 방식으로 안전하게 전면 전환했습니다.

정리하면,
**prompt.txt → base64 인코딩 → Secret 저장 → EC2에서 디코딩 후 ENV로 설정**

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.