### PR TITLE
fix(auth): Google azp 검증을 Android 전용으로 되돌림

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/GoogleOAuth2Client.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/GoogleOAuth2Client.java
@@ -203,14 +203,10 @@ public class GoogleOAuth2Client {
             throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
         }
 
-        // azp (Authorized party) 검증 (azp가 있으면 Android 또는 iOS Client ID 중 하나와 일치하는지 확인)
-        if (tokenInfo.getAzp() != null) {
-            boolean isValidAzp = googleProperties.getAndroidClientId().equals(tokenInfo.getAzp()) ||
-                    googleProperties.getIosClientId().equals(tokenInfo.getAzp());
-            if (!isValidAzp) {
-                log.warn("구글 ID Token 검증 실패: 유효하지 않은 authorized party - {}", tokenInfo.getAzp());
-                throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
-            }
+        // azp (Authorized party) 검증 (azp가 있으면 우리 앱의 Android Client ID인지 확인)
+        if (tokenInfo.getAzp() != null && !googleProperties.getAndroidClientId().equals(tokenInfo.getAzp())) {
+            log.warn("구글 ID Token 검증 실패: 유효하지 않은 authorized party - {}", tokenInfo.getAzp());
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
         }
 
         // 만료 시간 검증


### PR DESCRIPTION
## 📝 요약(Summary)
iOS 지원 추가 시 변경된 azp 검증 로직으로 인해 Android 구글 로그인이 실패하는 문제 해결

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.