### PR TITLE
fix(auth): 쿠키 생성 시 path 설정 변경

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/cookie/CookieManager.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/cookie/CookieManager.java
@@ -37,18 +37,18 @@ public class CookieManager {
                 .httpOnly(true)
                 .secure(isCookieSecure)
                 .sameSite(cookieSameSite)
-                .path("/api/v1/auth")
+                .path("/")
                 .maxAge(maxAge)
                 .build();
     }
 
     // Refresh Token 쿠키 삭제
-    private ResponseCookie delete() {
+    private ResponseCookie deleteWithPath(String path) {
         return ResponseCookie.from(COOKIE_NAME, "")
                 .httpOnly(true)
                 .secure(isCookieSecure)
                 .sameSite(cookieSameSite)
-                .path("/api/v1/auth")
+                .path(path)
                 .maxAge(0) // 즉시 만료
                 .build();
     }
@@ -61,8 +61,11 @@ public class CookieManager {
 
     // Refresh Token 쿠키를 만료시켜 응답에 추가
     public void removeRefreshTokenCookie(HttpServletResponse response) {
-        ResponseCookie cookie = delete();
-        response.addHeader("Set-Cookie", cookie.toString());
+        // 신규 path
+        response.addHeader("Set-Cookie", deleteWithPath("/").toString());
+
+        // 레거시 호환: 예전에 발급했던 path도 함께 삭제
+        response.addHeader("Set-Cookie", deleteWithPath("/api/v1/auth").toString());
     }
 
     // 쿠키에서 Refresh Token 추출


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- iOS 사파리 브라우저에서 새로고침을 하거나 탭 삭제 후 재접속 시에 로그인이 풀리는 현상 발생
- 로그 확인 결과 쿠키에서 refresh token을 추출할 수 없다고 뜸 -> iOS 사파리의 쿠키 정책이 좀 더 엄격하기 때문

- 프론트와 서버 각각에서 처리해야할 것들이 있는데, 서버 측에서는 현재 쿠키 설정에서 path만 ```"/```"로 수정하면 되어 수정함
- 이에 따라 쿠키 삭제 시에 기존 path의 쿠키와 새로운 path의 쿠키를 함께 삭제하도록 변경

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.