### PR TITLE
refactor: emotions 테이블에서 '사랑', '고통'에 해당하는 레코드 제거

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
@@ -99,10 +99,8 @@ public class DailyReportController {
                     | :--- | :--- |
                     | `JOY` | 기쁨 |
                     | `PLEASURE` | 즐거움 |
-                    | `LOVE` | 사랑 |
                     | `SADNESS` | 슬픔 |
                     | `ANGER` | 분노 |
-                    | `PAIN` | 고통 |
                     | `REGRET` | 후회 |
                     | `FRUSTRATION` | 좌절 |
                     | `GROWTH` | 성장 |

--- a/src/main/resources/db/migration/V20260101_0234__IS_replace_daily_reports_emotion_and_remove_love_pain.sql
+++ b/src/main/resources/db/migration/V20260101_0234__IS_replace_daily_reports_emotion_and_remove_love_pain.sql
@@ -1,0 +1,16 @@
+-- 1) daily_reports.emotion_id 를 '기타(ETC)'로 치환
+UPDATE daily_reports
+SET emotion_id = (
+    SELECT id
+    FROM emotions
+    WHERE code = 'ETC'
+)
+WHERE emotion_id IN (
+    SELECT id
+    FROM emotions
+    WHERE code IN ('LOVE', 'PAIN')
+);
+
+-- 2) emotions에서 '사랑(LOVE)', '고통(PAIN)' 레코드 삭제
+DELETE FROM emotions
+WHERE code IN ('LOVE', 'PAIN');


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
emotions 테이블에서 '사랑', '고통'에 해당하는 레코드를 제거했습니다. 이에 따라
- flyway 마이그레이션 sql 작성 : (1) daily_reports의 FK를 먼저 ‘ETC(기타)’로 치환 → (2) emotions에서 LOVE/PAIN 삭제.
- 스웨거 문서 수정
- 오늘의 리포트 생성 프롬프트 수정(Github Secrets)

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.