### PR TITLE
fix(infra): 개발 서버 배포 스크립트의 백슬래시 뒤 공백으로 인한 실행 오류 해결

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -90,7 +90,7 @@ jobs:
             BUCKET_NAME="${{ secrets.BUCKET_NAME }}" \
             PROFILE_IMAGE_BASE_URL="${{ secrets.PROFILE_IMAGE_BASE_URL }}" \
             MAIL_ADDRESS="${{ secrets.MAIL_ADDRESS }}" \
-            MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \            
+            MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
             nohup java -jar "$JAR_PATH" \
               --spring.profiles.active=dev > app.log 2>&1 &
             


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
GitHub Actions의 EC2 배포 단계에서 다음과 같은 오류가 발생했습니다.

```
bash: line XX: : command not found
```

원인은 `MAIL_PASSWORD="..." \` 뒤에 **공백이 포함되어 있어**,  
bash에서 줄 계속(line continuation)이 깨지고  
공백만 있는 빈 줄이 하나의 명령으로 실행된 것이었습니다.

### 🔧 해결 내용
- 해당 줄의 **백슬래시 뒤 공백을 제거**하여 정상적인 줄 계속이 되도록 수정했습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.