### PR TITLE
feat(friend): 친구 검색 대소문자 구분 제거

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
@@ -54,7 +54,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
         where (f.user1.id = :userId or f.user2.id = :userId)
         and f.requester.id != :userId
         and f.status = 'PENDING'
-        and r.nickname like :keyword escape '\\'
+        and lower(r.nickname) like lower(:keyword) escape '\\'
         and f.user1.deletedAt is null and f.user2.deletedAt is null
         order by f.createdAt desc
         """)

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
@@ -39,14 +39,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
         from User u
         left join Friendship f1 on f1.user1.id = :userId and f1.user2.id = u.id
         left join Friendship f2 on f2.user2.id = :userId and f2.user1.id = u.id
-        where u.nickname like :keyword escape '\\'
+        where lower(u.nickname) like lower(:keyword) escape '\\'
           and u.deletedAt is null
           and (:cursor is null or u.nickname > :cursor)
           and (:excludeUserIds is null or u.id not in :excludeUserIds)
         order by
           case
-            when u.nickname = :rawKeyword then 1
-            when u.nickname like :prefixKeyword escape '\\' then 2
+            when lower(u.nickname) = lower(:rawKeyword) then 1
+            when lower(u.nickname) like lower(:prefixKeyword) escape '\\' then 2
             else 3
           end asc,
           u.nickname asc

--- a/src/main/resources/db/migration/V20260206_1126__CH_add_case_insensitive_index_to_users_nickname.sql
+++ b/src/main/resources/db/migration/V20260206_1126__CH_add_case_insensitive_index_to_users_nickname.sql
@@ -1,0 +1,2 @@
+-- 대소문자 구분 없는 닉네임 검색을 위한 함수 기반 인덱스
+CREATE INDEX idx_users_nickname_lower ON users (LOWER(nickname));


### PR DESCRIPTION
## 📝 요약(Summary)
친구 검색 시 대소문자를 구분하지 않도록 개선했습니다.  기존 쿼리에서 LOWER() 함수를 사용하여 조회하도록 변경하였습니다. 그리고 LOWER(nickname)에 대한 Function-based Index를 추가하여 검색 성능을 향상시켰습니다.

## 🔗 Related Issue
- Closes: 

## 💬 공유사항
정렬은 원본 nickname 기준(ASCII 순서)으로 됩니다. 커서 기반 페이지네이션에서 누락을 방지하고자 이렇게 설계하였습니다.
예시)
사용자가 "joh" 입력 중...

  검색 결과:
  [접두사 일치 그룹]
  1. JOHN      ← 대문자, 짧은 이름
  2. JOHNNY    ← 대문자, 긴 이름
  3. John      ← 일반적인 표기
  4. Johnny
  5. john      ← 소문자
  6. johnny

사용자가 "john" 입력 완료

  검색 결과:
  [정확히 일치 그룹]
  1. JOHN      ← 대문자 우선
  2. John
  3. john      ← 소문자는 나중

  [접두사 일치 그룹]
  4. JOHNNY
  5. Johnny
  6. johnny

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.