### PR TITLE
hotfix(notify): 알림 설정 미생성으로 인한 작성 리마인더 알림 미발송 수정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/NotificationSettingService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/NotificationSettingService.java
@@ -9,6 +9,7 @@ import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class NotificationSettingService {
 
     private final NotificationSettingRepository notificationSettingRepository;
@@ -65,6 +67,26 @@ public class NotificationSettingService {
         return settings.stream()
             .sorted(Comparator.comparing(s -> s.getGroup().ordinal()))
             .toList();
+    }
+
+    /**
+     * 없는 그룹의 알림 설정을 기본값으로 생성(디바이스 등록 시)
+     */
+    public void ensureSettingsExist(User user) {
+        Set<NotificationGroup> existingGroups = notificationSettingRepository.findByUser(user)
+            .stream()
+            .map(NotificationSetting::getGroup)
+            .collect(Collectors.toSet());
+
+        for (NotificationGroup group : NotificationGroup.values()) {
+            if (!existingGroups.contains(group)) {
+                try {
+                    notificationSettingRepository.save(NotificationSetting.create(user, group));
+                } catch (DataIntegrityViolationException e) {
+                    log.debug("NotificationSetting already exists (race condition): userId={}, group={}", user.getId(), group);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/UserDeviceCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/UserDeviceCommandService.java
@@ -23,6 +23,7 @@ public class UserDeviceCommandService {
 
     private final UserDeviceRepository userDeviceRepository;
     private final UserRepository userRepository;
+    private final NotificationSettingService notificationSettingService;
 
     /**
      * FCM 토큰 등록
@@ -62,6 +63,7 @@ public class UserDeviceCommandService {
             UserDevice device = existingDevice.get();
             device.updateToken(fcmToken);
             log.debug("Device token updated: userId={}, platform={}", userId, platform);
+            notificationSettingService.ensureSettingsExist(user);
             return false; // 기존 디바이스 업데이트
         } else {
             // 새 디바이스 등록
@@ -69,6 +71,7 @@ public class UserDeviceCommandService {
                 UserDevice newDevice = UserDevice.create(user, fcmToken, deviceId, platform);
                 userDeviceRepository.save(newDevice);
                 log.debug("Device registered: userId={}, platform={}", userId, platform);
+                notificationSettingService.ensureSettingsExist(user);
                 return true; // 새 디바이스 등록
             } catch (DataIntegrityViolationException e) {
                 // 동시성으로 인해 이미 생성된 경우 (Race Condition)

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/NotificationSettingBackfillRunner.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/scheduler/NotificationSettingBackfillRunner.java
@@ -1,0 +1,47 @@
+package com.devkor.ifive.nadab.domain.notification.application.scheduler;
+
+import com.devkor.ifive.nadab.domain.notification.application.NotificationSettingService;
+import com.devkor.ifive.nadab.domain.notification.core.repository.UserDeviceRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 알림 설정 백필 러너
+ * - FCM 디바이스가 등록된 유저 중 알림 설정이 없는 유저에게 기본값으로 생성
+ * - 백필 완료 후 삭제 예정
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationSettingBackfillRunner implements ApplicationRunner {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final NotificationSettingService notificationSettingService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            List<User> usersWithDevices = userDeviceRepository.findDistinctActiveUsers();
+
+            int count = 0;
+            for (User user : usersWithDevices) {
+                try {
+                    notificationSettingService.ensureSettingsExist(user);
+                    count++;
+                } catch (Exception e) {
+                    log.error("Failed to initialize notification settings: userId={}", user.getId(), e);
+                }
+            }
+
+            log.info("NotificationSetting backfill completed: {}/{} users processed", count, usersWithDevices.size());
+        } catch (Exception e) {
+            log.error("NotificationSetting backfill runner failed", e);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/core/entity/NotificationSetting.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/core/entity/NotificationSetting.java
@@ -56,7 +56,7 @@ public class NotificationSetting extends AuditableEntity {
 
         // ACTIVITY_REMINDER 그룹이면 기본값 설정
         if (group == NotificationGroup.ACTIVITY_REMINDER) {
-            setting.dailyWriteTime = LocalTime.of(20, 0);
+            setting.dailyWriteTime = LocalTime.of(8, 0);
         }
 
         return setting;

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/core/repository/UserDeviceRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/core/repository/UserDeviceRepository.java
@@ -24,6 +24,9 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     void deleteByFcmToken(String fcmToken);
 
+    @Query("SELECT DISTINCT ud.user FROM UserDevice ud WHERE ud.user.deletedAt IS NULL")
+    List<User> findDistinctActiveUsers();
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from UserDevice ud where ud.fcmToken in :fcmTokens")
     int deleteByFcmTokenIn(@Param("fcmTokens") List<String> fcmTokens);


### PR DESCRIPTION
## 📝 요약(Summary)
FCM 디바이스가 등록된 유저 중 알림 설정 레코드가 없는 경우 DailyWriteReminderScheduler가 해당 유저를 조회하지 못해 알림이 발송되지 않는 버그를 수정합니다.

  - 디바이스 등록(registerDevice()) 시 ensureSettingsExist() 호출로 알림 설정 생성
  - NotificationSettingBackfillRunner 추가로 배포 시점에 기존 유저 백필 처리
  - 알림 기본 시간 20시 → 8시로 변경

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.