### PR TITLE
refactor(report): 일간 리포트 생성 트랜잭션 단순화 및 동시성 안정화

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/AnswerEntryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/AnswerEntryService.java
@@ -7,8 +7,8 @@ import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import com.devkor.ifive.nadab.global.shared.util.dto.TodayDateTimeRangeDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -21,15 +21,24 @@ public class AnswerEntryService {
     private final AnswerEntryRepository answerEntryRepository;
 
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public AnswerEntry getOrCreateTodayAnswerEntry(User user, DailyQuestion dq, String answerText) {
 
         TodayDateTimeRangeDto range = TodayDateTimeProvider.getRange();
 
         LocalDate today = TodayDateTimeProvider.getTodayDate();
 
-        return answerEntryRepository.findByUserAndCreatedAtBetween(user, range.startOfToday(), range.startOfTomorrow())
-                .orElseGet(() -> answerEntryRepository.save(AnswerEntry.create(user, dq, answerText, today)));
+        return answerEntryRepository.
+                findByUserAndCreatedAtBetween(user, range.startOfToday(), range.startOfTomorrow())
+                .orElseGet(() -> {
+                    try {
+                        return answerEntryRepository.save(AnswerEntry.create(user, dq, answerText, today));
+                    } catch (DataIntegrityViolationException e) {
+                        // 동시 요청에서 이미 누가 만들었을 수 있음 -> 재조회로 멱등 처리
+                        return answerEntryRepository.findByUserAndCreatedAtBetween(user, range.startOfToday(), range.startOfTomorrow())
+                                .orElseThrow(() -> e);
+                    }
+                });
     }
 }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/PendingDailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/PendingDailyReportService.java
@@ -9,8 +9,8 @@ import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import com.devkor.ifive.nadab.global.shared.util.dto.TodayDateTimeRangeDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -23,15 +23,24 @@ public class PendingDailyReportService {
     private final DailyReportRepository dailyReportRepository;
 
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public DailyReport getOrCreatePendingDailyReport(AnswerEntry entry) {
 
         TodayDateTimeRangeDto range = TodayDateTimeProvider.getRange();
 
         LocalDate today = TodayDateTimeProvider.getTodayDate();
 
-        DailyReport report = dailyReportRepository.findByAnswerEntryAndCreatedAtBetween(entry, range.startOfToday(), range.startOfTomorrow())
-                .orElseGet(() -> dailyReportRepository.save(DailyReport.createPending(entry, today)));
+        DailyReport report = dailyReportRepository.
+                findByAnswerEntryAndCreatedAtBetween(entry, range.startOfToday(), range.startOfTomorrow())
+                .orElseGet(() -> {
+                    try {
+                        return dailyReportRepository.save(DailyReport.createPending(entry, today));
+                    } catch (DataIntegrityViolationException e) {
+                        // 동시 요청에서 이미 누가 만들었을 수 있음 -> 재조회로 멱등 처리
+                        return dailyReportRepository.findByAnswerEntryAndCreatedAtBetween(entry, range.startOfToday(), range.startOfTomorrow())
+                                .orElseThrow(() -> e);
+                    }
+                });
 
         if (report.getStatus() == DailyReportStatus.COMPLETED) {
             throw new ConflictException(ErrorCode.DAILY_REPORT_ALREADY_COMPLETED);


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존 일간 리포트 생성 로직에서는 ```AnswerEntry``` 생성과 Pending ```DailyReport``` 생성을 각각 ```REQUIRES_NEW``` 트랜잭션으로 분리하고 있었습니다.
이로 인해,
- 상위 트랜잭션 실패 시에도 일부 데이터가 커밋되는 부분 커밋 위험
- prepare 단계에서 불필요하게 트랜잭션 경계가 쪼개져 정합성 추론이 어려운 구조
- 동시 요청 시 find → save 패턴으로 인한 중복 생성 가능성
이 존재했습니다.

**변경 사항**
- ```AnswerEntry``` / Pending ```DailyReport``` 생성 로직에서 ```REQUIRES_NEW``` 전파 제거
- 일간 리포트 prepare 단계를 단일 트랜잭션으로 묶어 원자성 보장
- ```AnswerEntry```, ```DailyReport```에 DB 유니크 제약을 기반으로 중복 생성 방지
- 동시 요청으로 유니크 제약 위반 발생 시, 재조회 방식으로 멱등 처리

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.