### PR TITLE
feat(stats): APPLE 제공자 반영 및 유형 리포트 통계 페이지 추가

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,6 +20,7 @@ module.exports = {
             "report",
             "moderation",
             "search",
+            "stats",
             "friend",
             "notify",
             "infra",
@@ -115,6 +116,9 @@ module.exports = {
                     },
                     search: {
                         description: '🔍 검색 도메인 (예: 질문/답변 검색, 최근 검색어)'
+                    },
+                    stats: {
+                        description: '📊 통계 도메인 (예: 일간 통계 페이지)'
                     },
                     friend: {
                         description: '👥 친구 도메인 (예: 친구 신청, 수락, 목록 관리)'

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/TotalStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/TotalStatsService.java
@@ -35,7 +35,7 @@ public class TotalStatsService {
         providerMap.put("NORMAL", normal);
 
         // 표시 순서 고정
-        List<String> providerLabels = List.of("GOOGLE", "KAKAO", "NAVER", "NORMAL");
+        List<String> providerLabels = List.of("APPLE", "GOOGLE", "KAKAO", "NAVER", "NORMAL");
         List<Long> providerCounts = providerLabels.stream()
                 .map(l -> providerMap.getOrDefault(l, 0L))
                 .toList();

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/TypeStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/TypeStatsService.java
@@ -1,0 +1,42 @@
+package com.devkor.ifive.nadab.domain.stats.application;
+
+import com.devkor.ifive.nadab.domain.stats.core.dto.total.LabelCountDto;
+import com.devkor.ifive.nadab.domain.stats.core.dto.type.TypeStatsViewModel;
+import com.devkor.ifive.nadab.domain.stats.core.repository.TypeStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TypeStatsService {
+
+    private final TypeStatsRepository repo;
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public TypeStatsViewModel getTypeStats() {
+        long inProgressTypeReportCount = repo.countInProgressTypeReportsNow();
+        List<LabelCountDto> completedByInterest = repo.countCompletedTypeReportsByInterest();
+
+        List<String> interestLabels = completedByInterest.stream()
+                .map(LabelCountDto::label)
+                .toList();
+        List<Long> completedTypeReportCounts = completedByInterest.stream()
+                .map(LabelCountDto::count)
+                .toList();
+
+        return new TypeStatsViewModel(
+                inProgressTypeReportCount,
+                interestLabels,
+                completedTypeReportCounts,
+                OffsetDateTime.now(SEOUL).format(FMT)
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/controller/StatsController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/controller/StatsController.java
@@ -3,10 +3,12 @@ package com.devkor.ifive.nadab.domain.stats.controller;
 import com.devkor.ifive.nadab.domain.stats.application.DailyStatsService;
 import com.devkor.ifive.nadab.domain.stats.application.MonthlyStatsService;
 import com.devkor.ifive.nadab.domain.stats.application.TotalStatsService;
+import com.devkor.ifive.nadab.domain.stats.application.TypeStatsService;
 import com.devkor.ifive.nadab.domain.stats.application.WeeklyStatsService;
 import com.devkor.ifive.nadab.domain.stats.core.dto.daily.DailyStatsViewModel;
 import com.devkor.ifive.nadab.domain.stats.core.dto.monthly.MonthlyStatsViewModel;
 import com.devkor.ifive.nadab.domain.stats.core.dto.total.TotalStatsViewModel;
+import com.devkor.ifive.nadab.domain.stats.core.dto.type.TypeStatsViewModel;
 import com.devkor.ifive.nadab.domain.stats.core.dto.weekly.WeeklyStatsViewModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -21,6 +23,7 @@ public class StatsController {
     private final WeeklyStatsService weeklyStatsService;
     private final MonthlyStatsService monthlyStatsService;
     private final TotalStatsService totalStatsService;
+    private final TypeStatsService typeStatsService;
 
 
     @GetMapping("stats/daily")
@@ -53,5 +56,13 @@ public class StatsController {
         model.addAttribute("vm", vm);
         model.addAttribute("activeTab", "total");
         return "stats/total";
+    }
+
+    @GetMapping("/stats/type")
+    public String typeStats(Model model) {
+        TypeStatsViewModel vm = typeStatsService.getTypeStats();
+        model.addAttribute("vm", vm);
+        model.addAttribute("activeTab", "type");
+        return "stats/type";
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/total/TotalStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/total/TotalStatsViewModel.java
@@ -6,7 +6,7 @@ public record TotalStatsViewModel(
 
         long totalUserCount,
 
-        // provider labels: ["GOOGLE","KAKAO","NAVER","NORMAL"]
+        // provider labels: ["APPLE","GOOGLE","KAKAO","NAVER","NORMAL"]
         List<String> providerLabels,
         List<Long> providerCounts,
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/type/TypeStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/type/TypeStatsViewModel.java
@@ -1,0 +1,10 @@
+package com.devkor.ifive.nadab.domain.stats.core.dto.type;
+
+import java.util.List;
+
+public record TypeStatsViewModel(
+        long inProgressTypeReportCount,
+        List<String> interestLabels,
+        List<Long> completedTypeReportCounts,
+        String refreshedAt
+) {}

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/TypeStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/TypeStatsRepository.java
@@ -1,0 +1,41 @@
+package com.devkor.ifive.nadab.domain.stats.core.repository;
+
+import com.devkor.ifive.nadab.domain.stats.core.dto.total.LabelCountDto;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TypeStatsRepository {
+
+    private final EntityManager em;
+
+    public long countInProgressTypeReportsNow() {
+        return em.createQuery("""
+                select count(tr.id)
+                from TypeReport tr
+                where tr.status = com.devkor.ifive.nadab.domain.typereport.core.entity.TypeReportStatus.IN_PROGRESS
+                  and tr.deletedAt is null
+                """, Long.class)
+                .getSingleResult();
+    }
+
+    public List<LabelCountDto> countCompletedTypeReportsByInterest() {
+        return em.createQuery("""
+                select new com.devkor.ifive.nadab.domain.stats.core.dto.total.LabelCountDto(
+                    cast(i.code as string),
+                    count(tr.id)
+                )
+                from Interest i
+                left join TypeReport tr on tr.interestCode = i.code
+                                       and tr.status = com.devkor.ifive.nadab.domain.typereport.core.entity.TypeReportStatus.COMPLETED
+                                       and tr.deletedAt is null
+                group by i.code
+                order by i.code
+                """, LabelCountDto.class)
+                .getResultList();
+    }
+}

--- a/src/main/resources/templates/stats/daily.html
+++ b/src/main/resources/templates/stats/daily.html
@@ -278,6 +278,9 @@
      th:classappend="${activeTab} == 'monthly' ? ' active' : ''"
      th:href="@{/stats/monthly}">월간</a>
   <a class="tab-link"
+     th:classappend="${activeTab} == 'type' ? ' active' : ''"
+     th:href="@{/stats/type}">유형</a>
+  <a class="tab-link"
      th:classappend="${activeTab} == 'total' ? ' active' : ''"
      th:href="@{/stats/total}">전체</a>
 </div>

--- a/src/main/resources/templates/stats/total.html
+++ b/src/main/resources/templates/stats/total.html
@@ -287,6 +287,9 @@
      th:classappend="${activeTab} == 'monthly' ? ' active' : ''"
      th:href="@{/stats/monthly}">월간</a>
   <a class="tab-link"
+     th:classappend="${activeTab} == 'type' ? ' active' : ''"
+     th:href="@{/stats/type}">유형</a>
+  <a class="tab-link"
      th:classappend="${activeTab} == 'total' ? ' active' : ''"
      th:href="@{/stats/total}">전체</a>
 </div>

--- a/src/main/resources/templates/stats/total.html
+++ b/src/main/resources/templates/stats/total.html
@@ -359,6 +359,17 @@
     'rgba(77,195,255,0.85)',
   ];
 
+  const providerPaletteByLabel = {
+    APPLE: 'rgba(180,120,255,0.85)',
+    GOOGLE: 'rgba(108,143,255,0.85)',
+    KAKAO: 'rgba(255,126,179,0.85)',
+    NAVER: 'rgba(77,232,194,0.85)',
+    NORMAL: 'rgba(255,196,77,0.85)',
+  };
+  const providerPalette = providerLabels.map(
+    (label, index) => providerPaletteByLabel[label] ?? PALETTE[index % PALETTE.length]
+  );
+
   const tooltipDefaults = {
     backgroundColor: '#1e2230',
     borderColor: 'rgba(255,255,255,0.1)',
@@ -378,7 +389,7 @@
       datasets: [{
         label: '유저 수',
         data: providerCounts,
-        backgroundColor: PALETTE,
+        backgroundColor: providerPalette,
         borderRadius: 6,
         borderSkipped: false,
       }]

--- a/src/main/resources/templates/stats/type.html
+++ b/src/main/resources/templates/stats/type.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>NADAB · Monthly Stats</title>
+  <title>NADAB - Type Stats</title>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Syne:wght@400;600;700;800&display=swap" rel="stylesheet"/>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -14,7 +14,6 @@
       --border: #2a2f3e;
       --accent: #6c8fff;
       --accent-2: #ff7eb3;
-      --accent-3: #4de8c2;
       --text-1: #e8eaf2;
       --text-2: #8b91a8;
       --text-3: #4f556a;
@@ -105,7 +104,7 @@
       background: var(--text-3);
       transition: background .3s, box-shadow .3s;
     }
-    .health-bar.ok .health-dot { background: var(--accent-3); box-shadow: 0 0 6px rgba(77,232,194,.7); }
+    .health-bar.ok .health-dot { background: #4de8c2; box-shadow: 0 0 6px rgba(77,232,194,.7); }
     .health-bar.error .health-dot { background: var(--accent-2); box-shadow: 0 0 6px rgba(255,126,179,.7); }
 
     @keyframes pulse {
@@ -174,15 +173,6 @@
       color: var(--text-1);
     }
 
-    .charts-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 20px;
-    }
-    @media (max-width: 800px) {
-      .charts-grid { grid-template-columns: 1fr; }
-    }
-
     .chart-card {
       background: var(--surface);
       border: 1px solid var(--border);
@@ -215,21 +205,19 @@
       vertical-align: middle;
       position: relative;
       top: -1px;
+      background: var(--accent-2);
     }
-    .dot-blue { background: var(--accent); }
-    .dot-pink { background: var(--accent-2); }
-    .dot-teal { background: var(--accent-3); }
-    .dot-orange { background: #f5a524; }
   </style>
 </head>
 <body>
 
 <div class="page-header">
-  <div class="page-title">NADAB · Stats</div>
+  <div class="page-title">NADAB ·
+    Stats</div>
   <div class="header-right">
     <div id="healthBar" class="health-bar loading">
       <span class="health-dot"></span>
-      <span id="healthText" class="health-text">Checking...</span>
+      <span id="healthText" class="health-text">서버 확인 중…</span>
     </div>
     <div class="refreshed-at">
       마지막 갱신 <span th:text="${vm.refreshedAt}">-</span>
@@ -264,59 +252,24 @@
 
 <div class="kpi-card">
   <div>
-    <div class="kpi-label">현재 생성 중 월간 리포트</div>
-    <div class="kpi-value" th:text="${vm.inProgressMonthlyReportCount}">0</div>
+    <div class="kpi-label">현재 생성 중 유형 리포트</div>
+    <div class="kpi-value" th:text="${vm.inProgressTypeReportCount}">0</div>
   </div>
 </div>
 
-<div class="charts-grid">
-  <div class="chart-card">
-    <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-blue"></span>월간 가입자 수</div>
-      <div class="chart-card-subtitle">최근 5개월</div>
-    </div>
-    <div class="chart-card-body">
-      <canvas id="signupChart" height="140"></canvas>
-    </div>
+<div class="chart-card">
+  <div class="chart-card-header">
+    <div class="chart-card-title"><span class="dot"></span>관심 주제별 생성된 총 유형 리포트 수</div>
+    <div class="chart-card-subtitle">전체 누적 (COMPLETED 기준)</div>
   </div>
-
-  <div class="chart-card">
-    <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-pink"></span>월간 할당 질문 수</div>
-      <div class="chart-card-subtitle">최근 5개월</div>
-    </div>
-    <div class="chart-card-body">
-      <canvas id="assignedChart" height="140"></canvas>
-    </div>
-  </div>
-
-  <div class="chart-card">
-    <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-teal"></span>생성된 일간 리포트 수</div>
-      <div class="chart-card-subtitle">최근 5개월</div>
-    </div>
-    <div class="chart-card-body">
-      <canvas id="completedDailyChart" height="140"></canvas>
-    </div>
-  </div>
-
-  <div class="chart-card">
-    <div class="chart-card-header">
-      <div class="chart-card-title"><span class="dot dot-orange"></span>생성된 월간 리포트 수</div>
-      <div class="chart-card-subtitle">최근 5개월</div>
-    </div>
-    <div class="chart-card-body">
-      <canvas id="completedMonthlyChart" height="140"></canvas>
-    </div>
+  <div class="chart-card-body">
+    <canvas id="typeByInterestChart" height="140"></canvas>
   </div>
 </div>
 
 <script th:inline="javascript">
-  const labels = [[${vm.labels}]];
-  const signupCounts = [[${vm.signupCounts}]].map(v => parseInt(v, 10));
-  const assignedCounts = [[${vm.assignedQuestionCounts}]].map(v => parseInt(v, 10));
-  const completedDailyCounts = [[${vm.completedDailyReportCounts}]].map(v => parseInt(v, 10));
-  const completedMonthlyCounts = [[${vm.completedMonthlyReportCounts}]].map(v => parseInt(v, 10));
+  const interestLabels = [[${vm.interestLabels}]];
+  const completedTypeReportCounts = [[${vm.completedTypeReportCounts}]].map(v => parseInt(v, 10));
 
   Chart.defaults.color = '#8b91a8';
   Chart.defaults.font.family = "'DM Mono', monospace";
@@ -324,72 +277,51 @@
 
   const gridColor = 'rgba(255,255,255,0.05)';
   const borderColor = 'rgba(255,255,255,0.08)';
-
-  function makeGradient(ctx, color) {
-    const g = ctx.createLinearGradient(0, 0, 0, 220);
-    g.addColorStop(0, color.replace('1)', '0.18)'));
-    g.addColorStop(1, color.replace('1)', '0)'));
-    return g;
-  }
-
-  const configs = [
-    { id: 'signupChart', label: '가입자 수', data: signupCounts, color: 'rgba(108,143,255,1)' },
-    { id: 'assignedChart', label: '할당 질문 수', data: assignedCounts, color: 'rgba(255,126,179,1)' },
-    { id: 'completedDailyChart', label: '일간 리포트 생성 수', data: completedDailyCounts, color: 'rgba(77,232,194,1)' },
-    { id: 'completedMonthlyChart', label: '월간 리포트 생성 수', data: completedMonthlyCounts, color: 'rgba(245,165,36,1)' },
+  const barColors = [
+    'rgba(108,143,255,0.85)',
+    'rgba(255,126,179,0.85)',
+    'rgba(77,232,194,0.85)',
+    'rgba(255,196,77,0.85)',
+    'rgba(180,120,255,0.85)',
+    'rgba(77,195,255,0.85)',
   ];
 
-  configs.forEach(({ id, label, data, color }) => {
-    const canvasEl = document.getElementById(id);
-    const ctx2d = canvasEl.getContext('2d');
-    const gradient = makeGradient(ctx2d, color);
-
-    new Chart(canvasEl, {
-      type: 'line',
-      data: {
-        labels,
-        datasets: [{
-          label,
-          data,
-          tension: 0.35,
-          fill: true,
-          backgroundColor: gradient,
-          borderColor: color,
-          borderWidth: 2,
-          pointBackgroundColor: color,
-          pointRadius: 4,
-          pointHoverRadius: 6,
-        }]
-      },
-      options: {
-        responsive: true,
-        interaction: { mode: 'index', intersect: false },
-        plugins: {
-          legend: { display: false },
-          tooltip: {
-            backgroundColor: '#1e2230',
-            borderColor: 'rgba(255,255,255,0.1)',
-            borderWidth: 1,
-            padding: 12,
-            titleColor: '#e8eaf2',
-            bodyColor: '#8b91a8',
-            titleFont: { family: "'Syne', sans-serif", weight: '700', size: 12 },
-            bodyFont: { family: "'DM Mono', monospace", size: 12 },
-          }
+  new Chart(document.getElementById('typeByInterestChart'), {
+    type: 'bar',
+    data: {
+      labels: interestLabels,
+      datasets: [{
+        label: '유형 리포트 수',
+        data: completedTypeReportCounts,
+        backgroundColor: interestLabels.map((_, index) => barColors[index % barColors.length]),
+        borderRadius: 6,
+        borderSkipped: false,
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1e2230',
+          borderColor: 'rgba(255,255,255,0.1)',
+          borderWidth: 1,
+          padding: 12,
+          titleColor: '#e8eaf2',
+          bodyColor: '#8b91a8',
+          titleFont: { family: "'Syne', sans-serif", weight: '700', size: 12 },
+          bodyFont: { family: "'DM Mono', monospace", size: 12 },
         },
-        scales: {
-          x: {
-            grid: { color: gridColor, borderColor },
-            ticks: { maxRotation: 0 },
-          },
-          y: {
-            beginAtZero: true,
-            grid: { color: gridColor, borderColor },
-            ticks: { precision: 0, stepSize: 1 },
-          }
-        }
+      },
+      scales: {
+        x: { grid: { color: gridColor, borderColor } },
+        y: {
+          beginAtZero: true,
+          grid: { color: gridColor, borderColor },
+          ticks: { precision: 0, stepSize: 1 },
+        },
       }
-    });
+    }
   });
 
   async function checkHealth() {

--- a/src/main/resources/templates/stats/weekly.html
+++ b/src/main/resources/templates/stats/weekly.html
@@ -255,6 +255,9 @@
      th:classappend="${activeTab} == 'monthly' ? ' active' : ''"
      th:href="@{/stats/monthly}">월간</a>
   <a class="tab-link"
+     th:classappend="${activeTab} == 'type' ? ' active' : ''"
+     th:href="@{/stats/type}">유형</a>
+  <a class="tab-link"
      th:classappend="${activeTab} == 'total' ? ' active' : ''"
      th:href="@{/stats/total}">전체</a>
 </div>


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 1) 전체 통계(`/stats/total`) APPLE 반영
- Apple 로그인이 도입되어 전체 통계의 provider 집계/표시에 APPLE 반영
   - providerLabels에 `APPLE` 추가

### 2) 유형 리포트 통계 페이지(`/stats/type`) 신규 추가
- 컨트롤러 라우트 추가
- 통계 집계용 `TypeStatsRepository`, `TypeStatsService`, `TypeStatsViewModel` 신규 추가
- 집계 항목
  - 현재 생성 중 유형 리포트 수 (`IN_PROGRESS`)
  - 관심 주제별 생성된 총 유형 리포트 수 (`COMPLETED`, soft delete 제외, 0건 포함)
- `stats/type.html` 템플릿 추가
  - KPI 카드: 현재 생성 중 유형 리포트 수
  - Bar 차트: 관심 주제별 총 유형 리포트 수

### 3) 통계 페이지 네비게이션 확장
- `daily/weekly/monthly/total` 탭에 `유형` 탭 링크 추가



## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.