### PR TITLE
feat: 답변에 이미지 업로드 추가 및 탈퇴 사용자 이미지 정리 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -71,6 +71,10 @@ jobs:
             INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d | tr -d '\r')"
             export INSIGHT_PROMPT
             
+            INSIGHT_WITH_IMAGE_PROMPT_B64="${{ secrets.INSIGHT_WITH_IMAGE_PROMPT_B64 }}"
+            INSIGHT_WITH_IMAGE_PROMPT="$(printf '%s' "$INSIGHT_WITH_IMAGE_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export INSIGHT_WITH_IMAGE_PROMPT
+            
             WEEKLY_PROMPT_B64="${{ secrets.WEEKLY_PROMPT_B64 }}"
             WEEKLY_PROMPT="$(printf '%s' "$WEEKLY_PROMPT_B64" | base64 -d | tr -d '\r')"
             export WEEKLY_PROMPT

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -70,6 +70,10 @@ jobs:
             INSIGHT_PROMPT_B64="${{ secrets.INSIGHT_PROMPT_B64 }}"
             INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d | tr -d '\r')"
             export INSIGHT_PROMPT
+            
+            INSIGHT_WITH_IMAGE_PROMPT_B64="${{ secrets.INSIGHT_WITH_IMAGE_PROMPT_B64 }}"
+            INSIGHT_WITH_IMAGE_PROMPT="$(printf '%s' "$INSIGHT_WITH_IMAGE_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export INSIGHT_WITH_IMAGE_PROMPT
 
             WEEKLY_PROMPT_B64="${{ secrets.WEEKLY_PROMPT_B64 }}"
             WEEKLY_PROMPT="$(printf '%s' "$WEEKLY_PROMPT_B64" | base64 -d | tr -d '\r')"

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/scheduler/UserCleanupScheduler.java
@@ -1,6 +1,8 @@
 package com.devkor.ifive.nadab.domain.auth.infra.scheduler;
 
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.AnswerEntryRepository;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -8,6 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * 탈퇴 유저 영구 삭제 스케줄러
@@ -20,11 +25,23 @@ import java.time.OffsetDateTime;
 public class UserCleanupScheduler {
 
     private final UserRepository userRepository;
+    private final AnswerEntryRepository answerEntryRepository;
+    private final ProfileImageService profileImageService;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정
     @Transactional
     public void cleanupDeletedUsers() {
         OffsetDateTime expirationDate = OffsetDateTime.now().minusDays(14);
+
+        // 영구 삭제될 User의 id들
+        List<Long> targetUserIds = userRepository.findOldWithdrawnUserIds(expirationDate);
+
+        // 삭제 대상 회원들의 프로필 이미지 키와 답변 이미지 키를 모두 수집하여 S3에서 삭제
+        Set<String> imageKeysToDelete = new HashSet<>();
+        imageKeysToDelete.addAll(userRepository.findProfileImageKeysByIdIn(targetUserIds));
+        imageKeysToDelete.addAll(answerEntryRepository.findImageKeysByUserIds(targetUserIds));
+        imageKeysToDelete.forEach(profileImageService::deleteProfileImage);
+
         int deletedCount = userRepository.deleteOldWithdrawnUsers(expirationDate);
 
         if (deletedCount > 0) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/auth/infra/scheduler/UserCleanupScheduler.java
@@ -36,18 +36,21 @@ public class UserCleanupScheduler {
         // 영구 삭제될 User의 id들
         List<Long> targetUserIds = userRepository.findOldWithdrawnUserIds(expirationDate);
 
+        if(targetUserIds.isEmpty()) {
+            log.debug("정리할 탈퇴 회원이 없습니다.");
+            return;
+        }
+
         // 삭제 대상 회원들의 프로필 이미지 키와 답변 이미지 키를 모두 수집하여 S3에서 삭제
         Set<String> imageKeysToDelete = new HashSet<>();
         imageKeysToDelete.addAll(userRepository.findProfileImageKeysByIdIn(targetUserIds));
         imageKeysToDelete.addAll(answerEntryRepository.findImageKeysByUserIds(targetUserIds));
         imageKeysToDelete.forEach(profileImageService::deleteProfileImage);
 
-        int deletedCount = userRepository.deleteOldWithdrawnUsers(expirationDate);
+        int deletedCount = userRepository.deleteWithdrawnUsersByIdIn(targetUserIds);
 
         if (deletedCount > 0) {
             log.info("회원 정리 완료: {}명의 탈퇴 회원 영구 삭제 (기준일: {})", deletedCount, expirationDate.toLocalDate());
-        } else {
-            log.debug("정리할 탈퇴 회원이 없습니다.");
         }
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
@@ -45,6 +45,15 @@ public class DailyReportController {
                     이 때 유저의 답변은 기존의 답변으로 자동으로 사용됩니다. <br/>
                     소요 시간이 최대 3~4초밖에 안 되어 동기처리로 구현했습니다. <br/>
                     
+                    이미지 미포함의 경우 objectKey는 null로 보내주시면 됩니다. <br/>
+                    
+                    <이미지가 포함된 경우> <br/>
+                    **5MB 이하의 이미지 파일만 허용됩니다.** <br/>
+                    POST /daily-report/image/upload-url 엔드포인트로
+                    미리 발급받은 PresignedURL을 통해 이미지를 업로드한 후,
+                    해당 엔드포인트에서 반환된 objectKey를 이 요청에 포함시켜야 합니다. <br/>
+                  
+                    
                     | 응답의 emotion | 해당 감정 |
                     | :--- | :--- |
                     | `ACHIEVEMENT` | 성취 |

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
@@ -1,7 +1,9 @@
 package com.devkor.ifive.nadab.domain.dailyreport.api;
 
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.request.CreateAnswerImageUploadUrlRequest;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.request.DailyReportRequest;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.AnswerDetailResponse;
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateAnswerImageUploadUrlResponse;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateDailyReportResponse;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.DailyReportResponse;
 import com.devkor.ifive.nadab.domain.dailyreport.application.DailyReportQueryService;
@@ -183,6 +185,48 @@ public class DailyReportController {
             @PathVariable Long reportId
     ) {
         AnswerDetailResponse response = dailyReportQueryService.getDailyReportById(principal.getId(), reportId);
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/image/upload-url")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "답변 이미지 업로드 PresignedURL 생성",
+            description = """
+                    답변에 포함되는 이미지를 업로드할 수 있는 PresignedURL을 생성합니다.
+                    
+                    - HTTP Method: PUT
+                    - Headers:
+                        - Content-Type(필수): image/jpeg, image/png만 허용
+                    - Body: 이미지 파일
+                    - URL 만료 시간: 5분
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공",
+                            content = @Content(schema = @Schema(implementation = CreateAnswerImageUploadUrlResponse.class), mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = """
+                                    - ErrorCode: IMAGE_UNSUPPORTED_TYPE - 지원하지 않는 이미지 타입
+                                    """,
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패 (JWT 토큰 관련)",
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<CreateAnswerImageUploadUrlResponse>> createAnswerImageUploadUrl(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateAnswerImageUploadUrlRequest request) {
+        CreateAnswerImageUploadUrlResponse response =
+                dailyReportService.createUploadUrl(principal.getId(), request);
         return ApiResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/request/CreateAnswerImageUploadUrlRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/request/CreateAnswerImageUploadUrlRequest.java
@@ -1,0 +1,12 @@
+package com.devkor.ifive.nadab.domain.dailyreport.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "답변 이미지 업로드 PresignedURL 생성 요청")
+public record CreateAnswerImageUploadUrlRequest(
+        @Schema(description = "파일 확장자 (image/png, image/jpeg만 허용)", example = "image/png")
+        @NotBlank(message = "파일 확장자는 필수입니다.")
+        String contentType
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/request/DailyReportRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/request/DailyReportRequest.java
@@ -13,6 +13,12 @@ public record DailyReportRequest(
         @Size(max = 200, message = "answer는 최대 200자까지 입력 가능합니다")
         @Size(min = 1, message = "answer는 최소 1자 이상 입력해야 합니다")
         @NotBlank(message = "answer는 필수입니다")
-        String answer
+        String answer,
+
+        @Schema(
+                description = "이 값은 presignedURL 생성 API의 응답에서 받은 objectKey여야 합니다. ",
+                example = "dev/answers/original/12345/092f7ab2-c845-4bdf-8458-e2897135d4e7.png"
+        )
+        String objectKey
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/AnswerDetailResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/AnswerDetailResponse.java
@@ -24,16 +24,20 @@ public record AnswerDetailResponse(
         String content,
 
         @Schema(description = "리포트 감정 상태", example = "ACHIEVEMENT")
-        String emotion
+        String emotion,
+
+        @Schema(description = "이미지 URL")
+        String imageUrl
 ) {
-    public static AnswerDetailResponse from(AnswerDetailDto dto) {
+    public static AnswerDetailResponse from(AnswerDetailDto dto, String imageUrl) {
         return new AnswerDetailResponse(
                 dto.questionText(),
                 dto.interestCode() != null ? dto.interestCode().name() : null,
                 dto.answerDate(),
                 dto.answerContent(),
                 dto.reportContent(),
-                dto.emotionCode() != null ? dto.emotionCode().name() : null
+                dto.emotionCode() != null ? dto.emotionCode().name() : null,
+                imageUrl
         );
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/CreateAnswerImageUploadUrlResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/CreateAnswerImageUploadUrlResponse.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.domain.dailyreport.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "답변 이미지 업로드 PresignedURL 생성 응답")
+public record CreateAnswerImageUploadUrlResponse(
+        @Schema(description = "답변 이미지 업로드 PresignedURL", example = "https://nadab-profile-images.s3.amazonaws.com/...")
+        String uploadUrl,
+
+        @Schema(description = "답변 이미지 Object Key. 일간 리포트 생성에 사용됩니다.", example = "dev/answers/original/12345/092f7ab2-c845-4bdf-8458-e2897135d4e7.png")
+        String objectKey
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/CreateDailyReportResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/CreateDailyReportResponse.java
@@ -14,6 +14,9 @@ public record CreateDailyReportResponse(
         String emotion,
 
         @Schema(description = "리포트 작성 후 크리스탈 잔액", example = "100")
-        Long balanceAfter
+        Long balanceAfter,
+
+        @Schema(description = "이미지 URL")
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/DailyReportResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/DailyReportResponse.java
@@ -15,6 +15,9 @@ public record DailyReportResponse(
         String emotion,
 
         @Schema(description = "피드 공유 상태", example = "false")
-        Boolean isShared
+        Boolean isShared,
+
+        @Schema(description = "이미지 URL")
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedResponse.java
@@ -24,6 +24,9 @@ public record FeedResponse(
         String answer,
 
         @Schema(description = "감정 코드", example = "ACHIEVEMENT")
-        String emotionCode
+        String emotionCode,
+
+        @Schema(description = "이미지 URL")
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/AnswerQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/AnswerQueryService.java
@@ -14,6 +14,7 @@ import com.devkor.ifive.nadab.domain.dailyreport.core.dto.SearchAnswerEntryDto;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.EmotionCode;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.AnswerEntryQueryRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.application.helper.CursorParser;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import com.devkor.ifive.nadab.global.shared.util.MonthRangeCalculator;
@@ -34,6 +35,8 @@ import java.util.List;
 public class AnswerQueryService {
 
     private final AnswerEntryQueryRepository answerEntryQueryRepository;
+
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
 
     private static final int PAGE_SIZE = 20;
 
@@ -129,14 +132,18 @@ public class AnswerQueryService {
         AnswerDetailDto dto = answerEntryQueryRepository.findDetailByAnswerId(userId, answerId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ANSWER_NOT_FOUND));
 
-        return AnswerDetailResponse.from(dto);
+        String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
+
+        return AnswerDetailResponse.from(dto, imageUrl);
     }
 
     public AnswerDetailResponse getAnswerDetailByDate(Long userId, LocalDate date) {
         AnswerDetailDto dto = answerEntryQueryRepository.findDetailByUserAndDate(userId, date)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ANSWER_NOT_FOUND));
 
-        return AnswerDetailResponse.from(dto);
+        String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
+
+        return AnswerDetailResponse.from(dto, imageUrl);
     }
 
     /**

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportQueryService.java
@@ -9,6 +9,7 @@ import com.devkor.ifive.nadab.domain.dailyreport.core.repository.AnswerEntryRepo
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
@@ -28,6 +29,8 @@ public class DailyReportQueryService {
     private final DailyReportRepository dailyReportRepository;
     private final AnswerEntryRepository answerEntryRepository;
 
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
+
     public DailyReportResponse getDailyReport(Long id) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -40,11 +43,14 @@ public class DailyReportQueryService {
         DailyReport report = dailyReportRepository.findByAnswerEntryAndDate(entry, today)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
 
+        String imageUrl = entry.getImageKey() != null ? profileImageUrlBuilder.buildUrl(entry.getImageKey()) : null;
+
         return new DailyReportResponse(
                 entry.getContent(),
                 report.getContent(),
                 report.getEmotion().getCode().toString(),
-                report.getIsShared()
+                report.getIsShared(),
+                imageUrl
         );
     }
 
@@ -56,6 +62,8 @@ public class DailyReportQueryService {
         AnswerDetailDto dto = dailyReportRepository.findDetailByReportId(user.getId(), reportId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ANSWER_NOT_FOUND));
 
-        return AnswerDetailResponse.from(dto);
+        String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
+
+        return AnswerDetailResponse.from(dto, imageUrl);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -76,7 +76,7 @@ public class DailyReportService {
 
         AiDailyReportResultDto dto;
         try {
-            dto = dailyReportLlmClient.generate(question.getQuestionText(), answerEntry.getContent());
+            dto = dailyReportLlmClient.generate(question.getQuestionText(), answerEntry);
         } catch (Exception e) {
             dailyReportTxService.failDaily(prep.reportId());
             throw e;
@@ -123,6 +123,6 @@ public class DailyReportService {
 
         String uploadUrl = profileImageService.generatePresignedUploadUrl(objectKey, contentType);
 
-        return new CreateAnswerImageUploadUrlResponse(objectKey, uploadUrl);
+        return new CreateAnswerImageUploadUrlResponse(uploadUrl, objectKey);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -1,6 +1,8 @@
 package com.devkor.ifive.nadab.domain.dailyreport.application;
 
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.request.CreateAnswerImageUploadUrlRequest;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.request.DailyReportRequest;
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateAnswerImageUploadUrlResponse;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateDailyReportResponse;
 import com.devkor.ifive.nadab.domain.dailyreport.application.event.DailyReportCompletedEvent;
 import com.devkor.ifive.nadab.domain.dailyreport.core.dto.ConfirmDailyAndRewardDto;
@@ -15,16 +17,19 @@ import com.devkor.ifive.nadab.domain.question.core.repository.UserDailyQuestionR
 import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -35,11 +40,14 @@ public class DailyReportService {
     private final UserDailyQuestionRepository userDailyQuestionRepository;
 
     private final DailyReportTxService dailyReportTxService;
+    private final ProfileImageService profileImageService;
 
     private final DailyReportLlmClient dailyReportLlmClient;
 
     private final ApplicationEventPublisher eventPublisher;
 
+    @Value("${profile-image.env}")
+    private String env;
 
     public CreateDailyReportResponse generateDailyReport(Long userId, DailyReportRequest request) {
         User user = userRepository.findById(userId)
@@ -90,5 +98,31 @@ public class DailyReportService {
                 confirmDto.emotion().getCode().toString(),
                 confirmDto.balanceAfter()
         );
+    }
+
+    public CreateAnswerImageUploadUrlResponse createUploadUrl(
+            Long userId,
+            CreateAnswerImageUploadUrlRequest request) {
+
+        // content type / 확장자 검증
+        String contentType = request.contentType();
+        if (!"image/jpeg".equalsIgnoreCase(contentType)
+                && !"image/png".equalsIgnoreCase(contentType)) {
+            throw new BadRequestException(ErrorCode.IMAGE_UNSUPPORTED_TYPE);
+        }
+
+        String extension = switch (contentType) {
+            case "image/jpeg" -> "jpg";
+            case "image/png" -> "png";
+            default -> throw new BadRequestException(ErrorCode.IMAGE_UNSUPPORTED_TYPE);
+        };
+
+        String uuid = UUID.randomUUID().toString();
+        String objectKey = "%s/answers/original/%d/%s.%s"
+                .formatted(env, userId, uuid, extension);
+
+        String uploadUrl = profileImageService.generatePresignedUploadUrl(objectKey, contentType);
+
+        return new CreateAnswerImageUploadUrlResponse(objectKey, uploadUrl);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -112,10 +112,6 @@ public class DailyReportService {
 
         // content type / 확장자 검증
         String contentType = request.contentType();
-        if (!"image/jpeg".equalsIgnoreCase(contentType)
-                && !"image/png".equalsIgnoreCase(contentType)) {
-            throw new BadRequestException(ErrorCode.IMAGE_UNSUPPORTED_TYPE);
-        }
 
         String extension = switch (contentType) {
             case "image/jpeg" -> "jpg";

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -62,7 +62,7 @@ public class DailyReportService {
             throw new BadRequestException(ErrorCode.DAILY_QUESTION_MISMATCH);
         }
 
-        PrepareDailyResultDto prep = dailyReportTxService.prepareDaily(user, question, request.answer(), isDayPassed);
+        PrepareDailyResultDto prep = dailyReportTxService.prepareDaily(user, question, request.answer(), isDayPassed, request.objectKey());
 
         AnswerEntry answerEntry = prep.entry();
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -18,6 +18,7 @@ import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
@@ -45,6 +46,8 @@ public class DailyReportService {
     private final DailyReportLlmClient dailyReportLlmClient;
 
     private final ApplicationEventPublisher eventPublisher;
+
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
 
     @Value("${profile-image.env}")
     private String env;
@@ -92,11 +95,14 @@ public class DailyReportService {
             );
         }
 
+        String imageUrl = answerEntry.getImageKey() != null ? profileImageUrlBuilder.buildUrl(answerEntry.getImageKey()) : null;
+
         return new CreateDailyReportResponse(
                 prep.reportId(),
                 dto.message(),
                 confirmDto.emotion().getCode().toString(),
-                confirmDto.balanceAfter()
+                confirmDto.balanceAfter(),
+                imageUrl
         );
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportTxService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportTxService.java
@@ -25,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -42,10 +44,11 @@ public class DailyReportTxService {
 
     private static final long DAILY_REPORT_REWARD = 10L;
 
-    protected PrepareDailyResultDto prepareDaily(User user, DailyQuestion dq, String answerText, boolean isDayPassed) {
+    protected PrepareDailyResultDto prepareDaily(User user, DailyQuestion dq, String answerText, boolean isDayPassed,
+                                                 @Nullable String imageKey) {
 
         //  AnswerEntry 생성 또는 조회 (별도의 트랜잭션)
-        AnswerEntry entry = answerEntryService.getOrCreateTodayAnswerEntry(user, dq, answerText, isDayPassed);
+        AnswerEntry entry = answerEntryService.getOrCreateTodayAnswerEntry(user, dq, answerText, isDayPassed, imageKey);
 
         // DailyReport PENDING 생성 또는 조회 (별도의 트랜잭션)
         DailyReport report = pendingDailyReportService.getOrCreatePendingDailyReport(entry, isDayPassed);

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
@@ -79,6 +79,7 @@ public class FeedQueryService {
                 .filter(dto -> !reportedIds.contains(dto.dailyReportId()))
                 .map(dto -> {
                     String profileUrl = buildProfileUrl(dto.profileImageKey(), dto.defaultProfileType());
+                    String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
 
                     return new FeedResponse(
                             dto.dailyReportId(),
@@ -87,7 +88,8 @@ public class FeedQueryService {
                             dto.interestCode() != null ? dto.interestCode().name() : null,
                             dto.questionText(),
                             dto.answerContent(),
-                            dto.emotionCode() != null ? dto.emotionCode().name() : null
+                            dto.emotionCode() != null ? dto.emotionCode().name() : null,
+                            imageUrl
                     );
                 })
                 .toList();

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/AnswerDetailDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/AnswerDetailDto.java
@@ -15,6 +15,7 @@ public record AnswerDetailDto(
         LocalDate answerDate,
         String answerContent,
         String reportContent,
-        EmotionCode emotionCode
+        EmotionCode emotionCode,
+        String imageKey
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/FeedDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/FeedDto.java
@@ -15,6 +15,7 @@ public record FeedDto(
         InterestCode interestCode,
         String questionText,
         String answerContent,
-        EmotionCode emotionCode
+        EmotionCode emotionCode,
+        String imageKey
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/entity/AnswerEntry.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/entity/AnswerEntry.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 @Entity
@@ -38,6 +39,9 @@ public class AnswerEntry extends AuditableEntity {
 
     @Column(name = "date", nullable = false)
     private LocalDate date;
+
+    @Column(name = "image_key")
+    private String imageKey;
 
     public static AnswerEntry create(User user, DailyQuestion question, String content, LocalDate date) {
         AnswerEntry e = new AnswerEntry();

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/entity/AnswerEntry.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/entity/AnswerEntry.java
@@ -43,17 +43,20 @@ public class AnswerEntry extends AuditableEntity {
     @Column(name = "image_key")
     private String imageKey;
 
-    public static AnswerEntry create(User user, DailyQuestion question, String content, LocalDate date) {
+    public static AnswerEntry create(User user, DailyQuestion question, String content, LocalDate date,
+                                     @Nullable String imageKey) {
         AnswerEntry e = new AnswerEntry();
         e.user = user;
         e.question = question;
         e.content = content;
         e.date = date;
+        e.imageKey = imageKey;
         return e;
     }
 
-    public void updateContent(String content) {
+    public void updateContent(String content, @Nullable String imageKey) {
         this.content = content;
+        this.imageKey = imageKey;
         onUpdate();
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
@@ -108,7 +108,7 @@ public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long
      */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
-            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code
+            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
         )
         from AnswerEntry ae
         left join DailyReport dr on dr.answerEntry = ae and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
@@ -126,7 +126,7 @@ public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long
      */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
-            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code
+            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
         )
         from AnswerEntry ae
         left join DailyReport dr on dr.answerEntry = ae and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryRepository.java
@@ -88,4 +88,13 @@ public interface AnswerEntryRepository extends JpaRepository<AnswerEntry, Long> 
             @Param("userIds") List<Long> userIds,
             @Param("date") LocalDate date
     );
+
+    @Query("""
+        select a.imageKey
+        from AnswerEntry a
+        where a.user.id in :userIds
+          and a.imageKey is not null
+          and a.imageKey <> ''
+        """)
+    List<String> findImageKeysByUserIds(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -49,7 +49,8 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
             ae.date,
             ae.content,
             dr.content,
-            e.code
+            e.code,
+            ae.imageKey
         )
         from DailyReport dr
         join dr.answerEntry ae
@@ -129,7 +130,8 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
             ae.question.interest.code,
             ae.question.questionText,
             ae.content,
-            dr.emotion.code
+            dr.emotion.code,
+            ae.imageKey
         )
         from DailyReport dr
         join AnswerEntry ae on dr.answerEntry = ae

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/AnswerEntryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/service/AnswerEntryService.java
@@ -10,6 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 
@@ -21,24 +22,25 @@ public class AnswerEntryService {
 
 
     @Transactional
-    public AnswerEntry getOrCreateTodayAnswerEntry(User user, DailyQuestion dq, String answerText, boolean isDayPassed) {
+    public AnswerEntry getOrCreateTodayAnswerEntry(User user, DailyQuestion dq, String answerText, boolean isDayPassed,
+                                                   @Nullable String imageKey) {
 
         LocalDate targetDate =
                 isDayPassed ? TodayDateTimeProvider.getTodayDate().minusDays(1) : TodayDateTimeProvider.getTodayDate();
 
         return answerEntryRepository.findByUserAndDate(user, targetDate)
                 .map(existing -> {
-                    existing.updateContent(answerText);
+                    existing.updateContent(answerText, imageKey);
                     return existing;
                 })
                 .orElseGet(() -> {
                     try {
-                        return answerEntryRepository.save(AnswerEntry.create(user, dq, answerText, targetDate));
+                        return answerEntryRepository.save(AnswerEntry.create(user, dq, answerText, targetDate, imageKey));
                     } catch (DataIntegrityViolationException e) {
                         // 동시 요청에서 이미 누가 만들었을 수 있음 -> 재조회로 멱등 처리
                         return answerEntryRepository.findByUserAndDate(user, targetDate)
                                 .map(found -> {
-                                    found.updateContent(answerText);
+                                    found.updateContent(answerText, imageKey);
                                     return found;
                                 })
                                 .orElseThrow(() -> e);

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClient.java
@@ -2,8 +2,11 @@ package com.devkor.ifive.nadab.domain.dailyreport.infra;
 
 import com.devkor.ifive.nadab.domain.dailyreport.core.dto.AiDailyReportResultDto;
 import com.devkor.ifive.nadab.domain.dailyreport.core.dto.LlmDailyResultDto;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.AnswerEntry;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.prompt.daily.DailyReportPromptLoader;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
@@ -11,9 +14,15 @@ import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.Media;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+import java.net.URI;
 
 @Component
 @RequiredArgsConstructor
@@ -22,12 +31,19 @@ public class DailyReportLlmClient {
     private final DailyReportPromptLoader dailyReportPromptLoader;
     private final ObjectMapper objectMapper;
     private final LlmRouter llmRouter;
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
 
     private final LlmProvider provider = LlmProvider.OPENAI;
 
-    public AiDailyReportResultDto
-    generate(String question, String answer) {
+    public AiDailyReportResultDto generate(String question, AnswerEntry answerEntry) {
+
+        String answer = answerEntry.getContent();
+
         String prompt = dailyReportPromptLoader.loadPrompt()
+                .replace("{question}", question)
+                .replace("{answer}", answer);
+
+        String withImagePrompt = dailyReportPromptLoader.loadWithImagePrompt()
                 .replace("{question}", question)
                 .replace("{answer}", answer);
 
@@ -39,8 +55,10 @@ public class DailyReportLlmClient {
                 .maxTokens(512)
                 .build();
 
+        UserMessage userMessage = buildUserMessage(prompt, withImagePrompt,answerEntry);
+
         String content = chatClient.prompt()
-                .user(prompt)
+                .messages(userMessage)
                 .options(options)
                 .call()
                 .content();
@@ -70,6 +88,38 @@ public class DailyReportLlmClient {
             // GPT가 JSON 형식을 지키지 못했을 경우 대비
             throw new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
+    }
+
+    private UserMessage buildUserMessage(String prompt, String withImagePrompt, AnswerEntry answerEntry) {
+        String imageKey = answerEntry.getImageKey();
+
+        //이미지 없는 경우
+        if (isBlank(imageKey)) {
+            return new UserMessage(prompt);
+        }
+
+        //이미지 있는 경우
+        String imageUrl = profileImageUrlBuilder.buildUrl(imageKey);
+
+        MimeType mimeType = inferMimeType(imageUrl);
+
+        return UserMessage.builder()
+                .text(withImagePrompt)
+                .media(new Media(mimeType, URI.create(imageUrl)))
+                .build();
+    }
+
+    private MimeType inferMimeType(String imageUrl) {
+        String lower = imageUrl.toLowerCase();
+
+        if (lower.contains(".png")) {
+            return MimeTypeUtils.IMAGE_PNG;
+        }
+        if (lower.contains(".jpg") || lower.contains(".jpeg")) {
+            return MimeTypeUtils.IMAGE_JPEG;
+        }
+
+        throw new BadRequestException(ErrorCode.IMAGE_UNSUPPORTED_TYPE);
     }
 
     private boolean isBlank(String s) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
@@ -74,4 +74,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("DELETE FROM User u WHERE u.deletedAt IS NOT NULL AND u.deletedAt < :expirationDate")
     int deleteOldWithdrawnUsers(@Param("expirationDate") OffsetDateTime expirationDate);
+
+    @Query("""
+        select u.id
+        from User u
+        where u.deletedAt is not null
+          and u.deletedAt < :expirationDate
+        """)
+    List<Long> findOldWithdrawnUserIds(@Param("expirationDate") OffsetDateTime expirationDate);
+
+    @Query("""
+        select u.profileImageKey
+        from User u
+        where u.id in :userIds
+          and u.profileImageKey is not null
+          and u.profileImageKey <> ''
+        """)
+    List<String> findProfileImageKeysByIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/user/core/repository/UserRepository.java
@@ -71,9 +71,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
             Pageable pageable
     );
 
-    @Modifying
-    @Query("DELETE FROM User u WHERE u.deletedAt IS NOT NULL AND u.deletedAt < :expirationDate")
-    int deleteOldWithdrawnUsers(@Param("expirationDate") OffsetDateTime expirationDate);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from User u
+        where u.id in :userIds
+          and u.deletedAt is not null
+        """)
+    int deleteWithdrawnUsersByIdIn(@Param("userIds") List<Long> userIds);
 
     @Query("""
         select u.id

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/DailyReportPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/DailyReportPromptLoader.java
@@ -2,4 +2,5 @@ package com.devkor.ifive.nadab.global.core.prompt.daily;
 
 public interface DailyReportPromptLoader {
     String loadPrompt();
+    String loadWithImagePrompt();
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/LocalDailyReportPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/LocalDailyReportPromptLoader.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 public class LocalDailyReportPromptLoader implements DailyReportPromptLoader {
 
     private static final String PROMPT_PATH = "secret/daily-prompt-local.txt";
+    private static final String WITH_IMAGE_PROMPT_PATH = "secret/daily-with-image-prompt-local.txt";
 
     @Override
     public String loadPrompt() {
@@ -32,6 +33,25 @@ public class LocalDailyReportPromptLoader implements DailyReportPromptLoader {
 
         } catch (IOException e) {
             log.error("로컬 일간 리포트 프롬프트 파일 읽기 실패: {}", PROMPT_PATH, e);
+            throw new BadRequestException(ErrorCode.PROMPT_DAILY_FILE_READ_FAILED);
+        }
+    }
+
+    @Override
+    public String loadWithImagePrompt() {
+        try {
+            ClassPathResource resource = new ClassPathResource(WITH_IMAGE_PROMPT_PATH);
+
+            if (!resource.exists()) {
+                log.error("일간 리포트(이미지 포함) 프롬프트 파일이 존재하지 않습니다: {}", WITH_IMAGE_PROMPT_PATH);
+                throw new BadRequestException(ErrorCode.PROMPT_DAILY_FILE_NOT_FOUND);
+            }
+
+            byte[] bytes = resource.getContentAsByteArray();
+            return new String(bytes, StandardCharsets.UTF_8);
+
+        } catch (IOException e) {
+            log.error("로컬 일간 리포트(이미지 포함) 프롬프트 파일 읽기 실패: {}", WITH_IMAGE_PROMPT_PATH, e);
             throw new BadRequestException(ErrorCode.PROMPT_DAILY_FILE_READ_FAILED);
         }
     }

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/SecretDailyReportPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/SecretDailyReportPromptLoader.java
@@ -17,6 +17,9 @@ public class SecretDailyReportPromptLoader implements DailyReportPromptLoader{
     @Value("${INSIGHT_PROMPT}")
     private String rawPrompt;
 
+    @Value("${INSIGHT_WITH_IMAGE_PROMPT}")
+    private String rawWithImagePrompt;
+
     @Override
     public String loadPrompt() {
         if (rawPrompt == null || rawPrompt.isBlank()) {
@@ -25,5 +28,15 @@ public class SecretDailyReportPromptLoader implements DailyReportPromptLoader{
         }
 
         return rawPrompt;
+    }
+
+    @Override
+    public String loadWithImagePrompt() {
+        if (rawPrompt == null || rawPrompt.isBlank()) {
+            log.error("환경 변수 INSIGHT_WITH_IMAGE_PROMPT가 비어있습니다.");
+            throw new BadRequestException(ErrorCode.PROMPT_DAILY_ENV_VAR_NOT_SET);
+        }
+
+        return rawWithImagePrompt;
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/SecretDailyReportPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/daily/SecretDailyReportPromptLoader.java
@@ -32,7 +32,7 @@ public class SecretDailyReportPromptLoader implements DailyReportPromptLoader{
 
     @Override
     public String loadWithImagePrompt() {
-        if (rawPrompt == null || rawPrompt.isBlank()) {
+        if (rawWithImagePrompt == null || rawWithImagePrompt.isBlank()) {
             log.error("환경 변수 INSIGHT_WITH_IMAGE_PROMPT가 비어있습니다.");
             throw new BadRequestException(ErrorCode.PROMPT_DAILY_ENV_VAR_NOT_SET);
         }

--- a/src/main/resources/db/migration/V20260420_1954__IS_add_image_key_to_answer_entries_table.sql
+++ b/src/main/resources/db/migration/V20260420_1954__IS_add_image_key_to_answer_entries_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE answer_entries ADD COLUMN image_key varchar(255);


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
답변에 이미지 첨부 기능을 일간 리포트 생성 플로우에 통합하고, 
탈퇴 사용자 영구 삭제 시 S3 이미지 리소스까지 함께 정리하도록 개선했습니다.

## 주요 변경 사항
- DB
  - `answer_entries` 테이블에 `image_key` 컬럼 추가
  - 마이그레이션 추가

- API
  - `POST /daily-report/image/upload-url` 추가
      - JPEG/PNG 업로드용 Presigned URL 발급 로직 추가 (만료 5분)
  - 일간 리포트 생성 요청에 이미지 키(`objectKey`) 추가

- 비즈니스 로직
  - `AnswerEntry` 생성/조회 로직에 `imageKey` 반영
  - 일간 리포트 생성/조회/피드 응답에 이미지 URL 포함
  - `DailyReportLlmClient` 및 `DailyReportPromptLoader` 확장
      - 이미지 포함 여부에 따라 프롬프트 및 UserMessage 분기 처리

- 사용자 정리 스케줄러 (`UserCleanupScheduler`)
  - 탈퇴 사용자 영구 삭제 시
    - 프로필 이미지 키
    - 답변 이미지 키
    를 수집해 S3에서 함께 삭제하도록 변경

- 배포/환경
  - dev/prod 배포 워크플로우에 프롬프트 환경 변수 추가

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.