### PR TITLE
fix(notify): 뱃지 동기화 타이밍 이슈 해결 및 notificationId 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/NotificationCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/NotificationCommandService.java
@@ -1,5 +1,6 @@
 package com.devkor.ifive.nadab.domain.notification.application;
 
+import com.devkor.ifive.nadab.domain.notification.application.event.BadgeSyncEvent;
 import com.devkor.ifive.nadab.domain.notification.application.event.NotificationCreatedEvent;
 import com.devkor.ifive.nadab.domain.notification.core.entity.Notification;
 import com.devkor.ifive.nadab.domain.notification.core.entity.NotificationGroup;
@@ -207,9 +208,9 @@ public class NotificationCommandService {
 
     /**
      * 다른 기기로 뱃지 개수 동기화 (Silent Badge Update)
-     * - 비동기로 즉시 실행 (실시간 동기화)
+     * - 이벤트 발행 (트랜잭션 커밋 후 실행)
      */
     private void syncBadgeCount(Long userId) {
-        fcmNotificationSender.sendSilentBadgeUpdate(userId);
+        eventPublisher.publishEvent(new BadgeSyncEvent(userId));
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/BadgeSyncEvent.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/BadgeSyncEvent.java
@@ -1,0 +1,16 @@
+package com.devkor.ifive.nadab.domain.notification.application.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뱃지 동기화 이벤트
+ * - 알림 읽음/삭제 후 다른 기기로 뱃지 개수를 동기화할 때 사용
+ * - 트랜잭션 커밋 후 처리 (AFTER_COMMIT)
+ */
+@Getter
+@RequiredArgsConstructor
+public class BadgeSyncEvent {
+
+    private final Long userId;
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/NotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/NotificationEventListener.java
@@ -87,4 +87,16 @@ public class NotificationEventListener {
             transactionHelper.markAsFailed(notificationId);
         }
     }
+
+    /**
+     * 뱃지 동기화 이벤트 처리
+     * - AFTER_COMMIT: 알림 읽음/삭제 트랜잭션이 커밋된 후 실행
+     * - @Async: 비동기로 다른 기기에 뱃지 카운트 동기화
+     */
+    @Async("fcmTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBadgeSync(BadgeSyncEvent event) {
+        log.debug("Badge sync event received: userId={}", event.getUserId());
+        fcmSender.sendSilentBadgeUpdate(event.getUserId());
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/answer/DailyWriteReminderScheduler.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/answer/DailyWriteReminderScheduler.java
@@ -156,6 +156,7 @@ public class DailyWriteReminderScheduler {
 
             // 4. FCM 푸시 발송
             NotificationMessageDto messageDto = NotificationMessageDto.builder()
+                .notificationId(null)  // 알림함에 저장하지 않음
                 .type(NotificationType.DAILY_WRITE_REMINDER)
                 .title(content.title())
                 .body(content.body())

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/answer/InactiveUserNotificationScheduler.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/answer/InactiveUserNotificationScheduler.java
@@ -178,6 +178,7 @@ public class InactiveUserNotificationScheduler {
 
             // 5. FCM 푸시 발송
             NotificationMessageDto messageDto = NotificationMessageDto.builder()
+                .notificationId(null)  // 알림함에 저장하지 않음
                 .type(NotificationType.INACTIVE_USER_REMINDER)
                 .title(content.title())
                 .body(content.body())

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/core/dto/NotificationMessageDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/core/dto/NotificationMessageDto.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 @Builder
 public class NotificationMessageDto {
 
+    private Long notificationId;  // 푸시 알림 탭 시 읽음 처리용
     private NotificationType type;
     private String title;
     private String body;
@@ -21,6 +22,7 @@ public class NotificationMessageDto {
 
     public static NotificationMessageDto from(Notification notification, int unreadCount) {
         return NotificationMessageDto.builder()
+            .notificationId(notification.getId())
             .type(notification.getType())
             .title(notification.getTitle())
             .body(notification.getBody())

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/infra/FcmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/infra/FcmClient.java
@@ -60,6 +60,7 @@ public class FcmClient {
                     .setTitle(message.getTitle())
                     .setBody(message.getBody())
                     .build())
+                .putData("notificationId", String.valueOf(message.getNotificationId()))
                 .putData("type", message.getType().name())
                 .putData("targetId", message.getTargetId() != null ? message.getTargetId() : "")
                 .putData("inboxMessage", message.getInboxMessage())

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/infra/FcmNotificationSender.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/infra/FcmNotificationSender.java
@@ -221,10 +221,9 @@ public class FcmNotificationSender {
 
     /**
      * Silent Badge Update (알림 없이 뱃지만 업데이트)
-     * - 알림 읽음/삭제 후 다른 기기 뱃지 동기화
-     * - 비동기로 즉시 실행 (실시간 동기화)
+     * - EventListener에서 호출 (다른 기기 뱃지 동기화)
+     * - Multicast 발송
      */
-    @Async("fcmTaskExecutor")
     public void sendSilentBadgeUpdate(Long userId) {
         // 사용자 조회
         User user = userRepository.findById(userId).orElse(null);


### PR DESCRIPTION
## 📝 요약(Summary)
- unreadCount가 불일치하는 문제 때문에 트랜잭션 커밋 후 뱃지 동기화하여 타이밍을 맞추기 위해 BadgeSyncEvent 추가
- 상태표시줄에서 알림을 읽으면서 읽음처리 API 호출을 위해 FCM 메시지에 notificationId 추가
- 리마인더 알림 notificationId=null 명시

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.