### PR TITLE
feat(auth): Google OAuth2에 iOS 네이티브 앱 지원 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -117,6 +117,7 @@ jobs:
             NAVER_REDIRECT_URI="${{ secrets.NAVER_REDIRECT_URI }}" \
             GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
             GOOGLE_ANDROID_CLIENT_ID="${{ secrets.GOOGLE_ANDROID_CLIENT_ID }}" \
+            GOOGLE_IOS_CLIENT_ID="${{ secrets.GOOGLE_IOS_CLIENT_ID }}" \
             GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
             GOOGLE_REDIRECT_URI="${{ secrets.GOOGLE_REDIRECT_URI }}" \
             KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -114,6 +114,7 @@ jobs:
             NAVER_REDIRECT_URI="${{ secrets.NAVER_REDIRECT_URI }}" \
             GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
             GOOGLE_ANDROID_CLIENT_ID="${{ secrets.GOOGLE_ANDROID_CLIENT_ID }}" \
+            GOOGLE_IOS_CLIENT_ID="${{ secrets.GOOGLE_IOS_CLIENT_ID }}" \
             GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
             GOOGLE_REDIRECT_URI="${{ secrets.GOOGLE_REDIRECT_URI }}" \
             KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/GoogleOAuth2Client.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/GoogleOAuth2Client.java
@@ -203,10 +203,14 @@ public class GoogleOAuth2Client {
             throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
         }
 
-        // azp (Authorized party) 검증 (azp가 있으면 우리 앱의 Android Client ID인지 확인)
-        if (tokenInfo.getAzp() != null && !googleProperties.getAndroidClientId().equals(tokenInfo.getAzp())) {
-            log.warn("구글 ID Token 검증 실패: 유효하지 않은 authorized party - {}", tokenInfo.getAzp());
-            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        // azp (Authorized party) 검증 (azp가 있으면 Android 또는 iOS Client ID 중 하나와 일치하는지 확인)
+        if (tokenInfo.getAzp() != null) {
+            boolean isValidAzp = googleProperties.getAndroidClientId().equals(tokenInfo.getAzp()) ||
+                    googleProperties.getIosClientId().equals(tokenInfo.getAzp());
+            if (!isValidAzp) {
+                log.warn("구글 ID Token 검증 실패: 유효하지 않은 authorized party - {}", tokenInfo.getAzp());
+                throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+            }
         }
 
         // 만료 시간 검증

--- a/src/main/java/com/devkor/ifive/nadab/global/core/properties/GoogleProperties.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/properties/GoogleProperties.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class GoogleProperties {
     private String clientId;           // 웹용 Client ID
     private String androidClientId;    // Android용 Client ID
+    private String iosClientId;        // iOS용 Client ID
     private String clientSecret;
     private String redirectUri;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,6 +29,7 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     android-client-id: ${GOOGLE_ANDROID_CLIENT_ID}
+    ios-client-id: ${GOOGLE_IOS_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
   kakao:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,6 +30,7 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     android-client-id: ${GOOGLE_ANDROID_CLIENT_ID}
+    ios-client-id: ${GOOGLE_IOS_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
   kakao:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,7 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     android-client-id: ${GOOGLE_ANDROID_CLIENT_ID}
+    ios-client-id: ${GOOGLE_IOS_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
   kakao:


### PR DESCRIPTION
## 📝 요약(Summary)
- GoogleOAuth2Client의 azp(Authorized party) 검증 로직 개선
    - 기존: Android Client ID만 검증
    - 변경: Android 또는 iOS Client ID 중 하나와 매칭
- application-*.yml (dev/prod/local)에 ios-client-id 환경변수 추가
- GitHub Actions CI/CD (deploy-to-dev/prod-ec2.yml)에 GOOGLE_IOS_CLIENT_ID 환경변수 주입 설정

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.