### PR TITLE
feat(auth): 애플 소셜 로그인 구현

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -124,10 +124,15 @@ jobs:
             KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
             KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
             KAKAO_APP_ID="${{ secrets.KAKAO_APP_ID }}" \
+            APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
+            APPLE_TEAM_ID="${{ secrets.APPLE_TEAM_ID }}" \
+            APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \
+            APPLE_PRIVATE_KEY="${{ secrets.APPLE_PRIVATE_KEY }}" \
             IAM_ACCESS_KEY="${{ secrets.IAM_ACCESS_KEY }}" \
             IAM_SECRET_KEY="${{ secrets.IAM_SECRET_KEY }}" \
             BUCKET_NAME="${{ secrets.BUCKET_NAME }}" \
             PROFILE_IMAGE_BASE_URL="${{ secrets.PROFILE_IMAGE_BASE_URL }}" \
+            KMS_KEY_ID="${{ secrets.KMS_KEY_ID }}" \
             MAIL_ADDRESS="${{ secrets.MAIL_ADDRESS }}" \
             MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
             OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" \

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -121,10 +121,15 @@ jobs:
             KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
             KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
             KAKAO_APP_ID="${{ secrets.KAKAO_APP_ID }}" \
+            APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
+            APPLE_TEAM_ID="${{ secrets.APPLE_TEAM_ID }}" \
+            APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \
+            APPLE_PRIVATE_KEY="${{ secrets.APPLE_PRIVATE_KEY }}" \
             IAM_ACCESS_KEY="${{ secrets.IAM_ACCESS_KEY }}" \
             IAM_SECRET_KEY="${{ secrets.IAM_SECRET_KEY }}" \
             BUCKET_NAME="${{ secrets.BUCKET_NAME }}" \
             PROFILE_IMAGE_BASE_URL="${{ secrets.PROFILE_IMAGE_BASE_URL }}" \
+            KMS_KEY_ID="${{ secrets.KMS_KEY_ID }}" \
             MAIL_ADDRESS="${{ secrets.MAIL_ADDRESS }}" \
             MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
             OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" \

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.39.4')
     implementation 'software.amazon.awssdk:s3'
 
+    // AWS KMS
+    implementation 'software.amazon.awssdk:kms'
+
     // BadWordFiltering 라이브러리
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
     implementation 'com.modernmt.text:profanity-filter:1.0.1'

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/api/AuthController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/api/AuthController.java
@@ -8,6 +8,7 @@ import com.devkor.ifive.nadab.domain.auth.api.dto.request.SignupRequest;
 import com.devkor.ifive.nadab.domain.auth.api.dto.request.NaverNativeLoginRequest;
 import com.devkor.ifive.nadab.domain.auth.api.dto.request.GoogleNativeLoginRequest;
 import com.devkor.ifive.nadab.domain.auth.api.dto.request.KakaoNativeLoginRequest;
+import com.devkor.ifive.nadab.domain.auth.api.dto.request.AppleNativeLoginRequest;
 import com.devkor.ifive.nadab.domain.auth.api.dto.response.AuthorizationUrlResponse;
 import com.devkor.ifive.nadab.domain.auth.api.dto.request.SocialLoginRequest;
 import com.devkor.ifive.nadab.domain.auth.api.dto.response.TokenResponse;
