### PR TITLE
fix(report): ID로 오늘의 리포트 상세 조회 JPQL에서 question/interest 조인 명시화

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -43,16 +43,23 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
      * 리포트 ID(DailyReport.id)로 답변 상세 조회
      */
     @Query("""
-    select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
-        ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code
-    )
-    from DailyReport dr
-    join dr.answerEntry ae
-    left join dr.emotion e
-    where dr.id = :reportId
-      and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
-      and ae.user.id = :userId
-    """)
+        select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
+            q.questionText,
+            i.code,
+            ae.date,
+            ae.content,
+            dr.content,
+            e.code
+        )
+        from DailyReport dr
+        join dr.answerEntry ae
+        join ae.question q
+        left join q.interest i
+        left join dr.emotion e
+        where dr.id = :reportId
+        and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+        and ae.user.id = :userId
+""")
     Optional<AnswerDetailDto> findDetailByReportId(
             @Param("userId") Long userId,
             @Param("reportId") Long reportId


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- ```ae.question.interest.code``` 같은 path-expression 접근이 JPA에서 암묵적 inner join을 유발할 수 있어,
  특정 데이터(interest null 등)에서 상세 조회가 비정상(결과 누락) 가능
- DailyReport 상세 조회 JPQL을 조인 경로 기반(path expression) 접근에서 명시적 join 방식으로 수정
  - ```DailyQuestion.interest```를 left join으로 변경하여, interest가 null인 케이스에서 조회 결과가 사라지는 문제를 예방

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.