### PR TITLE
refactor(search): JPQL 호환성 문제 해결

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/AnswerQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/AnswerQueryService.java
@@ -8,6 +8,8 @@ import com.devkor.ifive.nadab.domain.dailyreport.core.entity.EmotionCode;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.AnswerEntryQueryRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.application.helper.CursorParser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -30,14 +32,29 @@ public class AnswerQueryService {
         EmotionCode emotionCode = parseEmotionCode(request.emotionCode());
         LocalDate cursorDate = CursorParser.parse(request.cursor());
 
-        // 검색 실행 (PAGE_SIZE + 1개 조회)
-        List<SearchAnswerEntryDto> results = answerEntryQueryRepository.searchAnswerEntries(
-                userId,
-                keyword,
-                emotionCode,
-                cursorDate,
-                PAGE_SIZE + 1
-        );
+        // Pageable 생성 (PAGE_SIZE + 1개 조회)
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
+
+        // 검색 실행 - 조건별 분기
+        List<SearchAnswerEntryDto> results;
+        if (cursorDate == null) {
+            // 첫 페이지 조회
+            results = answerEntryQueryRepository.searchAnswerEntriesFirstPage(
+                    userId,
+                    keyword,
+                    emotionCode,
+                    pageable
+            );
+        } else {
+            // 다음 페이지 조회 (cursor 있음)
+            results = answerEntryQueryRepository.searchAnswerEntriesWithCursor(
+                    userId,
+                    keyword,
+                    emotionCode,
+                    cursorDate,
+                    pageable
+            );
+        }
 
         // hasNext 판단
         boolean hasNext = results.size() > PAGE_SIZE;

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.dailyreport.core.repository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.dto.SearchAnswerEntryDto;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.AnswerEntry;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.EmotionCode;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +14,9 @@ import java.util.Optional;
 
 public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long> {
 
+    /**
+     * 첫 페이지 조회 (cursor 없음)
+     */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.SearchAnswerEntryDto(
             ae.id, ae.question.interest.code, e.code, ae.question.questionText, ae.content, ae.date
@@ -23,15 +27,36 @@ public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long
         where ae.user.id = :userId
           and (:keyword is null or ae.question.questionText like :keyword escape '\\' or ae.content like :keyword escape '\\')
           and (:emotionCode is null or e.code = :emotionCode)
-          and (cast(:cursorDate as date) is null or ae.date < :cursorDate)
         order by ae.date desc
-        limit :size
         """)
-    List<SearchAnswerEntryDto> searchAnswerEntries(
+    List<SearchAnswerEntryDto> searchAnswerEntriesFirstPage(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            @Param("emotionCode") EmotionCode emotionCode,
+            Pageable pageable
+    );
+
+    /**
+     * 다음 페이지 조회 (cursor 있음)
+     */
+    @Query("""
+        select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.SearchAnswerEntryDto(
+            ae.id, ae.question.interest.code, e.code, ae.question.questionText, ae.content, ae.date
+        )
+        from AnswerEntry ae
+        left join DailyReport dr on dr.answerEntry = ae and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+        left join dr.emotion e
+        where ae.user.id = :userId
+          and (:keyword is null or ae.question.questionText like :keyword escape '\\' or ae.content like :keyword escape '\\')
+          and (:emotionCode is null or e.code = :emotionCode)
+          and ae.date < :cursorDate
+        order by ae.date desc
+        """)
+    List<SearchAnswerEntryDto> searchAnswerEntriesWithCursor(
             @Param("userId") Long userId,
             @Param("keyword") String keyword,
             @Param("emotionCode") EmotionCode emotionCode,
             @Param("cursorDate") LocalDate cursorDate,
-            @Param("size") int size
+            Pageable pageable
     );
 }


### PR DESCRIPTION
## 📝 요약(Summary)
서버가 502 Bad Gateway가 떠서 JPQL 호환성 문제로 의심하고 수정해보았습니다.
limit :size를 Pageable로 변경, cast() 조건을 메서드 분리로 대체

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.