### PR TITLE
feat(stats): 통계 WAU/MAU 추이 차트 적용 및 일간 리포트 이미지 키 검증 강화

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/DailyReportController.java
@@ -77,6 +77,7 @@ public class DailyReportController {
                             description = """
                                     - ErrorCode: DAILY_QUESTION_MISMATCH - 요청한 질문이 사용자에게 할당된 오늘의 질문과 일치하지 않음
                                     - ErrorCode: IMAGE_INVALID_KEY - 유효하지 않은 이미지 키
+                                    - ErrorCode: IMAGE_WEBP_KEY_REQUIRED - objectKey는 존재하지만 webpKey가 누락됨
                                     """,
                             content = @Content
                     ),

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -61,9 +61,12 @@ public class DailyReportService {
         DailyQuestion question = dailyQuestionRepository.findByIdWithInterest(request.questionId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.QUESTION_NOT_FOUND));
 
-        // webpKey 존재 시 검증
-        if(!isBlank(request.webpKey())) {
-            validateWebpKey(request.webpKey(), userId);
+        // objectKey, webpKey 존재 시 검증
+        if(!isBlank(request.objectKey())) {
+            if(isBlank(request.webpKey())) {
+                throw new BadRequestException(ErrorCode.IMAGE_WEBP_KEY_REQUIRED);
+            }
+             validateWebpKey(request.webpKey(), userId);
         }
 
         LocalDate today = TodayDateTimeProvider.getTodayDate();

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/MonthlyStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/MonthlyStatsService.java
@@ -59,11 +59,15 @@ public class MonthlyStatsService {
         Map<YearMonth, Long> completedDailyMap = aggregateByMonth(
                 repo.findCompletedDailyReportCountsByDateBetween(startDate, endDateInclusive)
         );
+        Map<YearMonth, Long> mauMap = aggregateByMonth(
+                repo.findMonthlyActiveUserCountsByDateBetween(startDate, endDateInclusive)
+        );
 
         List<Long> signupCounts = months.stream().map(m -> signupMap.getOrDefault(m, 0L)).toList();
         List<Long> assignedCounts = months.stream().map(m -> assignedMap.getOrDefault(m, 0L)).toList();
         List<Long> completedDailyCounts = months.stream().map(m -> completedDailyMap.getOrDefault(m, 0L)).toList();
         List<Long> completedCounts = months.stream().map(m -> completedMap.getOrDefault(m, 0L)).toList();
+        List<Long> mauCounts = months.stream().map(m -> mauMap.getOrDefault(m, 0L)).toList();
 
         long inProgressNow = repo.countInProgressMonthlyReportsNow();
 
@@ -73,6 +77,7 @@ public class MonthlyStatsService {
                 assignedCounts,
                 completedDailyCounts,
                 completedCounts,
+                mauCounts,
                 inProgressNow,
                 OffsetDateTime.now(SEOUL).format(FMT)
         );

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/application/WeeklyStatsService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/application/WeeklyStatsService.java
@@ -58,11 +58,15 @@ public class WeeklyStatsService {
         Map<LocalDate, Long> completedDailyMap = aggregateByWeekStart(
                 repo.findCompletedDailyReportCountsByDateBetween(startWeekStart, endDateInclusive)
         );
+        Map<LocalDate, Long> wauMap = toMapByDate(
+                repo.findWeeklyActiveUserCountsByDateBetween(startWeekStart, endDateInclusive)
+        );
 
         List<Long> signupCounts = weekStarts.stream().map(d -> signupMap.getOrDefault(d, 0L)).toList();
         List<Long> assignedCounts = weekStarts.stream().map(d -> assignedMap.getOrDefault(d, 0L)).toList();
         List<Long> completedDailyCounts = weekStarts.stream().map(d -> completedDailyMap.getOrDefault(d, 0L)).toList();
         List<Long> completedCounts = weekStarts.stream().map(d -> completedMap.getOrDefault(d, 0L)).toList();
+        List<Long> wauCounts = weekStarts.stream().map(d -> wauMap.getOrDefault(d, 0L)).toList();
 
         long inProgressNow = repo.countInProgressWeeklyReportsNow();
 
@@ -72,6 +76,7 @@ public class WeeklyStatsService {
                 assignedCounts,
                 completedDailyCounts,
                 completedCounts,
+                wauCounts,
                 inProgressNow,
                 OffsetDateTime.now(SEOUL).format(FMT)
         );
@@ -82,6 +87,14 @@ public class WeeklyStatsService {
         for (DateCountDto dto : dailyCounts) {
             LocalDate weekStart = dto.date().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
             map.merge(weekStart, dto.count(), Long::sum);
+        }
+        return map;
+    }
+
+    private Map<LocalDate, Long> toMapByDate(List<DateCountDto> counts) {
+        Map<LocalDate, Long> map = new HashMap<>();
+        for (DateCountDto dto : counts) {
+            map.put(dto.date(), dto.count());
         }
         return map;
     }

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/monthly/MonthlyStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/monthly/MonthlyStatsViewModel.java
@@ -8,6 +8,7 @@ public record MonthlyStatsViewModel(
         List<Long> assignedQuestionCounts,
         List<Long> completedDailyReportCounts,
         List<Long> completedMonthlyReportCounts,
+        List<Long> mauCounts,
         long inProgressMonthlyReportCount,
         String refreshedAt
 ) {}

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/weekly/WeeklyStatsViewModel.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/dto/weekly/WeeklyStatsViewModel.java
@@ -8,6 +8,7 @@ public record WeeklyStatsViewModel(
         List<Long> assignedQuestionCounts,
         List<Long> completedDailyReportCounts,
         List<Long> completedWeeklyReportCounts,
+        List<Long> wauCounts,
         long inProgressWeeklyReportCount,
         String refreshedAt
 ) {}

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/DailyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/DailyStatsRepository.java
@@ -31,8 +31,7 @@ public class DailyStatsRepository {
         return em.createQuery("""
             select function('date', u.registeredAt), count(u.id)
             from User u
-            where u.deletedAt is null
-              and u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
+            where u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
               and u.registeredAt is not null
               and u.registeredAt >= :start
               and u.registeredAt < :endExclusive

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -91,8 +92,39 @@ public class MonthlyStatsRepository {
                 .getSingleResult();
     }
 
+    public List<DateCountDto> findMonthlyActiveUserCountsByDateBetween(LocalDate startDate, LocalDate endDateInclusive) {
+        List<Object[]> rows = em.createQuery("""
+                select function('date_trunc', 'month', dr.date), count(distinct dr.answerEntry.user.id)
+                from DailyReport dr
+                where dr.date between :startDate and :endDate
+                  and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+                group by function('date_trunc', 'month', dr.date)
+                order by function('date_trunc', 'month', dr.date)
+                """, Object[].class)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDateInclusive)
+                .getResultList();
+
+        return rows.stream()
+                .map(MonthlyStatsRepository::toDateCountDtoFromDateTrunc)
+                .toList();
+    }
+
     private static DateCountDto toDateCountDto(Object[] row) {
         LocalDate date = ((Date) row[0]).toLocalDate();
+        long count = (Long) row[1];
+        return new DateCountDto(date, count);
+    }
+
+    private static DateCountDto toDateCountDtoFromDateTrunc(Object[] row) {
+        LocalDate date;
+        if (row[0] instanceof Timestamp timestamp) {
+            date = timestamp.toLocalDateTime().toLocalDate();
+        } else if (row[0] instanceof Date sqlDate) {
+            date = sqlDate.toLocalDate();
+        } else {
+            date = LocalDate.parse(row[0].toString().substring(0, 10));
+        }
         long count = (Long) row[1];
         return new DateCountDto(date, count);
     }

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/MonthlyStatsRepository.java
@@ -25,8 +25,7 @@ public class MonthlyStatsRepository {
         List<Object[]> rows = em.createQuery("""
             select function('date', u.registeredAt), count(u.id)
             from User u
-            where u.deletedAt is null
-              and u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
+            where u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
               and u.registeredAt is not null
               and u.registeredAt >= :start
               and u.registeredAt < :endExclusive

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -97,8 +98,39 @@ public class WeeklyStatsRepository {
                 .getSingleResult();
     }
 
+    public List<DateCountDto> findWeeklyActiveUserCountsByDateBetween(LocalDate startDate, LocalDate endDateInclusive) {
+        List<Object[]> rows = em.createQuery("""
+                select function('date_trunc', 'week', dr.date), count(distinct dr.answerEntry.user.id)
+                from DailyReport dr
+                where dr.date between :startDate and :endDate
+                  and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+                group by function('date_trunc', 'week', dr.date)
+                order by function('date_trunc', 'week', dr.date)
+                """, Object[].class)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDateInclusive)
+                .getResultList();
+
+        return rows.stream()
+                .map(WeeklyStatsRepository::toDateCountDtoFromDateTrunc)
+                .toList();
+    }
+
     private static DateCountDto toDateCountDto(Object[] row) {
         LocalDate date = ((Date) row[0]).toLocalDate();
+        long count = (Long) row[1];
+        return new DateCountDto(date, count);
+    }
+
+    private static DateCountDto toDateCountDtoFromDateTrunc(Object[] row) {
+        LocalDate date;
+        if (row[0] instanceof Timestamp timestamp) {
+            date = timestamp.toLocalDateTime().toLocalDate();
+        } else if (row[0] instanceof Date sqlDate) {
+            date = sqlDate.toLocalDate();
+        } else {
+            date = LocalDate.parse(row[0].toString().substring(0, 10));
+        }
         long count = (Long) row[1];
         return new DateCountDto(date, count);
     }

--- a/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/stats/core/repository/WeeklyStatsRepository.java
@@ -25,8 +25,7 @@ public class WeeklyStatsRepository {
         List<Object[]> rows = em.createQuery("""
             select function('date', u.registeredAt), count(u.id)
             from User u
-            where u.deletedAt is null
-              and u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
+            where u.signupStatus = com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType.COMPLETED
               and u.registeredAt is not null
               and u.registeredAt >= :start
               and u.registeredAt < :endExclusive

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -93,6 +93,7 @@ public enum ErrorCode {
     IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 크기가 제한을 초과했습니다 (최대 5MB)"),
     IMAGE_METADATA_INVALID(HttpStatus.BAD_REQUEST, "파일 메타데이터를 읽을 수 없습니다. 다시 시도해주세요."),
     IMAGE_INVALID_KEY(HttpStatus.BAD_REQUEST, "잘못된 이미지 key입니다."),
+    IMAGE_WEBP_KEY_REQUIRED(HttpStatus.BAD_REQUEST, "objectKey가 존재할 때 webpKey도 함께 제공되어야 합니다"),
 
     // ==================== QUESTION (질문) ====================
     // 400 Bad Request

--- a/src/main/resources/templates/stats/daily.html
+++ b/src/main/resources/templates/stats/daily.html
@@ -325,7 +325,7 @@
   <div class="chart-card chart-card-wide">
     <div class="chart-card-header">
       <div class="chart-card-title">
-        <span class="dot dot-teal"></span>생성된 일간 리포트 개수
+        <span class="dot dot-teal"></span>생성된 일간 리포트 개수 (DAU)
       </div>
       <div class="chart-card-subtitle">최근 7일</div>
     </div>

--- a/src/main/resources/templates/stats/monthly.html
+++ b/src/main/resources/templates/stats/monthly.html
@@ -309,6 +309,15 @@
       <canvas id="completedMonthlyChart" height="140"></canvas>
     </div>
   </div>
+<div class="chart-card">
+  <div class="chart-card-header">
+    <div class="chart-card-title"><span class="dot dot-blue"></span>MAU</div>
+    <div class="chart-card-subtitle">활성 사용자 기준 : 일간 리포트를 작성한 고유 사용자 수</div>
+  </div>
+  <div class="chart-card-body">
+    <canvas id="mauChart" height="140"></canvas>
+  </div>
+</div>
 </div>
 
 <script th:inline="javascript">
@@ -317,6 +326,7 @@
   const assignedCounts = [[${vm.assignedQuestionCounts}]].map(v => parseInt(v, 10));
   const completedDailyCounts = [[${vm.completedDailyReportCounts}]].map(v => parseInt(v, 10));
   const completedMonthlyCounts = [[${vm.completedMonthlyReportCounts}]].map(v => parseInt(v, 10));
+  const mauCounts = [[${vm.mauCounts}]].map(v => parseInt(v, 10));
 
   Chart.defaults.color = '#8b91a8';
   Chart.defaults.font.family = "'DM Mono', monospace";
@@ -333,6 +343,7 @@
   }
 
   const configs = [
+    { id: 'mauChart', label: 'MAU', data: mauCounts, color: 'rgba(108,143,255,1)' },
     { id: 'signupChart', label: '가입자 수', data: signupCounts, color: 'rgba(108,143,255,1)' },
     { id: 'assignedChart', label: '할당 질문 수', data: assignedCounts, color: 'rgba(255,126,179,1)' },
     { id: 'completedDailyChart', label: '일간 리포트 생성 수', data: completedDailyCounts, color: 'rgba(77,232,194,1)' },

--- a/src/main/resources/templates/stats/weekly.html
+++ b/src/main/resources/templates/stats/weekly.html
@@ -309,6 +309,15 @@
       <canvas id="completedWeeklyChart" height="140"></canvas>
     </div>
   </div>
+<div class="chart-card">
+  <div class="chart-card-header">
+    <div class="chart-card-title"><span class="dot dot-blue"></span>WAU</div>
+    <div class="chart-card-subtitle">활성 사용자 기준 : 일간 리포트를 작성한 고유 사용자 수</div>
+  </div>
+  <div class="chart-card-body">
+    <canvas id="wauChart" height="140"></canvas>
+  </div>
+</div>
 </div>
 
 <script th:inline="javascript">
@@ -317,6 +326,7 @@
   const rawAssignedCounts = [[${vm.assignedQuestionCounts}]].map(v => parseInt(v, 10));
   const rawCompletedDailyCounts = [[${vm.completedDailyReportCounts}]].map(v => parseInt(v, 10));
   const rawCompletedWeeklyCounts = [[${vm.completedWeeklyReportCounts}]].map(v => parseInt(v, 10));
+  const rawWauCounts = [[${vm.wauCounts}]].map(v => parseInt(v, 10));
 
   const slicedRawLabels = rawLabels.slice(-5);
   const labels = slicedRawLabels.map(label => {
@@ -327,6 +337,7 @@
   const assignedCounts = rawAssignedCounts.slice(-5);
   const completedDailyCounts = rawCompletedDailyCounts.slice(-5);
   const completedWeeklyCounts = rawCompletedWeeklyCounts.slice(-5);
+  const wauCounts = rawWauCounts.slice(-5);
 
   Chart.defaults.color = '#8b91a8';
   Chart.defaults.font.family = "'DM Mono', monospace";
@@ -347,6 +358,7 @@
     { id: 'assignedChart', label: '할당 질문 수', data: assignedCounts, color: 'rgba(255,126,179,1)' },
     { id: 'completedDailyChart', label: '일간 리포트 생성 수', data: completedDailyCounts, color: 'rgba(77,232,194,1)' },
     { id: 'completedWeeklyChart', label: '주간 리포트 생성 수', data: completedWeeklyCounts, color: 'rgba(245,165,36,1)' },
+    { id: 'wauChart', label: 'WAU', data: wauCounts, color: 'rgba(108,143,255,1)' },
   ];
 
   configs.forEach(({ id, label, data, color }) => {


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

주간/월간 통계 페이지에 WAU/MAU를 추이 차트로 추가했습니다.

- 주간 페이지: 최근 5주 WAU 차트
- 월간 페이지: 최근 5달 MAU 차트

## 변경 사항
- WAU/MAU 집계 로직을 주/월 단위 distinct 유저 기준으로 추가
  - 기준: 해당 기간에 `COMPLETED` 상태의 일간 리포트를 작성한 유저 수
  - 집계식: `COUNT(DISTINCT dr.answerEntry.user.id)`
- 주간/월간 템플릿에 WAU/MAU 라인 차트 추가

- 일간 리포트 생성 요청에서 이미지 관련 검증 로직을 보완
   - `objectKey`가 전달된 경우 `webpKey`를 필수로 요구하도록 검증 조건을 추가했습니다.
      - `objectKey`는 있는데 `webpKey`가 비어 있으면 `BadRequestException(IMAGE_WEBP_KEY_REQUIRED)`를 반환합니다.
   - `webpKey` 검증은 `objectKey`가 존재할 때만 수행되도록 정리했습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.