### PR TITLE
feat: 주간/월간 통계에 일간 리포트 생성 수 추가 및 생성 차트 분할

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/MonthlyStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/MonthlyStatsService.java
@@ -56,9 +56,13 @@ public class MonthlyStatsService {
         Map<YearMonth, Long> completedMap = aggregateByMonth(
                 repo.findCompletedMonthlyReportCountsByDateBetween(startDate, endDateInclusive)
         );
+        Map<YearMonth, Long> completedDailyMap = aggregateByMonth(
+                repo.findCompletedDailyReportCountsByDateBetween(startDate, endDateInclusive)
+        );
 
         List<Long> signupCounts = months.stream().map(m -> signupMap.getOrDefault(m, 0L)).toList();
         List<Long> assignedCounts = months.stream().map(m -> assignedMap.getOrDefault(m, 0L)).toList();
+        List<Long> completedDailyCounts = months.stream().map(m -> completedDailyMap.getOrDefault(m, 0L)).toList();
         List<Long> completedCounts = months.stream().map(m -> completedMap.getOrDefault(m, 0L)).toList();
 
         long inProgressNow = repo.countInProgressMonthlyReportsNow();
@@ -67,6 +71,7 @@ public class MonthlyStatsService {
                 labels,
                 signupCounts,
                 assignedCounts,
+                completedDailyCounts,
                 completedCounts,
                 inProgressNow,
                 OffsetDateTime.now(SEOUL).format(FMT)

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/WeeklyStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/WeeklyStatsService.java
@@ -55,9 +55,13 @@ public class WeeklyStatsService {
         Map<LocalDate, Long> completedMap = aggregateByWeekStart(
                 repo.findCompletedWeeklyReportCountsByDateBetween(startWeekStart, endDateInclusive)
         );
+        Map<LocalDate, Long> completedDailyMap = aggregateByWeekStart(
+                repo.findCompletedDailyReportCountsByDateBetween(startWeekStart, endDateInclusive)
+        );
 
         List<Long> signupCounts = weekStarts.stream().map(d -> signupMap.getOrDefault(d, 0L)).toList();
         List<Long> assignedCounts = weekStarts.stream().map(d -> assignedMap.getOrDefault(d, 0L)).toList();
+        List<Long> completedDailyCounts = weekStarts.stream().map(d -> completedDailyMap.getOrDefault(d, 0L)).toList();
         List<Long> completedCounts = weekStarts.stream().map(d -> completedMap.getOrDefault(d, 0L)).toList();
 
         long inProgressNow = repo.countInProgressWeeklyReportsNow();
@@ -66,6 +70,7 @@ public class WeeklyStatsService {
                 labels,
                 signupCounts,
                 assignedCounts,
+                completedDailyCounts,
                 completedCounts,
                 inProgressNow,
                 OffsetDateTime.now(SEOUL).format(FMT)

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/monthly/MonthlyStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/monthly/MonthlyStatsViewModel.java
@@ -6,6 +6,7 @@ public record MonthlyStatsViewModel(
         List<String> labels,
         List<Long> signupCounts,
         List<Long> assignedQuestionCounts,
+        List<Long> completedDailyReportCounts,
         List<Long> completedMonthlyReportCounts,
         long inProgressMonthlyReportCount,
         String refreshedAt

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/weekly/WeeklyStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/weekly/WeeklyStatsViewModel.java
@@ -6,6 +6,7 @@ public record WeeklyStatsViewModel(
         List<String> labels,
         List<Long> signupCounts,
         List<Long> assignedQuestionCounts,
+        List<Long> completedDailyReportCounts,
         List<Long> completedWeeklyReportCounts,
         long inProgressWeeklyReportCount,
         String refreshedAt

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
@@ -69,6 +69,20 @@ public class MonthlyStatsRepository {
                 .getResultList();
     }
 
+    public List<DateCountDto> findCompletedDailyReportCountsByDateBetween(LocalDate startDate, LocalDate endDateInclusive) {
+        return em.createQuery("""
+                select new com.devkor.ifive.nadab.domain.stats.core.dto.daily.DateCountDto(dr.date, count(dr.id))
+                from DailyReport dr
+                where dr.date between :startDate and :endDate
+                  and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+                group by dr.date
+                order by dr.date
+                """, DateCountDto.class)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDateInclusive)
+                .getResultList();
+    }
+
     public long countInProgressMonthlyReportsNow() {
         return em.createQuery("""
             select count(mr.id)

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
@@ -72,6 +72,23 @@ public class WeeklyStatsRepository {
                 .getResultList();
     }
 
+    public List<DateCountDto> findCompletedDailyReportCountsByDateBetween(
+            LocalDate startDate,
+            LocalDate endDateInclusive
+    ) {
+        return em.createQuery("""
+                select new com.devkor.ifive.nadab.domain.stats.core.dto.daily.DateCountDto(dr.date, count(dr.id))
+                from DailyReport dr
+                where dr.date between :startDate and :endDate
+                  and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+                group by dr.date
+                order by dr.date
+                """, DateCountDto.class)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDateInclusive)
+                .getResultList();
+    }
+
     public long countInProgressWeeklyReportsNow() {
         return em.createQuery("""
             select count(wr.id)

--- a/src/main/resources/templates/stats/monthly.html
+++ b/src/main/resources/templates/stats/monthly.html
@@ -179,11 +179,8 @@
       grid-template-columns: repeat(2, 1fr);
       gap: 20px;
     }
-    .chart-card-wide { grid-column: 1 / -1; }
-
     @media (max-width: 800px) {
       .charts-grid { grid-template-columns: 1fr; }
-      .chart-card-wide { grid-column: unset; }
     }
 
     .chart-card {
@@ -222,6 +219,7 @@
     .dot-blue { background: var(--accent); }
     .dot-pink { background: var(--accent-2); }
     .dot-teal { background: var(--accent-3); }
+    .dot-orange { background: #f5a524; }
   </style>
 </head>
 <body>
@@ -289,13 +287,23 @@
     </div>
   </div>
 
-  <div class="chart-card chart-card-wide">
+  <div class="chart-card">
     <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-teal"></span>생성된 월간 리포트 수</div>
+      <div class="chart-card-title"><span class="dot dot-teal"></span>생성된 일간 리포트 수</div>
       <div class="chart-card-subtitle">최근 5개월</div>
     </div>
     <div class="chart-card-body">
-      <canvas id="completedChart" height="90"></canvas>
+      <canvas id="completedDailyChart" height="140"></canvas>
+    </div>
+  </div>
+
+  <div class="chart-card">
+    <div class="chart-card-header">
+      <div class="chart-card-title"><span class="dot dot-orange"></span>생성된 월간 리포트 수</div>
+      <div class="chart-card-subtitle">최근 5개월</div>
+    </div>
+    <div class="chart-card-body">
+      <canvas id="completedMonthlyChart" height="140"></canvas>
     </div>
   </div>
 </div>
@@ -304,7 +312,8 @@
   const labels = [[${vm.labels}]];
   const signupCounts = [[${vm.signupCounts}]].map(v => parseInt(v, 10));
   const assignedCounts = [[${vm.assignedQuestionCounts}]].map(v => parseInt(v, 10));
-  const completedCounts = [[${vm.completedMonthlyReportCounts}]].map(v => parseInt(v, 10));
+  const completedDailyCounts = [[${vm.completedDailyReportCounts}]].map(v => parseInt(v, 10));
+  const completedMonthlyCounts = [[${vm.completedMonthlyReportCounts}]].map(v => parseInt(v, 10));
 
   Chart.defaults.color = '#8b91a8';
   Chart.defaults.font.family = "'DM Mono', monospace";
@@ -323,7 +332,8 @@
   const configs = [
     { id: 'signupChart', label: '가입자 수', data: signupCounts, color: 'rgba(108,143,255,1)' },
     { id: 'assignedChart', label: '할당 질문 수', data: assignedCounts, color: 'rgba(255,126,179,1)' },
-    { id: 'completedChart', label: '월간 리포트 생성 수', data: completedCounts, color: 'rgba(77,232,194,1)' },
+    { id: 'completedDailyChart', label: '일간 리포트 생성 수', data: completedDailyCounts, color: 'rgba(77,232,194,1)' },
+    { id: 'completedMonthlyChart', label: '월간 리포트 생성 수', data: completedMonthlyCounts, color: 'rgba(245,165,36,1)' },
   ];
 
   configs.forEach(({ id, label, data, color }) => {

--- a/src/main/resources/templates/stats/weekly.html
+++ b/src/main/resources/templates/stats/weekly.html
@@ -179,11 +179,8 @@
       grid-template-columns: repeat(2, 1fr);
       gap: 20px;
     }
-    .chart-card-wide { grid-column: 1 / -1; }
-
     @media (max-width: 800px) {
       .charts-grid { grid-template-columns: 1fr; }
-      .chart-card-wide { grid-column: unset; }
     }
 
     .chart-card {
@@ -222,6 +219,7 @@
     .dot-blue { background: var(--accent); }
     .dot-pink { background: var(--accent-2); }
     .dot-teal { background: var(--accent-3); }
+    .dot-orange { background: #f5a524; }
   </style>
 </head>
 <body>
@@ -289,13 +287,23 @@
     </div>
   </div>
 
-  <div class="chart-card chart-card-wide">
+  <div class="chart-card">
     <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-teal"></span>생성된 주간 리포트 수</div>
+      <div class="chart-card-title"><span class="dot dot-teal"></span>생성된 일간 리포트 수</div>
       <div class="chart-card-subtitle">최근 5주</div>
     </div>
     <div class="chart-card-body">
-      <canvas id="completedChart" height="90"></canvas>
+      <canvas id="completedDailyChart" height="140"></canvas>
+    </div>
+  </div>
+
+  <div class="chart-card">
+    <div class="chart-card-header">
+      <div class="chart-card-title"><span class="dot dot-orange"></span>생성된 주간 리포트 수</div>
+      <div class="chart-card-subtitle">최근 5주</div>
+    </div>
+    <div class="chart-card-body">
+      <canvas id="completedWeeklyChart" height="140"></canvas>
     </div>
   </div>
 </div>
@@ -304,7 +312,8 @@
   const rawLabels = [[${vm.labels}]];
   const rawSignupCounts = [[${vm.signupCounts}]].map(v => parseInt(v, 10));
   const rawAssignedCounts = [[${vm.assignedQuestionCounts}]].map(v => parseInt(v, 10));
-  const rawCompletedCounts = [[${vm.completedWeeklyReportCounts}]].map(v => parseInt(v, 10));
+  const rawCompletedDailyCounts = [[${vm.completedDailyReportCounts}]].map(v => parseInt(v, 10));
+  const rawCompletedWeeklyCounts = [[${vm.completedWeeklyReportCounts}]].map(v => parseInt(v, 10));
 
   const slicedRawLabels = rawLabels.slice(-5);
   const labels = slicedRawLabels.map(label => {
@@ -313,7 +322,8 @@
   });
   const signupCounts = rawSignupCounts.slice(-5);
   const assignedCounts = rawAssignedCounts.slice(-5);
-  const completedCounts = rawCompletedCounts.slice(-5);
+  const completedDailyCounts = rawCompletedDailyCounts.slice(-5);
+  const completedWeeklyCounts = rawCompletedWeeklyCounts.slice(-5);
 
   Chart.defaults.color = '#8b91a8';
   Chart.defaults.font.family = "'DM Mono', monospace";
@@ -332,7 +342,8 @@
   const configs = [
     { id: 'signupChart', label: '가입자 수', data: signupCounts, color: 'rgba(108,143,255,1)' },
     { id: 'assignedChart', label: '할당 질문 수', data: assignedCounts, color: 'rgba(255,126,179,1)' },
-    { id: 'completedChart', label: '주간 리포트 생성 수', data: completedCounts, color: 'rgba(77,232,194,1)' },
+    { id: 'completedDailyChart', label: '일간 리포트 생성 수', data: completedDailyCounts, color: 'rgba(77,232,194,1)' },
+    { id: 'completedWeeklyChart', label: '주간 리포트 생성 수', data: completedWeeklyCounts, color: 'rgba(245,165,36,1)' },
   ];
 
   configs.forEach(({ id, label, data, color }) => {


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `stats/weekly`, `stats/monthly` 페이지에 최근 5주/5달 기준 `DailyReport` 생성 수 집계 추가
- 기존 단일 "생성된 주간/월간 리포트 수" 영역을 2개 차트로 분할
  - 왼쪽: 생성된 일간 리포트 수
  - 오른쪽: 생성된 주간/월간 리포트 수
- 주간/월간 ViewModel, Service, Repository에 `completedDailyReportCounts` 필드/집계 로직 추가

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.