@@ -256,6 +257,7 @@ public class AuthController {
                             responseCode = "409",
                             description = """
                                     이메일 중복
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE - 애플 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER - 네이버 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE - 구글 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO - 카카오 계정으로 이미 가입됨
@@ -320,8 +322,8 @@ public class AuthController {
                     @ApiResponse(
                             responseCode = "409",
                             description = """
-                                    이메일 중복
-                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER - 네이버 계정으로 이미 가입됨
+                                    이메일 중복 (다른 제공자로 이미 가입된 경우)
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE - 애플 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE - 구글 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO - 카카오 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_BASIC - 일반 계정으로 이미 가입됨
@@ -384,9 +386,9 @@ public class AuthController {
                     @ApiResponse(
                             responseCode = "409",
                             description = """
-                                    이메일 중복
+                                    이메일 중복 (다른 제공자로 이미 가입된 경우)
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE - 애플 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER - 네이버 계정으로 이미 가입됨
-                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE - 구글 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO - 카카오 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_BASIC - 일반 계정으로 이미 가입됨
                                     """,
@@ -444,10 +446,10 @@ public class AuthController {
                     @ApiResponse(
                             responseCode = "409",
                             description = """
-                                    이메일 중복
+                                    이메일 중복 (다른 제공자로 이미 가입된 경우)
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE - 애플 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER - 네이버 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE - 구글 계정으로 이미 가입됨
-                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO - 카카오 계정으로 이미 가입됨
                                     - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_BASIC - 일반 계정으로 이미 가입됨
                                     """,
                             content = @Content
@@ -460,6 +462,74 @@ public class AuthController {
     ) {
         // 카카오 Access Token으로 사용자 정보 조회 및 로그인
         TokenBundle tokenBundle = nativeAuthService.executeKakaoLogin(request.kakaoAccessToken());
+
+        // Refresh Token을 HttpOnly 쿠키에 저장
+        cookieManager.addRefreshTokenCookie(response, tokenBundle.refreshToken());
+
+        return ApiResponseEntity.ok(
+                new TokenResponse(tokenBundle.accessToken(), tokenBundle.signupStatus())
+        );
+    }
+
+    @PostMapping("/apple/native-login")
+    @PermitAll
+    @Operation(
+            summary = "애플 Native SDK 로그인 (iOS 전용)",
+            description = """
+                    iOS 앱에서 Sign in with Apple SDK로 받은 Authorization Code를 사용하여 로그인을 완료합니다.<br>
+                    Access Token과 signupStatus는 응답 바디(JSON)로 반환되며, Refresh Token은 HttpOnly 쿠키로 자동 설정됩니다.<br>
+                    기존 회원은 바로 로그인 처리되며, 신규 사용자는 자동으로 회원가입 후 로그인됩니다.<br>
+                    <br>
+                    중요: iOS 클라이언트 설정<br>
+                    - request.requestedScopes = [.email] 설정 필수<br>
+                    - email scope를 포함해야 첫 로그인 시 이메일을 받을 수 있습니다<br>
+                    <br>
+                    신규 가입자(signupStatus: PROFILE_INCOMPLETE)는 온보딩 과정에서 약관 동의(POST /terms/consent) 후 닉네임을 입력해야 합니다.<br>
+                    <br>
+                    **signupStatus:**<br>
+                    - PROFILE_INCOMPLETE: 프로필 입력 필요 (신규 가입자, 약관 동의 + 닉네임 입력 필요)<br>
+                    - COMPLETED: 가입 완료 (모든 필수 정보 입력 완료)<br>
+                    - WITHDRAWN: 회원 탈퇴 (14일 내 복구 가능)
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공",
+                            content = @Content(schema = @Schema(implementation = TokenResponse.class), mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "ErrorCode: VALIDATION_FAILED - Authorization Code가 누락된 경우",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = """
+                                    Authorization Code 검증 실패
+                                    - ErrorCode: AUTH_OAUTH2_TOKEN_FAILED - 애플 토큰 발급 실패(유효하지 않은 코드, 만료된 코드)
+                                    - ErrorCode: AUTH_OAUTH2_USERINFO_FAILED - 애플 ID Token 파싱 실패
+                                    """,
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = """
+                                    이메일 중복 (다른 제공자로 이미 가입된 경우)
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER - 네이버 계정으로 이미 가입됨
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE - 구글 계정으로 이미 가입됨
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO - 카카오 계정으로 이미 가입됨
+                                    - ErrorCode: AUTH_EMAIL_ALREADY_REGISTERED_WITH_BASIC - 일반 계정으로 이미 가입됨
+                                    """,
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<TokenResponse>> appleNativeLogin(
+            @RequestBody @Valid AppleNativeLoginRequest request,
+            HttpServletResponse response
+    ) {
+        // 애플 Authorization Code로 토큰 교환 및 로그인
+        TokenBundle tokenBundle = nativeAuthService.executeAppleLogin(request.code());
 
         // Refresh Token을 HttpOnly 쿠키에 저장
         cookieManager.addRefreshTokenCookie(response, tokenBundle.refreshToken());

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/api/dto/request/AppleNativeLoginRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/api/dto/request/AppleNativeLoginRequest.java
@@ -1,0 +1,16 @@
+package com.devkor.ifive.nadab.domain.auth.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 애플 Native SDK 로그인 요청 DTO
+ * - iOS 앱에서 Sign in with Apple SDK로 받은 Authorization Code 전달
+ */
+@Schema(description = "애플 Native SDK 로그인 요청")
+public record AppleNativeLoginRequest(
+        @Schema(description = "애플 SDK로부터 받은 Authorization Code", example = "c1234567890abcdef")
+        @NotBlank(message = "애플 Authorization Code는 필수입니다")
+        String code
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/application/NativeAuthService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/application/NativeAuthService.java
@@ -1,16 +1,26 @@
 package com.devkor.ifive.nadab.domain.auth.application;
 
 import com.devkor.ifive.nadab.domain.auth.application.TokenService.TokenBundle;
+import com.devkor.ifive.nadab.domain.auth.core.entity.ProviderType;
+import com.devkor.ifive.nadab.domain.auth.core.entity.SocialAccount;
+import com.devkor.ifive.nadab.domain.auth.core.entity.SocialAuthRefreshToken;
+import com.devkor.ifive.nadab.domain.auth.core.repository.SocialAccountRepository;
 import com.devkor.ifive.nadab.domain.auth.infra.oauth.OAuth2Provider;
 import com.devkor.ifive.nadab.domain.auth.infra.oauth.OAuth2UserInfo;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.AppleOAuth2Client;
 import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.GoogleOAuth2Client;
 import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.KakaoOAuth2Client;
 import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.NaverOAuth2Client;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.dto.AppleTokenResponse;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.security.crypto.DataCryptoService;
+import com.devkor.ifive.nadab.global.security.crypto.EncryptedPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Native SDK 소셜 로그인 서비스
@@ -26,8 +36,11 @@ public class NativeAuthService {
     private final NaverOAuth2Client naverOAuth2Client;
     private final GoogleOAuth2Client googleOAuth2Client;
     private final KakaoOAuth2Client kakaoOAuth2Client;
+    private final AppleOAuth2Client appleOAuth2Client;
     private final SocialAccountService socialAccountService;
+    private final SocialAccountRepository socialAccountRepository;
     private final TokenService tokenService;
+    private final DataCryptoService dataCryptoService;
 
     // 네이버 Native SDK 로그인 처리
     public TokenBundle executeNaverLogin(String naverAccessToken) {
@@ -77,6 +90,35 @@ public class NativeAuthService {
         );
 
         // 4. JWT 토큰 발급
+        return tokenService.issueTokens(user.getId());
+    }
+
+    // 애플 Native SDK 로그인 처리 (iOS)
+    public TokenBundle executeAppleLogin(String code) {
+        // 1. Authorization Code → Access Token, Refresh Token, ID Token 교환
+        AppleTokenResponse appleTokens = appleOAuth2Client.fetchTokensForNative(code);
+
+        // 2. ID Token 파싱 및 사용자 정보 추출
+        OAuth2UserInfo userInfo = appleOAuth2Client.parseIdToken(appleTokens.getIdToken());
+
+        // 3. 사용자 조회 또는 생성
+        User user = socialAccountService.getOrCreateUser(
+                OAuth2Provider.APPLE,
+                userInfo.providerId(),
+                userInfo.email()
+        );
+
+        // 4. Refresh Token 암호화 저장
+        if (appleTokens.getRefreshToken() != null) {
+            ProviderType providerType = ProviderType.APPLE;
+            SocialAccount socialAccount = socialAccountRepository
+                    .findByProviderTypeAndProviderUserId(providerType, userInfo.providerId())
+                    .orElseThrow(() -> new IllegalStateException("SocialAccount 조회 실패"));
+            EncryptedPayload encrypted = dataCryptoService.encrypt(appleTokens.getRefreshToken().getBytes(UTF_8));
+            socialAccount.updateRefreshToken(SocialAuthRefreshToken.from(encrypted));
+        }
+
+        // 5. JWT 토큰 발급
         return tokenService.issueTokens(user.getId());
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/application/SocialAccountService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/application/SocialAccountService.java
@@ -46,7 +46,13 @@ public class SocialAccountService {
                     }
                     return user;
                 })
-                .orElseGet(() -> saveNewSocialUser(email, provider, providerId));
+                .orElseGet(() -> {
+                    // 신규 사용자 생성 시 email 필수
+                    if (email == null || email.isBlank()) {
+                        throw new BadRequestException(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+                    }
+                    return saveNewSocialUser(email, provider, providerId);
+                });
     }
 
     // User 조회 실패시 신규 소셜 로그인 사용자 생성
@@ -64,6 +70,7 @@ public class SocialAccountService {
             if (existingSocialAccount != null) {
                 // 소셜 로그인 계정
                 ErrorCode errorCode = switch (existingSocialAccount.getProviderType()) {
+                    case APPLE -> ErrorCode.AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE;
                     case GOOGLE -> ErrorCode.AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE;
                     case KAKAO -> ErrorCode.AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO;
                     case NAVER -> ErrorCode.AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER;

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/application/SocialAuthService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/application/SocialAuthService.java
@@ -43,6 +43,7 @@ public class SocialAuthService {
             case NAVER -> naverOAuth2Client.buildAuthorizationUrl(state);
             case GOOGLE -> googleOAuth2Client.buildAuthorizationUrl(state);
             case KAKAO -> kakaoOAuth2Client.buildAuthorizationUrl(state);
+            default -> throw new OAuth2Exception(ErrorCode.AUTH_UNSUPPORTED_OAUTH2_PROVIDER);
         };
     }
 
@@ -60,6 +61,7 @@ public class SocialAuthService {
             case NAVER -> naverOAuth2Client.fetchAccessToken(code, state);
             case GOOGLE -> googleOAuth2Client.fetchAccessToken(code);
             case KAKAO -> kakaoOAuth2Client.fetchAccessToken(code);
+            default -> throw new OAuth2Exception(ErrorCode.AUTH_UNSUPPORTED_OAUTH2_PROVIDER);
         };
 
         // 3. 사용자 정보 조회
@@ -67,6 +69,7 @@ public class SocialAuthService {
             case NAVER -> naverOAuth2Client.fetchUserInfo(accessToken);
             case GOOGLE -> googleOAuth2Client.fetchUserInfo(accessToken);
             case KAKAO -> kakaoOAuth2Client.fetchUserInfo(accessToken);
+            default -> throw new OAuth2Exception(ErrorCode.AUTH_UNSUPPORTED_OAUTH2_PROVIDER);
         };
 
         // 4. 사용자 조회 또는 생성

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/application/WithdrawalService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/application/WithdrawalService.java
@@ -1,7 +1,9 @@
 package com.devkor.ifive.nadab.domain.auth.application;
 
 import com.devkor.ifive.nadab.domain.auth.application.TokenService.TokenBundle;
+import com.devkor.ifive.nadab.domain.auth.core.entity.ProviderType;
 import com.devkor.ifive.nadab.domain.auth.core.repository.SocialAccountRepository;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.AppleOAuth2Client;
 import com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
@@ -9,13 +11,19 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import com.devkor.ifive.nadab.global.exception.UnauthorizedException;
+import com.devkor.ifive.nadab.global.security.crypto.DataCryptoService;
+import com.devkor.ifive.nadab.global.security.crypto.EncryptedPayload;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -25,6 +33,8 @@ public class WithdrawalService {
     private final SocialAccountRepository socialAccountRepository;
     private final TokenService tokenService;
     private final PasswordEncoder passwordEncoder;
+    private final AppleOAuth2Client appleOAuth2Client;
+    private final DataCryptoService dataCryptoService;
 
     public void withdrawUser(Long userId) {
         User user = userRepository.findById(userId)
@@ -35,12 +45,37 @@ public class WithdrawalService {
             throw new BadRequestException(ErrorCode.AUTH_ALREADY_WITHDRAWN);
         }
 
+        // 애플 Refresh Token revoke
+        revokeAppleTokenIfNeeded(user);
+
         // Soft Delete
         user.softDelete();
         user.updateSignupStatus(SignupStatusType.WITHDRAWN);
 
         // 모든 Refresh Token 삭제
         tokenService.revokeTokens(userId);
+    }
+
+    // 애플 계정 revoke
+    private void revokeAppleTokenIfNeeded(User user) {
+        socialAccountRepository.findByUser(user).ifPresent(account -> {
+            if (account.getProviderType() == ProviderType.APPLE
+                    && account.getRefreshToken() != null) {
+                try {
+                    // Refresh Token 복호화
+                    EncryptedPayload payload = account.getRefreshToken().toPayload();
+                    byte[] decrypted = dataCryptoService.decrypt(payload);
+                    String refreshToken = new String(decrypted, UTF_8);
+
+                    // 애플 서버에 revoke 요청
+                    appleOAuth2Client.revokeToken(refreshToken);
+                    log.info("애플 Refresh Token revoke 성공 - userId: {}", user.getId());
+                } catch (Exception e) {
+                    // Revoke 실패해도 탈퇴는 계속 진행
+                    log.warn("애플 Refresh Token revoke 실패 (무시하고 계속) - userId: {}", user.getId(), e);
+                }
+            }
+        });
     }
 
     // 회원 복구 (일반 유저)

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/ProviderType.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/ProviderType.java
@@ -1,6 +1,7 @@
 package com.devkor.ifive.nadab.domain.auth.core.entity;
 
 public enum ProviderType {
+    APPLE,
     GOOGLE,
     KAKAO,
     NAVER

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/SocialAccount.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/SocialAccount.java
@@ -30,10 +30,8 @@ public class SocialAccount extends CreatableEntity {
     @Column(name = "provider_type", nullable = false)
     private ProviderType providerType;
 
-    // @Convert(converter = KmsEncryptedStringConverter.class)
-    // 추후 구현 예정. 구현될 때까지 이 필드는 null로 둘 것
-    @Column(name = "refresh_token", columnDefinition = "TEXT")
-    private String refreshToken = null;
+    @Embedded
+    private SocialAuthRefreshToken refreshToken;
 
     public static SocialAccount create(User user, String providerUserId, ProviderType providerType) {
         SocialAccount socialAccount = new SocialAccount();
@@ -41,5 +39,9 @@ public class SocialAccount extends CreatableEntity {
         socialAccount.providerUserId = providerUserId;
         socialAccount.providerType = providerType;
         return socialAccount;
+    }
+
+    public void updateRefreshToken(SocialAuthRefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/SocialAuthRefreshToken.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/core/entity/SocialAuthRefreshToken.java
@@ -1,0 +1,48 @@
+package com.devkor.ifive.nadab.domain.auth.core.entity;
+
+import com.devkor.ifive.nadab.global.security.crypto.EncryptedPayload;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * KMS Envelope Encryption을 사용한 Refresh Token 저장 (불변 객체)
+ * - ciphertext: AES-256-GCM으로 암호화된 Refresh Token
+ * - key: KMS로 암호화된 데이터 키 (Data Encryption Key)
+ * - iv: AES-GCM Initialization Vector
+ * - tag: AES-GCM Authentication Tag
+ */
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAuthRefreshToken {
+
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "refresh_token_ciphertext", columnDefinition = "BYTEA")
+    private byte[] ciphertext;
+
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "refresh_token_key", columnDefinition = "BYTEA")
+    private byte[] key;
+
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "refresh_token_iv", columnDefinition = "BYTEA")
+    private byte[] iv;
+
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "refresh_token_tag", columnDefinition = "BYTEA")
+    private byte[] tag;
+
+    public static SocialAuthRefreshToken from(EncryptedPayload payload) {
+        return new SocialAuthRefreshToken(
+                payload.ciphertext(),
+                payload.encryptedDataKey(),
+                payload.iv(),
+                payload.authTag()
+        );
+    }
+
+    public EncryptedPayload toPayload() {
+        return new EncryptedPayload(ciphertext, key, iv, tag);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/OAuth2Provider.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/OAuth2Provider.java
@@ -8,6 +8,7 @@ import com.devkor.ifive.nadab.global.exception.BadRequestException;
  * - 지원되는 소셜 로그인 제공자를 정의
  */
 public enum OAuth2Provider {
+    APPLE,
     GOOGLE,
     KAKAO,
     NAVER;

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/AppleOAuth2Client.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/AppleOAuth2Client.java
@@ -1,0 +1,217 @@
+package com.devkor.ifive.nadab.domain.auth.infra.oauth.client;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.OAuth2UserInfo;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.dto.AppleTokenResponse;
+import com.devkor.ifive.nadab.domain.auth.infra.oauth.client.dto.AppleIdTokenPayload;
+import com.devkor.ifive.nadab.global.core.properties.AppleProperties;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.OAuth2Exception;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.security.KeyFactory;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * 애플 OAuth2 인증 플로우 처리 (iOS Native 전용)
+ * - Authorization Code → Token 교환
+ * - ID Token 파싱 및 검증
+ * - Refresh Token Revoke
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleOAuth2Client {
+    private static final String TOKEN_URI = "https://appleid.apple.com/auth/token";
+    private static final String REVOKE_URI = "https://appleid.apple.com/auth/revoke";
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final long CLIENT_SECRET_EXPIRATION_SECONDS = 15777000L; // 6개월
+
+    private final AppleProperties appleProperties;
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    // Authorization Code → Access Token, Refresh Token, ID Token 교환
+    public AppleTokenResponse fetchTokensForNative(String code) {
+        String clientSecret = generateClientSecret(appleProperties.getClientId());
+
+        AppleTokenResponse response = webClient.post()
+                .uri(TOKEN_URI)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(BodyInserters.fromFormData("client_id", appleProperties.getClientId())
+                        .with("client_secret", clientSecret)
+                        .with("grant_type", "authorization_code")
+                        .with("code", code))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(AppleTokenResponse.class)
+                                .map(errorResponse -> {
+                                    String errorMessage = errorResponse.getErrorDescription() != null
+                                            ? errorResponse.getErrorDescription()
+                                            : "HTTP " + clientResponse.statusCode();
+                                    log.warn("애플 토큰 발급 실패 (Native): {}", errorMessage);
+                                    return new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+                                }))
+                .bodyToMono(AppleTokenResponse.class)
+                .block();
+
+        // 응답 검증
+        if (response == null) {
+            log.warn("애플 토큰 발급 실패 (Native): 응답 없음");
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+        }
+
+        if (response.getError() != null) {
+            String errorMessage = response.getErrorDescription() != null
+                    ? response.getErrorDescription()
+                    : "알 수 없는 오류";
+            log.warn("애플 토큰 발급 실패 (Native): {}", errorMessage);
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+        }
+
+        if (response.getIdToken() == null) {
+            log.warn("애플 토큰 발급 실패 (Native): id_token 필드 없음");
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+        }
+
+        return response;
+    }
+
+    // ID Token 파싱 및 검증
+    public OAuth2UserInfo parseIdToken(String idToken) {
+        try {
+            // 1. JWT 디코딩 (서명 검증은 생략, 애플 공개 키로 검증하려면 별도 구현 필요)
+            DecodedJWT jwt = JWT.decode(idToken);
+
+            // 2. Payload 파싱
+            String payloadJson = new String(Base64.getUrlDecoder().decode(jwt.getPayload()));
+            AppleIdTokenPayload payload = objectMapper.readValue(payloadJson, AppleIdTokenPayload.class);
+
+            // 3. 클레임 검증
+            validateIdTokenPayload(payload);
+
+            // 4. 사용자 정보 반환
+            return new OAuth2UserInfo(
+                    payload.getSub(),
+                    payload.getEmail()
+            );
+        } catch (OAuth2Exception e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("애플 ID Token 파싱 실패", e);
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        }
+    }
+
+    // Refresh Token Revoke (회원 탈퇴 시, iOS Native 전용)
+    public void revokeToken(String refreshToken) {
+        try {
+            String clientSecret = generateClientSecret(appleProperties.getClientId());
+
+            webClient.post()
+                    .uri(REVOKE_URI)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(BodyInserters.fromFormData("client_id", appleProperties.getClientId())
+                            .with("client_secret", clientSecret)
+                            .with("token", refreshToken)
+                            .with("token_type_hint", "refresh_token"))
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+
+            log.info("애플 Refresh Token revoke 성공");
+        } catch (Exception e) {
+            log.warn("애플 Refresh Token revoke 실패 (무시하고 계속): {}", e.getMessage());
+        }
+    }
+
+    private String generateClientSecret(String clientId) {
+        try {
+            // 1. Private Key 파싱
+            ECPrivateKey privateKey = parsePrivateKey(appleProperties.getPrivateKey());
+
+            // 2. ES256 알고리즘 생성
+            Algorithm algorithm = Algorithm.ECDSA256(null, privateKey);
+
+            // 3. JWT 생성
+            Instant now = Instant.now();
+            return JWT.create()
+                    .withKeyId(appleProperties.getKeyId())              // Header: kid
+                    .withIssuer(appleProperties.getTeamId())            // Payload: iss
+                    .withIssuedAt(Date.from(now))                       // Payload: iat
+                    .withExpiresAt(Date.from(now.plusSeconds(CLIENT_SECRET_EXPIRATION_SECONDS)))  // Payload: exp
+                    .withAudience(APPLE_ISSUER)                         // Payload: aud
+                    .withSubject(clientId)                              // Payload: sub (App ID 또는 Service ID)
+                    .sign(algorithm);
+        } catch (Exception e) {
+            log.error("애플 Client Secret 생성 실패", e);
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+        }
+    }
+
+    private ECPrivateKey parsePrivateKey(String privateKeyContent) {
+        try {
+            if (privateKeyContent == null || privateKeyContent.trim().isEmpty()) {
+                throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+            }
+
+            // 1. 리터럴 \n을 실제 개행으로 변환
+            String normalizedKey = privateKeyContent.replace("\\n", "\n");
+
+            // 2. PEM 헤더/푸터 제거
+            String privateKeyPEM = normalizedKey
+                    .replaceAll("-+BEGIN[A-Z ]*PRIVATE KEY-+", "")
+                    .replaceAll("-+END[A-Z ]*PRIVATE KEY-+", "")
+                    .replaceAll("\\s", "");
+
+            // 3. Base64 디코딩
+            byte[] encoded = Base64.getDecoder().decode(privateKeyPEM);
+
+            // 4. PKCS8 형식으로 파싱
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return (ECPrivateKey) keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            log.error("애플 Private Key 파싱 실패", e);
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_TOKEN_FAILED);
+        }
+    }
+
+    private void validateIdTokenPayload(AppleIdTokenPayload payload) {
+        // 필수 필드 체크 (sub 필수)
+        if (payload.getSub() == null) {
+            log.warn("애플 ID Token 검증 실패: sub 필드 없음");
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        }
+
+        // issuer 검증
+        if (!APPLE_ISSUER.equals(payload.getIss())) {
+            log.warn("애플 ID Token 검증 실패: 유효하지 않은 issuer - {}", payload.getIss());
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        }
+
+        // audience 검증 (App ID, iOS Native 전용)
+        if (!appleProperties.getClientId().equals(payload.getAud())) {
+            log.warn("애플 ID Token 검증 실패: 유효하지 않은 audience - {}", payload.getAud());
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        }
+
+        // 만료 시간 검증
+        long currentTime = System.currentTimeMillis() / 1000;
+        if (payload.getExp() != null && payload.getExp() < currentTime) {
+            log.warn("애플 ID Token 검증 실패: 토큰 만료");
+            throw new OAuth2Exception(ErrorCode.AUTH_OAUTH2_USERINFO_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/dto/AppleIdTokenPayload.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/dto/AppleIdTokenPayload.java
@@ -1,0 +1,40 @@
+package com.devkor.ifive.nadab.domain.auth.infra.oauth.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 애플 ID Token 페이로드 (JWT 디코딩 후)
+ * - JWT 형식: Header.Payload.Signature
+ * - Payload 부분을 Base64 디코딩한 결과
+ */
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AppleIdTokenPayload {
+    @JsonProperty("iss")
+    private String iss;             // 발급자: https://appleid.apple.com
+
+    @JsonProperty("aud")
+    private String aud;             // Audience: Bundle ID 또는 Service ID
+
+    @JsonProperty("exp")
+    private Long exp;               // 만료 시간 (Unix timestamp, 초)
+
+    @JsonProperty("iat")
+    private Long iat;               // 발급 시간 (Unix timestamp, 초)
+
+    @JsonProperty("sub")
+    private String sub;             // 사용자 고유 ID (providerId)
+
+    @JsonProperty("email")
+    private String email;           // 사용자 이메일
+
+    @JsonProperty("email_verified")
+    private Boolean emailVerified;  // 이메일 인증 여부 ("true" string 또는 boolean)
+
+    @JsonProperty("is_private_email")
+    private Boolean isPrivateEmail; // 애플 프라이빗 이메일 사용 여부
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/dto/AppleTokenResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/oauth/client/dto/AppleTokenResponse.java
@@ -1,0 +1,37 @@
+package com.devkor.ifive.nadab.domain.auth.infra.oauth.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 애플 Access Token 응답 DTO
+ * - 성공: access_token, refresh_token, id_token
+ * - 실패: error, error_description
+ */
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AppleTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;    // KMS 암호화해서 저장
+
+    @JsonProperty("id_token")
+    private String idToken;         // JWT 형식, 사용자 정보 포함
+
+    @JsonProperty("token_type")
+    private String tokenType;       // "Bearer"
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;         // 초 단위
+
+    @JsonProperty("error")
+    private String error;
+
+    @JsonProperty("error_description")
+    private String errorDescription;
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/config/infra/AwsConfig.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/config/infra/AwsConfig.java
@@ -6,11 +6,12 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-public class AwsS3Config {
+public class AwsConfig {
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -36,6 +37,16 @@ public class AwsS3Config {
         AwsBasicCredentials creds = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build();
+    }
+
+    @Bean
+    public KmsClient kmsClient() {
+        AwsBasicCredentials creds = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return KmsClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(creds))
                 .build();

--- a/src/main/java/com/devkor/ifive/nadab/global/core/properties/AppleProperties.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/properties/AppleProperties.java
@@ -1,0 +1,17 @@
+package com.devkor.ifive.nadab.global.core.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "oauth.apple")
+public class AppleProperties {
+    private String clientId;
+    private String teamId;
+    private String keyId;
+    private String privateKey;
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     AUTH_EMAIL_ALREADY_REGISTERED_WITH_NAVER(HttpStatus.CONFLICT, "이미 네이버 계정으로 가입된 이메일입니다. 네이버로 로그인해주세요."),
     AUTH_EMAIL_ALREADY_REGISTERED_WITH_GOOGLE(HttpStatus.CONFLICT, "이미 구글 계정으로 가입된 이메일입니다. 구글로 로그인해주세요."),
     AUTH_EMAIL_ALREADY_REGISTERED_WITH_KAKAO(HttpStatus.CONFLICT, "이미 카카오 계정으로 가입된 이메일입니다. 카카오로 로그인해주세요."),
+    AUTH_EMAIL_ALREADY_REGISTERED_WITH_APPLE(HttpStatus.CONFLICT, "이미 애플 계정으로 가입된 이메일입니다. 애플로 로그인해주세요."),
     AUTH_EMAIL_ALREADY_REGISTERED_WITH_BASIC(HttpStatus.CONFLICT, "이미 일반 계정으로 가입된 이메일입니다. 이메일/비밀번호로 로그인해주세요."),
 
     // ==================== EMAIL (이메일 인증) ====================

--- a/src/main/java/com/devkor/ifive/nadab/global/security/crypto/DataCryptoService.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/security/crypto/DataCryptoService.java
@@ -1,0 +1,14 @@
+package com.devkor.ifive.nadab.global.security.crypto;
+
+/**
+ * 민감 데이터 암호화/복호화 서비스 인터페이스
+ *
+ * 구현체:
+ * - KmsDataCryptoService: AWS KMS를 사용한 Envelope Encryption (dev, prod)
+ * - LocalDataCryptoService: XOR 기반 간단한 암호화 (local, test)
+ */
+public interface DataCryptoService {
+
+    EncryptedPayload encrypt(byte[] plaintext);
+    byte[] decrypt(EncryptedPayload payload);
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/security/crypto/EncryptedPayload.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/security/crypto/EncryptedPayload.java
@@ -1,0 +1,29 @@
+package com.devkor.ifive.nadab.global.security.crypto;
+
+import java.util.HexFormat;
+
+/**
+ * AES-256-GCM 암호화 결과를 담는 불변 DTO
+ *
+ * @param ciphertext 암호문
+ * @param encryptedDataKey KMS로 암호화된 데이터 키
+ * @param iv Initialization Vector (12 bytes)
+ * @param authTag 무결성 검증용 태그 (16 bytes)
+ */
+public record EncryptedPayload(
+        byte[] ciphertext,
+        byte[] encryptedDataKey,
+        byte[] iv,
+        byte[] authTag
+) {
+
+    @Override
+    public String toString() {
+        return "EncryptedPayload{" +
+                "ciphertext=" + ciphertext.length + "B, " + HexFormat.of().formatHex(ciphertext) +
+                ", encryptedDataKey=" + encryptedDataKey.length + "B, " + HexFormat.of().formatHex(encryptedDataKey) +
+                ", iv=" + iv.length + "B, " + HexFormat.of().formatHex(iv) +
+                ", authTag=" + authTag.length + "B, " + HexFormat.of().formatHex(authTag) +
+                '}';
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/security/crypto/KmsDataCryptoService.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/security/crypto/KmsDataCryptoService.java
@@ -1,0 +1,111 @@
+package com.devkor.ifive.nadab.global.security.crypto;
+
+import com.devkor.ifive.nadab.global.security.util.SecureRandomBytesGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DataKeySpec;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * AWS KMS를 사용한 Envelope Encryption 구현
+ *
+ * 동작 방식:
+ * 1. KMS로 데이터 키(DEK) 생성
+ * 2. DEK로 평문을 AES-256-GCM 암호화
+ * 3. KMS가 암호화한 DEK와 함께 저장
+ * 4. 복호화 시: KMS로 DEK 복호화 → DEK로 평문 복호화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"dev", "prod"})
+public class KmsDataCryptoService implements DataCryptoService {
+
+    private final KmsClient kmsClient;
+    private final SecureRandomBytesGenerator randomGenerator;
+
+    @Value("${cloud.aws.kms.key-id}")
+    private String cmkArn;
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12; // 96 bits
+    private static final int GCM_TAG_LENGTH = 128; // 128 bits
+
+    @Override
+    public EncryptedPayload encrypt(byte[] plaintext) {
+        try {
+            // 1. KMS로 데이터 키 생성
+            GenerateDataKeyResponse dataKeyResponse = kmsClient.generateDataKey(
+                    GenerateDataKeyRequest.builder()
+                            .keyId(cmkArn)
+                            .keySpec(DataKeySpec.AES_256)
+                            .build()
+            );
+            byte[] plaintextKey = dataKeyResponse.plaintext().asByteArray();
+            byte[] encryptedDataKey = dataKeyResponse.ciphertextBlob().asByteArray();
+
+            // 2. IV 생성
+            byte[] iv = randomGenerator.generate(GCM_IV_LENGTH);
+
+            // 3. AES-256-GCM으로 평문 암호화
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE,
+                    new SecretKeySpec(plaintextKey, "AES"),
+                    new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+            byte[] ciphertextWithTag = cipher.doFinal(plaintext);
+
+            // 4. Ciphertext와 Tag 분리
+            int tagLength = GCM_TAG_LENGTH / 8;
+            byte[] ciphertext = Arrays.copyOfRange(ciphertextWithTag, 0, ciphertextWithTag.length - tagLength);
+            byte[] tag = Arrays.copyOfRange(ciphertextWithTag, ciphertextWithTag.length - tagLength, ciphertextWithTag.length);
+
+            return new EncryptedPayload(ciphertext, encryptedDataKey, iv, tag);
+
+        } catch (Exception e) {
+            log.error("데이터 암호화 실패", e);
+            throw new RuntimeException("데이터 암호화에 실패했습니다", e);
+        }
+    }
+
+    @Override
+    public byte[] decrypt(EncryptedPayload payload) {
+        try {
+            // 1. KMS로 데이터 키 복호화
+            byte[] plaintextKey = kmsClient.decrypt(r -> r
+                            .ciphertextBlob(SdkBytes.fromByteArray(payload.encryptedDataKey())))
+                    .plaintext()
+                    .asByteArray();
+
+            // 2. Ciphertext + Tag 결합
+            byte[] ciphertextWithTag = ByteBuffer.allocate(payload.ciphertext().length + payload.authTag().length)
+                    .put(payload.ciphertext())
+                    .put(payload.authTag())
+                    .array();
+
+            // 3. AES-256-GCM으로 복호화
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE,
+                    new SecretKeySpec(plaintextKey, "AES"),
+                    new GCMParameterSpec(GCM_TAG_LENGTH, payload.iv()));
+
+            return cipher.doFinal(ciphertextWithTag);
+
+        } catch (Exception e) {
+            log.error("데이터 복호화 실패", e);
+            throw new RuntimeException("데이터 복호화에 실패했습니다", e);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/security/crypto/LocalDataCryptoService.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/security/crypto/LocalDataCryptoService.java
@@ -1,0 +1,44 @@
+package com.devkor.ifive.nadab.global.security.crypto;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 로컬 및 테스트 환경용 암호화 서비스
+ *
+ * XOR 기반 간단한 암호화로 실제 암호화 로직 테스트 가능
+ */
+@Component
+@Profile({"local", "test"})
+public class LocalDataCryptoService implements DataCryptoService {
+
+    private static final byte[] FIXED_KEY = "nadab-local-test".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public EncryptedPayload encrypt(byte[] plaintext) {
+        byte[] ciphertext = xor(plaintext, FIXED_KEY);
+
+        return new EncryptedPayload(
+                ciphertext,
+                new byte[0], // encryptedDataKey: 로컬에서는 빈 배열
+                new byte[0], // iv: 로컬에서는 빈 배열
+                new byte[0]  // authTag: 로컬에서는 빈 배열
+        );
+    }
+
+    @Override
+    public byte[] decrypt(EncryptedPayload payload) {
+        return xor(payload.ciphertext(), FIXED_KEY);
+    }
+
+    // XOR 암호화/복호화 (동일한 키로 두 번 XOR하면 원본 복원)
+    private byte[] xor(byte[] data, byte[] key) {
+        byte[] result = new byte[data.length];
+        for (int i = 0; i < data.length; i++) {
+            result[i] = (byte) (data[i] ^ key[i % key.length]);
+        }
+        return result;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,11 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 profile-image:
   env: dev

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,6 +38,11 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 profile-image:
   env: local

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,6 +37,11 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 profile-image:
   env: prod

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,8 @@ cloud:
       secret-key: ${IAM_SECRET_KEY}
     s3:
       bucket: ${BUCKET_NAME}
+    kms:
+      key-id: ${KMS_KEY_ID}
 
 app:
   cookie:

--- a/src/main/resources/db/migration/V20260409_0257__CH_refactor_social_account_refresh_token.sql
+++ b/src/main/resources/db/migration/V20260409_0257__CH_refactor_social_account_refresh_token.sql
@@ -1,0 +1,12 @@
+-- Refactor social_account refresh_token to use KMS Envelope Encryption
+-- 기존 TEXT 컬럼을 삭제하고 4개의 BYTEA 컬럼으로 변경
+
+-- 기존 컬럼 삭제
+ALTER TABLE social_account DROP COLUMN IF EXISTS refresh_token;
+
+-- 새 컬럼 추가 (KMS Envelope Encryption용)
+ALTER TABLE social_account
+    ADD COLUMN refresh_token_ciphertext BYTEA,
+    ADD COLUMN refresh_token_key BYTEA,
+    ADD COLUMN refresh_token_iv BYTEA,
+    ADD COLUMN refresh_token_tag BYTEA;


### PR DESCRIPTION
## 📝 요약(Summary)
iOS 앱에서 Sign in with Apple을 사용할 수 있도록 네이티브 로그인을 구현했습니다.

주요 구현 내용
  1. iOS Native 로그인 플로우
  iOS SDK → Authorization Code → 백엔드 → Apple Token API → ID Token 검증 → Refresh Token 암호화 저장 → JWT 발급

  2. 새로운 API 엔드포인트
  - POST /api/v1/auth/apple/native-login
  - Request: { "code": "Authorization Code" }
  - Response: Access Token + signupStatus

  3. Refresh Token 암호화 저장
  - KMS Envelope Encryption 방식 사용
  - 4개 BYTEA 컬럼에 분산 저장 (ciphertext, key, iv, tag)
  - 로컬 환경: XOR 암호화 (LocalDataCryptoService)
  - Dev/Prod: AWS KMS 암호화 (KmsDataCryptoService)

  4. 회원 탈퇴 시 Revoke
  - Apple API에 Refresh Token 무효화 요청
  - 실패해도 탈퇴 진행 (사용자 경험 우선)

## 🔗 Related Issue
- Closes: 

## 💬 공유사항
웹에서 애플 로그인은 이메일을 안정적으로 받을 수 없어 iOS Native만 지원하도록 결정했습니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.