### PR TITLE
fix(infra): base64 디코딩된 INSIGHT_PROMPT를 환경 변수로 export하도록 수정

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -68,7 +68,8 @@ jobs:
             
             # ✅ base64로 인코딩된 프롬프트를 환경 변수에 디코딩해서 넣기
             INSIGHT_PROMPT_B64="${{ secrets.INSIGHT_PROMPT_B64 }}"
-            INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d)"
+            INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export INSIGHT_PROMPT
             
             DB_URL="${{ secrets.DB_URL }}" \
             DB_USERNAME="${{ secrets.DB_USERNAME }}" \
@@ -90,7 +91,7 @@ jobs:
             PROFILE_IMAGE_BASE_URL="${{ secrets.PROFILE_IMAGE_BASE_URL }}" \
             MAIL_ADDRESS="${{ secrets.MAIL_ADDRESS }}" \
             MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
-            INSIGHT_PROMPT="${{ secrets.INSIGHT_PROMPT }}" \
+            
             nohup java -jar "$JAR_PATH" \
               --spring.profiles.active=dev > app.log 2>&1 &
             


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
GitHub Secrets → EC2 → Spring 환경 변수로 ```INSIGHT_PROMPT```를 전달하는 과정에서,
inline 환경 변수 정의 방식(```INSIGHT_PROMPT="$INSIGHT_PROMPT" \```)이 multiline 문자열을 정상적으로 처리하지 못해
실제 실행 시 ```INSIGHT_PROMPT=```(빈 값)으로 덮여버리는 문제가 발생했습니다.

그 결과 개발 서버 환경에서 ```SecretDailyReportPromptLoader```가
"INSIGHT_PROMPT 환경 변수에 프롬프트가 설정되어 있지 않습니다."
오류를 발생시키며 오늘의 리포트 생성 API가 400을 반환하는 현상이 나타났습니다.

따라서 환경 변수 주입 방식을 inline → export로 전환했습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.