### PR TITLE
feat(social): 댓글/대댓글, 좋아요 기능 및 신고, 소셜 정지 기능 구현

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,7 @@ module.exports = {
             "search",
             "stats",
             "friend",
+            "social",
             "notify",
             "infra",
             "db",
@@ -122,6 +123,9 @@ module.exports = {
                     },
                     friend: {
                         description: '👥 친구 도메인 (예: 친구 신청, 수락, 목록 관리)'
+                    },
+                    social: {
+                        description: '💬 소셜 도메인 (예: 댓글, 좋아요, 피드 공유)'
                     },
                     notify: {
                         description: '📧 알림/이메일 전송 (예: 질문 알림, 인증 이메일 전송)'

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
@@ -280,7 +280,8 @@ public class CommentController {
                     @ApiResponse(responseCode = "400", description = "ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중", content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 삭제 권한 없음", content = @Content),
-                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "ErrorCode: COMMENT_DELETED - 이미 삭제된 댓글", content = @Content)
             }
     )
     public ResponseEntity<ApiResponseDto<Void>> deleteComment(

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
@@ -106,7 +106,10 @@ public class CommentController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "작성 성공", content = @Content),
-                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과", content = @Content),
+                    @ApiResponse(responseCode = "400", description = """
+                            - ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과
+                            - ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중
+                            """, content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
@@ -204,7 +207,11 @@ public class CommentController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "작성 성공", content = @Content),
-                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과 / COMMENT_NOT_TOP_LEVEL - 대댓글에 대댓글 시도", content = @Content),
+                    @ApiResponse(responseCode = "400", description = """
+                            - ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과
+                            - ErrorCode: COMMENT_NOT_TOP_LEVEL - 대댓글에 대댓글 시도
+                            - ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중
+                            """, content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우", content = @Content),
                     @ApiResponse(responseCode = "409", description = "ErrorCode: COMMENT_DELETED - 이미 삭제된 댓글에 대댓글 시도", content = @Content)
@@ -234,7 +241,10 @@ public class CommentController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "수정 성공", content = @Content),
-                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과", content = @Content),
+                    @ApiResponse(responseCode = "400", description = """
+                            - ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과
+                            - ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중
+                            """, content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 댓글만 수정 가능", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)
@@ -267,6 +277,7 @@ public class CommentController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중", content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 삭제 권한 없음", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/CommentController.java
@@ -1,0 +1,282 @@
+package com.devkor.ifive.nadab.domain.comment.api;
+
+import com.devkor.ifive.nadab.domain.comment.api.dto.request.CreateCommentRequest;
+import com.devkor.ifive.nadab.domain.comment.api.dto.request.CreateSubCommentRequest;
+import com.devkor.ifive.nadab.domain.comment.api.dto.request.UpdateCommentRequest;
+import com.devkor.ifive.nadab.domain.comment.api.dto.response.CommentListResponse;
+import com.devkor.ifive.nadab.domain.comment.application.CommentCommandService;
+import com.devkor.ifive.nadab.domain.comment.application.CommentQueryService;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
+import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "댓글 API", description = "댓글 및 대댓글 관련 API")
+@RestController
+@RequestMapping("${api_prefix}")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentCommandService commentCommandService;
+    private final CommentQueryService commentQueryService;
+
+    @GetMapping("/comments")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글 목록 조회",
+            description = """
+                    피드 게시글의 댓글 목록을 커서 기반으로 최신순 조회합니다.
+
+                    요청 파라미터:
+                    - dailyReportId (필수): 댓글을 조회할 피드 게시글 ID
+                    - cursor (선택): 이전 응답의 nextCursor, 첫 요청 시 생략
+
+                    커서 페이지네이션 (페이지당 10개):
+                    - 첫 요청: cursor 없이 호출 → GET /api/v1/comments?dailyReportId=1
+                    - 다음 페이지: 응답의 nextCursor를 cursor로 전달 → GET /api/v1/comments?dailyReportId=1&cursor=42
+                    - hasNext=false이면 마지막 페이지입니다.
+
+                    비밀 댓글 응답:
+                    - 권한 있음 (작성자 본인, 게시글 작성자): canViewContent=true, 모든 필드 정상 반환
+                    - 권한 없음: canViewContent=false, authorProfileImageUrl·authorNickname·content·visibleSubCommentCount는 null 반환
+
+                    응답 필드 용도:
+                    - commentId: 수정(PATCH)·삭제(DELETE)·대댓글 조회(GET)·대댓글 작성(POST) API 호출 시 path variable로 사용
+                    - authorProfileImageUrl·authorNickname: 댓글 작성자 프로필 표시 (canViewContent=false이면 null → 비공개 처리)
+                    - content: 댓글 본문 (canViewContent=false이면 null → "비밀 댓글이에요." 등으로 대체 표시)
+                    - createdAt: 작성 시각 ISO 8601 timestamp (예: 2026-05-11T10:30:00+09:00) — 프론트에서 현재 시각 기준으로 아래 규칙에 따라 변환하여 표시, 타이머로 실시간 갱신 가능
+                      · 60초 미만 → N초 전
+                      · 60분 미만 → N분 전
+                      · 24시간 미만 → N시간 전
+                      · 30일 미만 → N일 전
+                      · 30일 이상 → 오래 전
+                    - isLiked·hasLikes: 좋아요 아이콘 상태 제어
+                      · isMine=true & hasLikes=false → 아이콘 미표시
+                      · isMine=true & hasLikes=true  → 채워진 아이콘 (단순 클릭 무반응, 길게 누르면 좋아요 리스트)
+                      · isMine=false & isLiked=false → 빈 아이콘
+                      · isMine=false & isLiked=true  → 채워진 아이콘
+                      · canViewContent=false (비밀 댓글 열람 권한 없음) → 아이콘 미표시
+                    - visibleSubCommentCount: "답글 N개 더보기" 버튼 표시용, null 또는 0이면 미표시
+                    - isSecret: 비밀 댓글 여부 (자물쇠 아이콘 표시, canViewContent=false이면 답글 버튼 미제공)
+                    - canViewContent: false이면 authorProfileImageUrl·authorNickname·content 마스킹 처리
+                    - isMine: 수정 버튼 표시 여부, 좋아요 아이콘 동작 제어 (본인 댓글은 좋아요 불가)
+                    - canDelete: 삭제 버튼 표시 여부 (본인 댓글 또는 내 피드 게시글에 달린 타인 댓글)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommentListResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<CommentListResponse>> getComments(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam Long dailyReportId,
+            @RequestParam(required = false) Long cursor
+    ) {
+        CommentListResponse response = commentQueryService.getComments(dailyReportId, principal.getId(), cursor);
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/comments")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글 작성",
+            description = """
+                    피드 게시글에 댓글을 작성합니다.
+
+                    - isSecret=true로 작성 시 비밀 댓글로 설정되며, 작성자 본인과 게시글 작성자만 내용을 확인할 수 있습니다.
+                    - isSecret은 작성 후 변경할 수 없습니다. (수정 API에서 내용만 변경 가능)
+                    - 댓글 작성 시 게시글 작성자에게 FCM 푸시 알림이 전송됩니다. (본인 피드 게시글에 작성 시 알림 미전송)
+                    - 작성 성공 후 GET /api/v1/comments?dailyReportId={id}로 목록을 재조회해야 합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "작성 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> createComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateCommentRequest request
+    ) {
+        commentCommandService.createComment(
+                request.dailyReportId(), principal.getId(), request.content(), request.isSecret());
+        return ApiResponseEntity.noContent();
+    }
+
+    @GetMapping("/comments/{commentId}/sub-comments")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "대댓글 목록 조회",
+            description = """
+                    특정 댓글의 대댓글 목록을 커서 기반으로 최신순 조회합니다.
+
+                    요청 파라미터:
+                    - commentId (path, 필수): 대댓글을 조회할 부모 댓글 ID
+                    - cursor (선택): 이전 응답의 nextCursor, 첫 요청 시 생략 (페이지당 10개)
+
+                    커서 페이지네이션:
+                    - 첫 요청: cursor 없이 호출 → GET /api/v1/comments/42/sub-comments
+                    - 다음 페이지: 응답의 nextCursor를 cursor로 전달 → GET /api/v1/comments/42/sub-comments?cursor=99
+                    - hasNext=false이면 마지막 페이지입니다.
+
+                    비밀 대댓글 응답:
+                    - 권한 있음 (작성자 본인, 게시글 작성자, 부모 댓글 작성자): canViewContent=true, 모든 필드 정상 반환
+                    - 권한 없음: canViewContent=false, authorProfileImageUrl·authorNickname·content는 null 반환
+
+                    "N개 더보기" 버튼 카운트 계산:
+                    - 첫 진입 시: 댓글 목록 조회(GET /comments) 응답의 visibleSubCommentCount 값을 사용
+                    - 대댓글 로드 후 hasNext=true이면: visibleSubCommentCount - 현재까지 로드한 대댓글 수 = 남은 개수로 갱신하여 표시 (프론트에서 직접 계산 및 갱신)
+                    - 예) visibleSubCommentCount=12 → 10개 로드 후 "2개 더보기" 표시
+
+                    응답 필드 용도:
+                    - commentId: 수정(PATCH)·삭제(DELETE) API 호출 시 path variable로 사용
+                    - authorProfileImageUrl·authorNickname: 대댓글 작성자 프로필 표시 (canViewContent=false이면 null → 비공개 처리)
+                    - content: 대댓글 본문 (canViewContent=false이면 null → "비밀 댓글이에요." 등으로 대체 표시)
+                    - createdAt: 작성 시각 ISO 8601 timestamp — 댓글 목록 조회와 동일한 변환 규칙 적용
+                    - isLiked·hasLikes: 좋아요 아이콘 상태 제어
+                      · isMine=true & hasLikes=false → 아이콘 미표시
+                      · isMine=true & hasLikes=true  → 채워진 아이콘 (단순 클릭 무반응, 길게 누르면 좋아요 리스트)
+                      · isMine=false & isLiked=false → 빈 아이콘
+                      · isMine=false & isLiked=true  → 채워진 아이콘
+                      · canViewContent=false (비밀 댓글 열람 권한 없음) → 아이콘 미표시
+                    - visibleSubCommentCount: 대댓글에서는 항상 null
+                    - isSecret: 비밀 댓글 여부 (자물쇠 아이콘 표시)
+                    - canViewContent: false이면 authorProfileImageUrl·authorNickname·content 마스킹 처리
+                      · 대댓글 열람 권한: 작성자 본인, 게시글 작성자, 부모 댓글 작성자
+                    - isMine: 수정 버튼 표시 여부, 좋아요 아이콘 동작 제어 (본인 댓글은 좋아요 불가)
+                    - canDelete: 삭제 버튼 표시 여부 (본인 대댓글 또는 내 피드 게시글에 달린 타인 대댓글)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommentListResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: COMMENT_NOT_TOP_LEVEL - commentId가 대댓글 ID인 경우 (대댓글의 대댓글 불가)", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = """
+                            - ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우
+                            - ErrorCode: AUTH_ACCESS_DENIED - 비밀 댓글에 대한 열람 권한 없음
+                            """, content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<CommentListResponse>> getSubComments(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId,
+            @RequestParam(required = false) Long cursor
+    ) {
+        CommentListResponse response = commentQueryService.getSubComments(commentId, principal.getId(), cursor);
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/comments/{commentId}/sub-comments")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "대댓글 작성",
+            description = """
+                    특정 댓글에 대댓글을 작성합니다.
+
+                    - 부모 댓글이 비밀 댓글인 경우, isSecret 값과 무관하게 대댓글도 강제로 비밀 처리됩니다. 이 경우 isSecret 토글을 사용하지 못하게 하고 isSecret=true로 고정 전송을 권장합니다.
+                    - isSecret은 작성 후 변경할 수 없습니다. (수정 API에서 내용만 변경 가능)
+                    - 대댓글에 대한 대댓글은 불가합니다.
+                    - 대댓글 작성 시 부모 댓글 작성자에게 FCM 푸시 알림이 전송됩니다.
+                    - 해당 댓글에 이미 대댓글을 단 다른 참여자들에게도 알림이 전송됩니다.
+                    - 작성 성공 후 GET /api/v1/comments/{commentId}/sub-comments로 목록을 재조회해야 합니다.
+                    - 대댓글 작성 성공 시 댓글 목록의 visibleSubCommentCount가 갱신되지 않습니다. "답글 N개 더보기" 카운트를 최신화하려면 성공 시 로컬에서 +1 업데이트하거나 GET /api/v1/comments?dailyReportId={id}로 댓글 목록도 재조회해야 합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "작성 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과 / COMMENT_NOT_TOP_LEVEL - 대댓글에 대댓글 시도", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 피드 게시글이 아니거나 친구의 공유 게시글이 아닌 경우", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "ErrorCode: COMMENT_DELETED - 이미 삭제된 댓글에 대댓글 시도", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> createSubComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CreateSubCommentRequest request
+    ) {
+        commentCommandService.createSubComment(
+                commentId, principal.getId(), request.content(), request.isSecret());
+        return ApiResponseEntity.noContent();
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글 수정",
+            description = """
+                    본인이 작성한 댓글/대댓글의 내용을 수정합니다.
+
+                    - 작성자 본인만 수정 가능합니다. (게시글 작성자도 타인 댓글 수정 불가)
+                    - 내용(content)만 변경 가능하며, 비밀 여부(isSecret)는 변경할 수 없습니다.
+                    - 1자 이상 500자 이하로 입력해야 합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "수정 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: VALIDATION_FAILED - 내용 누락 또는 500자 초과", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 본인 댓글만 수정 가능", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> updateComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        commentCommandService.updateComment(commentId, principal.getId(), request.content());
+        return ApiResponseEntity.noContent();
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글 삭제",
+            description = """
+                    댓글/대댓글을 삭제합니다.
+
+                    삭제 권한:
+                    - 본인이 작성한 댓글/대댓글: 작성자 본인
+                    - 내 피드 게시글에 달린 타인의 댓글/대댓글: 게시글 작성자
+                    - 타인 피드 게시글의 타인 댓글: 삭제 불가
+
+                    - 댓글 삭제 시 하위 대댓글도 함께 삭제됩니다.
+                    - 신고 이력이 있는 댓글도 삭제 가능합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 삭제 권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> deleteComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId
+    ) {
+        commentCommandService.deleteComment(commentId, principal.getId());
+        return ApiResponseEntity.noContent();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/CreateCommentRequest.java
@@ -1,0 +1,23 @@
+package com.devkor.ifive.nadab.domain.comment.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 작성 요청")
+public record CreateCommentRequest(
+
+        @Schema(description = "리포트 ID")
+        @NotNull(message = "리포트 ID를 입력해주세요")
+        Long dailyReportId,
+
+        @Schema(description = "댓글 내용 (1~500자)", example = "공감해요!")
+        @NotBlank(message = "댓글 내용을 입력해주세요")
+        @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요")
+        String content,
+
+        @Schema(description = "비밀 댓글 여부", example = "false")
+        boolean isSecret
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/CreateSubCommentRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/CreateSubCommentRequest.java
@@ -1,0 +1,18 @@
+package com.devkor.ifive.nadab.domain.comment.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "대댓글 작성 요청")
+public record CreateSubCommentRequest(
+
+        @Schema(description = "댓글 내용 (1~500자)", example = "공감해요!")
+        @NotBlank(message = "댓글 내용을 입력해주세요")
+        @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요")
+        String content,
+
+        @Schema(description = "비밀 댓글 여부", example = "false")
+        boolean isSecret
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,15 @@
+package com.devkor.ifive.nadab.domain.comment.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 수정 요청")
+public record UpdateCommentRequest(
+
+        @Schema(description = "수정할 댓글 내용 (1~500자)", example = "수정된 내용이에요")
+        @NotBlank(message = "댓글 내용을 입력해주세요")
+        @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요")
+        String content
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentListResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentListResponse.java
@@ -1,0 +1,19 @@
+package com.devkor.ifive.nadab.domain.comment.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "댓글/대댓글 목록 응답")
+public record CommentListResponse(
+
+        @Schema(description = "댓글 목록")
+        List<CommentResponse> comments,
+
+        @Schema(description = "다음 페이지 커서 (없으면 null)")
+        Long nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부")
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentResponse.java
@@ -1,0 +1,73 @@
+package com.devkor.ifive.nadab.domain.comment.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "댓글/대댓글 응답")
+public record CommentResponse(
+
+        @Schema(description = "댓글 ID")
+        Long commentId,
+
+        @Schema(description = "작성자 프로필 이미지 URL (canViewContent=false이면 null)")
+        String authorProfileImageUrl,
+
+        @Schema(description = "작성자 닉네임 (canViewContent=false이면 null)")
+        String authorNickname,
+
+        @Schema(description = "댓글 내용 (canViewContent=false이면 null)")
+        String content,
+
+        @Schema(description = "작성 시각 (ISO 8601, 예: 2024-05-11T10:30:00+09:00) — 프론트에서 현재 시각 기준으로 '3분 전' 등으로 변환하여 표시")
+        OffsetDateTime createdAt,
+
+        @Schema(description = "내가 좋아요 눌렀는지 여부")
+        boolean isLiked,
+
+        @Schema(description = "좋아요가 1개 이상인지 여부")
+        boolean hasLikes,
+
+        @Schema(description = "보이는 대댓글 수 (canViewContent=false이거나 대댓글에서는 null)")
+        Integer visibleSubCommentCount,
+
+        @Schema(description = "비밀 댓글 여부")
+        boolean isSecret,
+
+        @Schema(description = "비밀 댓글 열람 권한 여부 (false이면 authorProfileImageUrl·authorNickname·content가 null)")
+        boolean canViewContent,
+
+        @Schema(description = "내 댓글 여부")
+        boolean isMine,
+
+        @Schema(description = "삭제 가능 여부 (본인 또는 리포트 당사자)")
+        boolean canDelete
+) {
+    public static CommentResponse from(
+            Long commentId,
+            String authorProfileImageUrl,
+            String authorNickname,
+            String content,
+            OffsetDateTime createdAt,
+            Integer visibleSubCommentCount,
+            boolean isSecret,
+            boolean canViewContent,
+            boolean isMine,
+            boolean canDelete
+    ) {
+        return new CommentResponse(
+                commentId,
+                authorProfileImageUrl,
+                authorNickname,
+                content,
+                createdAt,
+                false, // TODO: 좋아요 구현 시 isLiked 실제 값으로 교체
+                false, // TODO: 좋아요 구현 시 hasLikes 실제 값으로 교체
+                visibleSubCommentCount,
+                isSecret,
+                canViewContent,
+                isMine,
+                canDelete
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/api/dto/response/CommentResponse.java
@@ -49,6 +49,8 @@ public record CommentResponse(
             String authorNickname,
             String content,
             OffsetDateTime createdAt,
+            boolean isLiked,
+            boolean hasLikes,
             Integer visibleSubCommentCount,
             boolean isSecret,
             boolean canViewContent,
@@ -61,8 +63,8 @@ public record CommentResponse(
                 authorNickname,
                 content,
                 createdAt,
-                false, // TODO: 좋아요 구현 시 isLiked 실제 값으로 교체
-                false, // TODO: 좋아요 구현 시 hasLikes 실제 값으로 교체
+                isLiked,
+                hasLikes,
                 visibleSubCommentCount,
                 isSecret,
                 canViewContent,

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
@@ -1,0 +1,132 @@
+package com.devkor.ifive.nadab.domain.comment.application;
+
+import com.devkor.ifive.nadab.domain.comment.application.event.CommentCreatedEvent;
+import com.devkor.ifive.nadab.domain.comment.application.event.SubCommentCreatedEvent;
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.ForbiddenException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final DailyReportRepository dailyReportRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public Long createComment(Long dailyReportId, Long authorId, String content, boolean isSecret) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentWriteAccess(dailyReportId, reportOwnerId, authorId);
+
+        DailyReport dailyReport = dailyReportRepository.getReferenceById(dailyReportId);
+        User author = userRepository.getReferenceById(authorId);
+
+        Comment comment = Comment.createTopLevel(dailyReport, author, content, isSecret);
+        commentRepository.save(comment);
+
+        eventPublisher.publishEvent(
+                new CommentCreatedEvent(comment.getId(), dailyReportId, authorId, reportOwnerId, content));
+
+        return comment.getId();
+    }
+
+    public Long createSubComment(Long parentCommentId, Long authorId, String content, boolean isSecret) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Comment parentComment = commentRepository.findByIdWithAuthorAndDailyReport(parentCommentId)
+                .orElseThrow(() -> new ConflictException(ErrorCode.COMMENT_DELETED));
+
+        if (!parentComment.isTopLevel()) {
+            throw new BadRequestException(ErrorCode.COMMENT_NOT_TOP_LEVEL);
+        }
+
+        // 비밀 댓글의 하위 대댓글은 강제 비밀 처리
+        boolean finalIsSecret = parentComment.isSecret() || isSecret;
+
+        Long dailyReportId = parentComment.getDailyReport().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentWriteAccess(dailyReportId, reportOwnerId, authorId);
+
+        if (parentComment.isSecret()) {
+            boolean canViewParent = parentComment.getAuthor().getId().equals(authorId)
+                    || reportOwnerId.equals(authorId);
+            if (!canViewParent) {
+                throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+            }
+        }
+
+        User author = userRepository.getReferenceById(authorId);
+
+        Comment subComment = Comment.createSubComment(author, parentComment, content, finalIsSecret);
+        commentRepository.save(subComment);
+        eventPublisher.publishEvent(new SubCommentCreatedEvent(
+                subComment.getId(),
+                dailyReportId,
+                authorId,
+                parentCommentId,
+                parentComment.getAuthor().getId(),
+                reportOwnerId,
+                content
+        ));
+
+        return subComment.getId();
+    }
+
+    private void checkCommentWriteAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
+        if (currentUserId.equals(reportOwnerId)) return;
+        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(currentUserId, reportOwnerId);
+        long largerId = Math.max(currentUserId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+    }
+
+    public void updateComment(Long commentId, Long userId, String content) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getAuthor().getId().equals(userId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+
+        comment.updateContent(content);
+    }
+
+    public void deleteComment(Long commentId, Long userId) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+        Long authorId = comment.getAuthor().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(comment.getDailyReport().getId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+
+        if (!userId.equals(authorId) && !userId.equals(reportOwnerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
@@ -19,6 +19,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -50,8 +52,7 @@ public class CommentCommandService {
 
     public Long createSubComment(Long parentCommentId, Long authorId, String content, boolean isSecret) {
         // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
-        Comment parentComment = commentRepository.findByIdWithAuthorAndDailyReport(parentCommentId)
-                .orElseThrow(() -> new ConflictException(ErrorCode.COMMENT_DELETED));
+        Comment parentComment = findActiveCommentOrThrow(parentCommentId);
 
         if (!parentComment.isTopLevel()) {
             throw new BadRequestException(ErrorCode.COMMENT_NOT_TOP_LEVEL);
@@ -104,8 +105,7 @@ public class CommentCommandService {
 
     public void updateComment(Long commentId, Long userId, String content) {
         // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
-        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+        Comment comment = findActiveCommentOrThrow(commentId);
 
         if (!comment.getAuthor().getId().equals(userId)) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
@@ -116,8 +116,7 @@ public class CommentCommandService {
 
     public void deleteComment(Long commentId, Long userId) {
         // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
-        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+        Comment comment = findActiveCommentOrThrow(commentId);
 
         Long authorId = comment.getAuthor().getId();
         Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(comment.getDailyReport().getId())
@@ -127,6 +126,17 @@ public class CommentCommandService {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
 
-        commentRepository.delete(comment);
+        OffsetDateTime now = OffsetDateTime.now();
+        if (comment.isTopLevel()) {
+            commentRepository.softDeleteSubCommentsByParentId(commentId, now);
+        }
+        comment.softDelete();
+    }
+
+    private Comment findActiveCommentOrThrow(Long commentId) {
+        return commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> commentRepository.existsById(commentId)
+                        ? new ConflictException(ErrorCode.COMMENT_DELETED)
+                        : new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
@@ -7,6 +7,7 @@ import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
@@ -31,9 +32,10 @@ public class CommentCommandService {
     private final FriendshipRepository friendshipRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final SharingSuspensionService sharingSuspensionService;
 
     public Long createComment(Long dailyReportId, Long authorId, String content, boolean isSecret) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(authorId);
         Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
         checkCommentWriteAccess(dailyReportId, reportOwnerId, authorId);
@@ -51,7 +53,7 @@ public class CommentCommandService {
     }
 
     public Long createSubComment(Long parentCommentId, Long authorId, String content, boolean isSecret) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(authorId);
         Comment parentComment = findActiveCommentOrThrow(parentCommentId);
 
         if (!parentComment.isTopLevel()) {
@@ -91,6 +93,12 @@ public class CommentCommandService {
         return subComment.getId();
     }
 
+    private void checkNotSuspended(Long userId) {
+        if (sharingSuspensionService.isSharingSuspended(userId)) {
+            throw new BadRequestException(ErrorCode.SOCIAL_SUSPENDED);
+        }
+    }
+
     private void checkCommentWriteAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
         if (currentUserId.equals(reportOwnerId)) return;
         if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
@@ -104,7 +112,7 @@ public class CommentCommandService {
     }
 
     public void updateComment(Long commentId, Long userId, String content) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(userId);
         Comment comment = findActiveCommentOrThrow(commentId);
 
         if (!comment.getAuthor().getId().equals(userId)) {
@@ -115,7 +123,7 @@ public class CommentCommandService {
     }
 
     public void deleteComment(Long commentId, Long userId) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(userId);
         Comment comment = findActiveCommentOrThrow(commentId);
 
         Long authorId = comment.getAuthor().getId();

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
@@ -8,6 +8,7 @@ import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
 import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
+import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
 import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
@@ -20,10 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,6 +37,7 @@ public class CommentQueryService {
     private final UserBlockRepository userBlockRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
+    private final SharingSuspensionService sharingSuspensionService;
 
     public CommentListResponse getComments(Long dailyReportId, Long currentUserId, Long cursor) {
         Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
@@ -47,7 +46,7 @@ public class CommentQueryService {
         List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
 
         List<Comment> comments = commentRepository.findTopLevelComments(
-                dailyReportId, cursor, excludedUserIds, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
+                dailyReportId, cursor, excludedUserIds, currentUserId, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
 
         boolean hasNext = comments.size() > DEFAULT_PAGE_SIZE;
         if (hasNext) {
@@ -115,7 +114,7 @@ public class CommentQueryService {
         List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
 
         List<Comment> subComments = commentRepository.findSubComments(
-                parentCommentId, cursor, excludedUserIds, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
+                parentCommentId, cursor, excludedUserIds, currentUserId, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
 
         boolean hasNext = subComments.size() > DEFAULT_PAGE_SIZE;
         if (hasNext) {
@@ -198,11 +197,15 @@ public class CommentQueryService {
         }
     }
 
-    // TODO: 소셜 정지 중인 유저 ID도 포함
     private List<Long> getExcludedUserIds(Long userId) {
         List<Long> blocked = userBlockRepository.findBlockedUserIdsBidirectional(userId);
-        // JPQL NOT IN 절에 빈 리스트 전달 방지
-        return blocked.isEmpty() ? List.of(-1L) : blocked;
+        List<Long> suspended = sharingSuspensionService.getAllActiveSuspendedUserIds();
+
+        Set<Long> combined = new HashSet<>(blocked);
+        combined.addAll(suspended);
+        combined.remove(userId);
+
+        return combined.isEmpty() ? List.of(-1L) : new ArrayList<>(combined);
     }
 
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
@@ -1,0 +1,185 @@
+package com.devkor.ifive.nadab.domain.comment.application;
+
+import com.devkor.ifive.nadab.domain.comment.api.dto.response.CommentListResponse;
+import com.devkor.ifive.nadab.domain.comment.api.dto.response.CommentResponse;
+import com.devkor.ifive.nadab.domain.comment.core.dto.SubCommentCountDto;
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ForbiddenException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    private final CommentRepository commentRepository;
+    private final DailyReportRepository dailyReportRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserBlockRepository userBlockRepository;
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
+
+    public CommentListResponse getComments(Long dailyReportId, Long currentUserId, Long cursor) {
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentViewAccess(dailyReportId, reportOwnerId, currentUserId);
+        List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
+
+        List<Comment> comments = commentRepository.findTopLevelComments(
+                dailyReportId, cursor, excludedUserIds, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
+
+        boolean hasNext = comments.size() > DEFAULT_PAGE_SIZE;
+        if (hasNext) {
+            comments = comments.subList(0, DEFAULT_PAGE_SIZE);
+        }
+        Long nextCursor = hasNext ? comments.get(comments.size() - 1).getId() : null;
+
+        Map<Long, Long> subCountMap = buildSubCountMap(comments, excludedUserIds, currentUserId, reportOwnerId);
+
+        List<CommentResponse> responses = comments.stream()
+                .map(c -> {
+                    boolean isMine = c.getAuthor().getId().equals(currentUserId);
+                    boolean canViewContent = !c.isSecret() || isMine || currentUserId.equals(reportOwnerId);
+                    boolean canDelete = isMine || currentUserId.equals(reportOwnerId);
+                    return CommentResponse.from(
+                            c.getId(),
+                            canViewContent ? profileImageUrlBuilder.buildUserProfileUrl(c.getAuthor()) : null,
+                            canViewContent ? c.getAuthor().getNickname() : null,
+                            canViewContent ? c.getContent() : null,
+                            c.getCreatedAt(),
+                            canViewContent ? subCountMap.getOrDefault(c.getId(), 0L).intValue() : null,
+                            c.isSecret(),
+                            canViewContent,
+                            isMine,
+                            canDelete
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new CommentListResponse(responses, nextCursor, hasNext);
+    }
+
+    public CommentListResponse getSubComments(Long parentCommentId, Long currentUserId, Long cursor) {
+        Comment parentComment = commentRepository.findByIdWithAuthorAndDailyReport(parentCommentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!parentComment.isTopLevel()) {
+            throw new BadRequestException(ErrorCode.COMMENT_NOT_TOP_LEVEL);
+        }
+
+        Long dailyReportId = parentComment.getDailyReport().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentViewAccess(dailyReportId, reportOwnerId, currentUserId);
+
+        if (parentComment.isSecret()) {
+            boolean canViewParent = parentComment.getAuthor().getId().equals(currentUserId)
+                    || reportOwnerId.equals(currentUserId);
+            if (!canViewParent) {
+                throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+            }
+        }
+
+        Long parentCommentAuthorId = parentComment.getAuthor().getId();
+        List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
+
+        List<Comment> subComments = commentRepository.findSubComments(
+                parentCommentId, cursor, excludedUserIds, PageRequest.of(0, DEFAULT_PAGE_SIZE + 1));
+
+        boolean hasNext = subComments.size() > DEFAULT_PAGE_SIZE;
+        if (hasNext) {
+            subComments = subComments.subList(0, DEFAULT_PAGE_SIZE);
+        }
+        Long nextCursor = hasNext ? subComments.get(subComments.size() - 1).getId() : null;
+
+        List<CommentResponse> responses = subComments.stream()
+                .map(c -> {
+                    boolean isMine = c.getAuthor().getId().equals(currentUserId);
+                    boolean canViewContent = !c.isSecret()
+                            || isMine
+                            || currentUserId.equals(reportOwnerId)
+                            || currentUserId.equals(parentCommentAuthorId);
+                    boolean canDelete = isMine || currentUserId.equals(reportOwnerId);
+                    return CommentResponse.from(
+                            c.getId(),
+                            canViewContent ? profileImageUrlBuilder.buildUserProfileUrl(c.getAuthor()) : null,
+                            canViewContent ? c.getAuthor().getNickname() : null,
+                            canViewContent ? c.getContent() : null,
+                            c.getCreatedAt(),
+                            null,
+                            c.isSecret(),
+                            canViewContent,
+                            isMine,
+                            canDelete
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new CommentListResponse(responses, nextCursor, hasNext);
+    }
+
+    private Map<Long, Long> buildSubCountMap(List<Comment> comments, List<Long> excludedUserIds,
+                                              Long currentUserId, Long reportOwnerId) {
+        if (comments.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> parentIds = comments.stream().map(Comment::getId).toList();
+
+        // 현재 사용자가 비밀 대댓글을 열람할 수 있는 부모 댓글 ID 목록
+        // - 리포트 소유자: 모든 부모 댓글의 비밀 대댓글 열람 가능
+        // - 그 외: 자신이 작성한 부모 댓글의 비밀 대댓글만 열람 가능
+        List<Long> visibleSecretParentIds;
+        if (currentUserId.equals(reportOwnerId)) {
+            visibleSecretParentIds = parentIds;
+        } else {
+            visibleSecretParentIds = comments.stream()
+                    .filter(c -> c.getAuthor().getId().equals(currentUserId))
+                    .map(Comment::getId)
+                    .toList();
+            if (visibleSecretParentIds.isEmpty()) {
+                visibleSecretParentIds = List.of(-1L);
+            }
+        }
+
+        return commentRepository.countVisibleSubCommentsByParentIds(
+                        parentIds, excludedUserIds, currentUserId, visibleSecretParentIds)
+                .stream()
+                .collect(Collectors.toMap(SubCommentCountDto::parentCommentId, SubCommentCountDto::count));
+    }
+
+    private void checkCommentViewAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
+        if (currentUserId.equals(reportOwnerId)) return;
+        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(currentUserId, reportOwnerId);
+        long largerId = Math.max(currentUserId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+    }
+
+    // TODO: 소셜 정지 중인 유저 ID도 포함
+    private List<Long> getExcludedUserIds(Long userId) {
+        List<Long> blocked = userBlockRepository.findBlockedUserIdsBidirectional(userId);
+        // JPQL NOT IN 절에 빈 리스트 전달 방지
+        return blocked.isEmpty() ? List.of(-1L) : blocked;
+    }
+
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
@@ -7,10 +7,12 @@ import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
 import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
 import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +20,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,6 +37,7 @@ public class CommentQueryService {
     private final DailyReportRepository dailyReportRepository;
     private final FriendshipRepository friendshipRepository;
     private final UserBlockRepository userBlockRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
 
     public CommentListResponse getComments(Long dailyReportId, Long currentUserId, Long cursor) {
@@ -52,6 +57,12 @@ public class CommentQueryService {
 
         Map<Long, Long> subCountMap = buildSubCountMap(comments, excludedUserIds, currentUserId, reportOwnerId);
 
+        List<Long> commentIds = comments.stream().map(Comment::getId).toList();
+        Set<Long> likedCommentIds = commentIds.isEmpty() ? Set.of()
+                : new HashSet<>(commentLikeRepository.findLikedCommentIds(commentIds, currentUserId));
+        Set<Long> commentIdsWithLikes = commentIds.isEmpty() ? Set.of()
+                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(commentIds));
+
         List<CommentResponse> responses = comments.stream()
                 .map(c -> {
                     boolean isMine = c.getAuthor().getId().equals(currentUserId);
@@ -63,6 +74,8 @@ public class CommentQueryService {
                             canViewContent ? c.getAuthor().getNickname() : null,
                             canViewContent ? c.getContent() : null,
                             c.getCreatedAt(),
+                            canViewContent && likedCommentIds.contains(c.getId()),
+                            canViewContent && commentIdsWithLikes.contains(c.getId()),
                             canViewContent ? subCountMap.getOrDefault(c.getId(), 0L).intValue() : null,
                             c.isSecret(),
                             canViewContent,
@@ -77,7 +90,9 @@ public class CommentQueryService {
 
     public CommentListResponse getSubComments(Long parentCommentId, Long currentUserId, Long cursor) {
         Comment parentComment = commentRepository.findByIdWithAuthorAndDailyReport(parentCommentId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow(() -> commentRepository.existsById(parentCommentId)
+                        ? new ConflictException(ErrorCode.COMMENT_DELETED)
+                        : new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
 
         if (!parentComment.isTopLevel()) {
             throw new BadRequestException(ErrorCode.COMMENT_NOT_TOP_LEVEL);
@@ -108,6 +123,12 @@ public class CommentQueryService {
         }
         Long nextCursor = hasNext ? subComments.get(subComments.size() - 1).getId() : null;
 
+        List<Long> subCommentIds = subComments.stream().map(Comment::getId).toList();
+        Set<Long> likedSubCommentIds = subCommentIds.isEmpty() ? Set.of()
+                : new HashSet<>(commentLikeRepository.findLikedCommentIds(subCommentIds, currentUserId));
+        Set<Long> subCommentIdsWithLikes = subCommentIds.isEmpty() ? Set.of()
+                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(subCommentIds));
+
         List<CommentResponse> responses = subComments.stream()
                 .map(c -> {
                     boolean isMine = c.getAuthor().getId().equals(currentUserId);
@@ -122,6 +143,8 @@ public class CommentQueryService {
                             canViewContent ? c.getAuthor().getNickname() : null,
                             canViewContent ? c.getContent() : null,
                             c.getCreatedAt(),
+                            canViewContent && likedSubCommentIds.contains(c.getId()),
+                            canViewContent && subCommentIdsWithLikes.contains(c.getId()),
                             null,
                             c.isSecret(),
                             canViewContent,

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/CommentCreatedEvent.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/CommentCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.devkor.ifive.nadab.domain.comment.application.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentCreatedEvent {
+
+    private final Long commentId;
+    private final Long dailyReportId;
+    private final Long authorId;
+    private final Long reportOwnerId;
+    private final String content;
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/SubCommentCreatedEvent.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/SubCommentCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.devkor.ifive.nadab.domain.comment.application.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SubCommentCreatedEvent {
+
+    private final Long subCommentId;
+    private final Long dailyReportId;
+    private final Long authorId;
+    private final Long parentCommentId;
+    private final Long parentCommentAuthorId;
+    private final Long reportOwnerId;
+    private final String content;
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/dto/SubCommentCountDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/dto/SubCommentCountDto.java
@@ -1,0 +1,4 @@
+package com.devkor.ifive.nadab.domain.comment.core.dto;
+
+public record SubCommentCountDto(Long parentCommentId, Long count) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/entity/Comment.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/entity/Comment.java
@@ -2,7 +2,7 @@ package com.devkor.ifive.nadab.domain.comment.core.entity;
 
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
-import com.devkor.ifive.nadab.global.shared.entity.AuditableEntity;
+import com.devkor.ifive.nadab.global.shared.entity.SoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "comments")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment extends AuditableEntity {
+public class Comment extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/entity/Comment.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/entity/Comment.java
@@ -1,0 +1,66 @@
+package com.devkor.ifive.nadab.domain.comment.core.entity;
+
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.AuditableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "daily_report_id", nullable = false)
+    private DailyReport dailyReport;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+    @Column(name = "is_secret", nullable = false)
+    private boolean secret;
+
+    public static Comment createTopLevel(DailyReport dailyReport, User author, String content, boolean isSecret) {
+        Comment comment = new Comment();
+        comment.dailyReport = dailyReport;
+        comment.author = author;
+        comment.content = content;
+        comment.secret = isSecret;
+        return comment;
+    }
+
+    public static Comment createSubComment(
+            User author, Comment parentComment, String content, boolean isSecret) {
+        Comment comment = new Comment();
+        comment.dailyReport = parentComment.dailyReport;
+        comment.author = author;
+        comment.parentComment = parentComment;
+        comment.content = content;
+        comment.secret = isSecret;
+        return comment;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isTopLevel() {
+        return parentComment == null;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -1,0 +1,84 @@
+package com.devkor.ifive.nadab.domain.comment.core.repository;
+
+import com.devkor.ifive.nadab.domain.comment.core.dto.SubCommentCountDto;
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("select c from Comment c join fetch c.author join fetch c.dailyReport where c.id = :id")
+    Optional<Comment> findByIdWithAuthorAndDailyReport(@Param("id") Long id);
+
+    @Query("""
+        select c from Comment c
+        join fetch c.author a
+        where c.dailyReport.id = :dailyReportId
+          and c.parentComment is null
+          and a.deletedAt is null
+          and (:cursor is null or c.id < :cursor)
+          and a.id not in :excludedUserIds
+        order by c.id desc
+    """)
+    List<Comment> findTopLevelComments(
+            @Param("dailyReportId") Long dailyReportId,
+            @Param("cursor") Long cursor,
+            @Param("excludedUserIds") List<Long> excludedUserIds,
+            Pageable pageable
+    );
+
+    @Query("""
+        select c from Comment c
+        join fetch c.author a
+        where c.parentComment.id = :parentCommentId
+          and a.deletedAt is null
+          and (:cursor is null or c.id < :cursor)
+          and a.id not in :excludedUserIds
+        order by c.id desc
+    """)
+    List<Comment> findSubComments(
+            @Param("parentCommentId") Long parentCommentId,
+            @Param("cursor") Long cursor,
+            @Param("excludedUserIds") List<Long> excludedUserIds,
+            Pageable pageable
+    );
+
+    @Query("""
+        select new com.devkor.ifive.nadab.domain.comment.core.dto.SubCommentCountDto(
+            c.parentComment.id, count(c)
+        )
+        from Comment c
+        where c.parentComment.id in :parentIds
+          and c.author.deletedAt is null
+          and c.author.id not in :excludedUserIds
+          and (
+            c.secret = false
+            or c.author.id = :currentUserId
+            or c.parentComment.id in :visibleSecretParentIds
+          )
+        group by c.parentComment.id
+    """)
+    List<SubCommentCountDto> countVisibleSubCommentsByParentIds(
+            @Param("parentIds") List<Long> parentIds,
+            @Param("excludedUserIds") List<Long> excludedUserIds,
+            @Param("currentUserId") Long currentUserId,
+            @Param("visibleSecretParentIds") List<Long> visibleSecretParentIds
+    );
+
+    @Query("""
+        select distinct c.author.id
+        from Comment c
+        where c.parentComment.id = :parentCommentId
+          and c.author.id not in :excludeUserIds
+          and c.author.deletedAt is null
+    """)
+    List<Long> findDistinctSubCommentAuthorIds(
+            @Param("parentCommentId") Long parentCommentId,
+            @Param("excludeUserIds") List<Long> excludeUserIds
+    );
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -4,22 +4,38 @@ import com.devkor.ifive.nadab.domain.comment.core.dto.SubCommentCountDto;
 import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("select c from Comment c join fetch c.author join fetch c.dailyReport where c.id = :id")
+    @Query("""
+        select c from Comment c
+        join fetch c.author
+        join fetch c.dailyReport
+        where c.id = :id
+          and c.deletedAt is null
+    """)
     Optional<Comment> findByIdWithAuthorAndDailyReport(@Param("id") Long id);
+
+    @Query("""
+        select c.parentComment.author.id from Comment c
+        where c.id = :id
+          and c.parentComment is not null
+    """)
+    Optional<Long> findParentAuthorIdById(@Param("id") Long id);
 
     @Query("""
         select c from Comment c
         join fetch c.author a
         where c.dailyReport.id = :dailyReportId
           and c.parentComment is null
+          and c.deletedAt is null
           and a.deletedAt is null
           and (:cursor is null or c.id < :cursor)
           and a.id not in :excludedUserIds
@@ -36,6 +52,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         select c from Comment c
         join fetch c.author a
         where c.parentComment.id = :parentCommentId
+          and c.deletedAt is null
           and a.deletedAt is null
           and (:cursor is null or c.id < :cursor)
           and a.id not in :excludedUserIds
@@ -54,6 +71,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         )
         from Comment c
         where c.parentComment.id in :parentIds
+          and c.deletedAt is null
           and c.author.deletedAt is null
           and c.author.id not in :excludedUserIds
           and (
@@ -74,6 +92,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         select distinct c.author.id
         from Comment c
         where c.parentComment.id = :parentCommentId
+          and c.deletedAt is null
           and c.author.id not in :excludeUserIds
           and c.author.deletedAt is null
     """)
@@ -81,4 +100,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("parentCommentId") Long parentCommentId,
             @Param("excludeUserIds") List<Long> excludeUserIds
     );
+
+    @Modifying
+    @Query("""
+        update Comment c
+        set c.deletedAt = :now, c.updatedAt = :now
+        where c.parentComment.id = :parentId and c.deletedAt is null
+    """)
+    void softDeleteSubCommentsByParentId(@Param("parentId") Long parentId, @Param("now") OffsetDateTime now);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -115,7 +115,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("excludeUserIds") List<Long> excludeUserIds
     );
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         update Comment c
         set c.deletedAt = :now, c.updatedAt = :now

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -39,12 +39,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
           and a.deletedAt is null
           and (:cursor is null or c.id < :cursor)
           and a.id not in :excludedUserIds
+          and not exists (
+              select 1 from ContentReport cr
+              where cr.reporter.id = :currentUserId and cr.comment = c
+          )
         order by c.id desc
     """)
     List<Comment> findTopLevelComments(
             @Param("dailyReportId") Long dailyReportId,
             @Param("cursor") Long cursor,
             @Param("excludedUserIds") List<Long> excludedUserIds,
+            @Param("currentUserId") Long currentUserId,
             Pageable pageable
     );
 
@@ -56,12 +61,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
           and a.deletedAt is null
           and (:cursor is null or c.id < :cursor)
           and a.id not in :excludedUserIds
+          and not exists (
+              select 1 from ContentReport cr
+              where cr.reporter.id = :currentUserId and cr.comment = c
+          )
         order by c.id desc
     """)
     List<Comment> findSubComments(
             @Param("parentCommentId") Long parentCommentId,
             @Param("cursor") Long cursor,
             @Param("excludedUserIds") List<Long> excludedUserIds,
+            @Param("currentUserId") Long currentUserId,
             Pageable pageable
     );
 
@@ -74,6 +84,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
           and c.deletedAt is null
           and c.author.deletedAt is null
           and c.author.id not in :excludedUserIds
+          and not exists (
+              select 1 from ContentReport cr
+              where cr.reporter.id = :currentUserId and cr.comment = c
+          )
           and (
             c.secret = false
             or c.author.id = :currentUserId

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedListResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedListResponse.java
@@ -6,7 +6,10 @@ import java.util.List;
 @Schema(description = "피드 목록 응답")
 public record FeedListResponse(
 
-        @Schema(description = "피드 목록")
+        @Schema(description = "오늘 내 공유 리포트 (미공유 시 null)")
+        FeedResponse myReport,
+
+        @Schema(description = "친구 피드 목록")
         List<FeedResponse> feeds
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/FeedResponse.java
@@ -27,6 +27,12 @@ public record FeedResponse(
         String emotionCode,
 
         @Schema(description = "이미지 URL")
-        String imageUrl
+        String imageUrl,
+
+        @Schema(description = "내가 좋아요 눌렀는지 여부")
+        boolean isLiked,
+
+        @Schema(description = "좋아요가 1개 이상인지 여부")
+        boolean hasLikes
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
@@ -8,6 +8,7 @@ import com.devkor.ifive.nadab.domain.dailyreport.core.dto.FeedDto;
 import com.devkor.ifive.nadab.domain.friend.core.entity.Friendship;
 import com.devkor.ifive.nadab.domain.friend.core.entity.FriendshipStatus;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.like.core.repository.DailyReportLikeRepository;
 import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.ContentReportRepository;
 import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
@@ -20,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class FeedQueryService {
 
     private final FriendshipRepository friendshipRepository;
     private final DailyReportRepository dailyReportRepository;
+    private final DailyReportLikeRepository dailyReportLikeRepository;
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
     private final ContentReportRepository contentReportRepository;
     private final SharingSuspensionService sharingSuspensionService;
@@ -36,26 +40,24 @@ public class FeedQueryService {
     public FeedListResponse getFeeds(Long userId) {
         LocalDate today = TodayDateTimeProvider.getTodayDate();
 
-        // 내 공유 리포트 조회 (미공유 시 null)
-        FeedResponse myReport = dailyReportRepository.findMySharedFeedByDate(userId, today)
-                .map(this::toFeedResponse)
-                .orElse(null);
+        // 1. 내 공유 리포트 조회
+        Optional<FeedDto> myFeedDto = dailyReportRepository.findMySharedFeedByDate(userId, today);
 
-        // 1. ACCEPTED 상태의 친구 관계 조회
+        // 2. ACCEPTED 상태의 친구 관계 조회
         List<Friendship> friendships = friendshipRepository
                 .findByUserIdAndStatusWithUsers(userId, FriendshipStatus.ACCEPTED);
 
-        // 2. 친구 ID 리스트 추출
+        // 3. 친구 ID 리스트 추출
         List<Long> friendIds = friendships.stream()
                 .map(f -> f.getOtherUserId(userId))
                 .toList();
 
-        // 3. 친구가 없으면 빈 피드 반환
+        // 4. 친구가 없으면 myReport만 매핑 후 반환
         if (friendIds.isEmpty()) {
-            return new FeedListResponse(myReport, List.of());
+            return toFeedListResponse(userId, myFeedDto, List.of());
         }
 
-        // 4. 공유 활동 중지된 유저 제외
+        // 5. 공유 활동 중지된 유저 제외
         Set<Long> suspendedUserIds = new HashSet<>(
                 sharingSuspensionService.getSharingSuspendedUserIds(friendIds)
         );
@@ -63,27 +65,47 @@ public class FeedQueryService {
                 .filter(id -> !suspendedUserIds.contains(id))
                 .toList();
 
-        // 5. 공유 가능한 친구가 없으면 빈 피드 반환
+        // 6. 공유 가능한 친구가 없으면 myReport만 반환
         if (activeFriendIds.isEmpty()) {
-            return new FeedListResponse(myReport, List.of());
+            return toFeedListResponse(userId, myFeedDto, List.of());
         }
 
-        // 6. 당일 공유된 피드 조회
+        // 7. 당일 공유된 피드 조회
         List<FeedDto> feedDtos = dailyReportRepository.findSharedFeedsByFriendIds(today, activeFriendIds);
 
-        // 7. 내가 신고한 글 제외
-        List<Long> dailyReportIds = feedDtos.stream()
+        // 8. 내가 신고한 글 제외
+        List<Long> friendReportIds = feedDtos.stream().map(FeedDto::dailyReportId).toList();
+        Set<Long> reportedIds = friendReportIds.isEmpty() ? Set.of()
+                : new HashSet<>(contentReportRepository.findReportedDailyReportIdsByReporter(userId, friendReportIds));
+        List<FeedDto> filteredFeedDtos = feedDtos.stream()
+                .filter(dto -> !reportedIds.contains(dto.dailyReportId()))
+                .toList();
+
+        return toFeedListResponse(userId, myFeedDto, filteredFeedDtos);
+    }
+
+    private FeedListResponse toFeedListResponse(Long userId, Optional<FeedDto> myFeedDto, List<FeedDto> feedDtos) {
+        // 전체 reportId 수집 후 좋아요 정보 벌크 조회
+        List<Long> allReportIds = Stream.concat(myFeedDto.stream(), feedDtos.stream())
                 .map(FeedDto::dailyReportId)
                 .toList();
 
-        Set<Long> reportedIds = new HashSet<>(
-                contentReportRepository.findReportedDailyReportIdsByReporter(userId, dailyReportIds)
-        );
+        Set<Long> likedReportIds;
+        Set<Long> reportIdsWithLikes;
+        if (allReportIds.isEmpty()) {
+            likedReportIds = Set.of();
+            reportIdsWithLikes = Set.of();
+        } else {
+            likedReportIds = new HashSet<>(dailyReportLikeRepository.findLikedReportIds(allReportIds, userId));
+            reportIdsWithLikes = new HashSet<>(dailyReportLikeRepository.findReportIdsWithLikes(allReportIds));
+        }
 
-        // 8. 필터링 및 응답 DTO 변환
+        FeedResponse myReport = myFeedDto
+                .map(dto -> toFeedResponse(dto, likedReportIds, reportIdsWithLikes))
+                .orElse(null);
+
         List<FeedResponse> feeds = feedDtos.stream()
-                .filter(dto -> !reportedIds.contains(dto.dailyReportId()))
-                .map(this::toFeedResponse)
+                .map(dto -> toFeedResponse(dto, likedReportIds, reportIdsWithLikes))
                 .toList();
 
         return new FeedListResponse(myReport, feeds);
@@ -96,7 +118,7 @@ public class FeedQueryService {
                 .orElse(new ShareStatusResponse(false));
     }
 
-    private FeedResponse toFeedResponse(FeedDto dto) {
+    private FeedResponse toFeedResponse(FeedDto dto, Set<Long> likedReportIds, Set<Long> reportIdsWithLikes) {
         String profileUrl = buildProfileUrl(dto.profileImageKey(), dto.defaultProfileType());
         String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
         return new FeedResponse(
@@ -107,7 +129,9 @@ public class FeedQueryService {
                 dto.questionText(),
                 dto.answerContent(),
                 dto.emotionCode() != null ? dto.emotionCode().name() : null,
-                imageUrl
+                imageUrl,
+                likedReportIds.contains(dto.dailyReportId()),
+                reportIdsWithLikes.contains(dto.dailyReportId())
         );
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
@@ -34,6 +34,13 @@ public class FeedQueryService {
     private final SharingSuspensionService sharingSuspensionService;
 
     public FeedListResponse getFeeds(Long userId) {
+        LocalDate today = TodayDateTimeProvider.getTodayDate();
+
+        // 내 공유 리포트 조회 (미공유 시 null)
+        FeedResponse myReport = dailyReportRepository.findMySharedFeedByDate(userId, today)
+                .map(this::toFeedResponse)
+                .orElse(null);
+
         // 1. ACCEPTED 상태의 친구 관계 조회
         List<Friendship> friendships = friendshipRepository
                 .findByUserIdAndStatusWithUsers(userId, FriendshipStatus.ACCEPTED);
@@ -43,9 +50,9 @@ public class FeedQueryService {
                 .map(f -> f.getOtherUserId(userId))
                 .toList();
 
-        // 3. 친구가 없으면 빈 리스트 반환
+        // 3. 친구가 없으면 빈 피드 반환
         if (friendIds.isEmpty()) {
-            return new FeedListResponse(List.of());
+            return new FeedListResponse(myReport, List.of());
         }
 
         // 4. 공유 활동 중지된 유저 제외
@@ -56,13 +63,12 @@ public class FeedQueryService {
                 .filter(id -> !suspendedUserIds.contains(id))
                 .toList();
 
-        // 5. 공유 가능한 친구가 없으면 빈 리스트 반환
+        // 5. 공유 가능한 친구가 없으면 빈 피드 반환
         if (activeFriendIds.isEmpty()) {
-            return new FeedListResponse(List.of());
+            return new FeedListResponse(myReport, List.of());
         }
 
         // 6. 당일 공유된 피드 조회
-        LocalDate today = TodayDateTimeProvider.getTodayDate();
         List<FeedDto> feedDtos = dailyReportRepository.findSharedFeedsByFriendIds(today, activeFriendIds);
 
         // 7. 내가 신고한 글 제외
@@ -77,24 +83,10 @@ public class FeedQueryService {
         // 8. 필터링 및 응답 DTO 변환
         List<FeedResponse> feeds = feedDtos.stream()
                 .filter(dto -> !reportedIds.contains(dto.dailyReportId()))
-                .map(dto -> {
-                    String profileUrl = buildProfileUrl(dto.profileImageKey(), dto.defaultProfileType());
-                    String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
-
-                    return new FeedResponse(
-                            dto.dailyReportId(),
-                            dto.nickname(),
-                            profileUrl,
-                            dto.interestCode() != null ? dto.interestCode().name() : null,
-                            dto.questionText(),
-                            dto.answerContent(),
-                            dto.emotionCode() != null ? dto.emotionCode().name() : null,
-                            imageUrl
-                    );
-                })
+                .map(this::toFeedResponse)
                 .toList();
 
-        return new FeedListResponse(feeds);
+        return new FeedListResponse(myReport, feeds);
     }
 
     public ShareStatusResponse getShareStatus(Long userId) {
@@ -102,6 +94,21 @@ public class FeedQueryService {
         return dailyReportRepository.findByUserIdAndDate(userId, today)
                 .map(report -> new ShareStatusResponse(report.getIsShared()))
                 .orElse(new ShareStatusResponse(false));
+    }
+
+    private FeedResponse toFeedResponse(FeedDto dto) {
+        String profileUrl = buildProfileUrl(dto.profileImageKey(), dto.defaultProfileType());
+        String imageUrl = dto.imageKey() != null ? profileImageUrlBuilder.buildUrl(dto.imageKey()) : null;
+        return new FeedResponse(
+                dto.dailyReportId(),
+                dto.nickname(),
+                profileUrl,
+                dto.interestCode() != null ? dto.interestCode().name() : null,
+                dto.questionText(),
+                dto.answerContent(),
+                dto.emotionCode() != null ? dto.emotionCode().name() : null,
+                imageUrl
+        );
     }
 
     private String buildProfileUrl(String profileImageKey, DefaultProfileType defaultProfileType) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -160,6 +160,35 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
         @Param("date") LocalDate date
     );
 
+    @Query("select ae.user.id from DailyReport dr join dr.answerEntry ae where dr.id = :reportId")
+    Optional<Long> findReportOwnerIdById(@Param("reportId") Long reportId);
+
+    boolean existsByIdAndIsSharedTrue(Long id);
+
+    @Query("""
+        select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.FeedDto(
+            dr.id,
+            ae.user.nickname,
+            ae.user.profileImageKey,
+            ae.user.defaultProfileType,
+            ae.question.interest.code,
+            ae.question.questionText,
+            ae.content,
+            dr.emotion.code,
+            ae.imageKey
+        )
+        from DailyReport dr
+        join dr.answerEntry ae
+        where ae.user.id = :userId
+          and dr.date = :date
+          and dr.isShared = true
+          and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
+    """)
+    Optional<FeedDto> findMySharedFeedByDate(
+        @Param("userId") Long userId,
+        @Param("date") LocalDate date
+    );
+
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.InterestCompletedCountDto(
             i.code,

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -206,4 +206,8 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
             @Param("userId") Long userId,
             @Param("status") DailyReportStatus status
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE DailyReport r SET r.isShared = false WHERE r.answerEntry.user.id = :userId AND r.date = :date AND r.isShared = true")
+    int stopSharingByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
@@ -21,6 +21,16 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     boolean existsByUserIds(@Param("userId1") Long userId1, @Param("userId2") Long userId2);
 
     @Query("""
+        select case when exists (
+            select 1 from Friendship f
+            where f.user1.id = :userId1 and f.user2.id = :userId2
+              and f.status = 'ACCEPTED'
+              and f.user1.deletedAt is null and f.user2.deletedAt is null
+        ) then true else false end
+        """)
+    boolean existsAcceptedByUserIds(@Param("userId1") Long userId1, @Param("userId2") Long userId2);
+
+    @Query("""
         select count(f) from Friendship f
         where (f.user1.id = :userId or f.user2.id = :userId)
         and f.status = :status

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
@@ -1,0 +1,180 @@
+package com.devkor.ifive.nadab.domain.like.api;
+
+import com.devkor.ifive.nadab.domain.like.api.dto.response.LikeListResponse;
+import com.devkor.ifive.nadab.domain.like.application.LikeCommandService;
+import com.devkor.ifive.nadab.domain.like.application.LikeQueryService;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
+import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "좋아요 API", description = "게시글 및 댓글 좋아요 관련 API")
+@RestController
+@RequestMapping("${api_prefix}")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeCommandService likeCommandService;
+    private final LikeQueryService likeQueryService;
+
+    @PostMapping("/feed/{dailyReportId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "게시글 좋아요",
+            description = """
+                    친구의 공유 게시글에 좋아요를 누릅니다.
+
+                    - 본인의 게시글에는 좋아요 불가 (400)
+                    - 이미 좋아요한 경우 204 반환 (멱등)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "좋아요 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: CANNOT_LIKE_OWN_CONTENT", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 공유되지 않은 게시글이거나 친구가 아닌 경우", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> likeReport(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long dailyReportId
+    ) {
+        likeCommandService.likeReport(dailyReportId, principal.getId());
+        return ApiResponseEntity.noContent();
+    }
+
+    @DeleteMapping("/feed/{dailyReportId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "게시글 좋아요 취소",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "취소 성공", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: LIKE_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> unlikeReport(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long dailyReportId
+    ) {
+        likeCommandService.unlikeReport(dailyReportId, principal.getId());
+        return ApiResponseEntity.noContent();
+    }
+
+    @GetMapping("/feed/{dailyReportId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "게시글 좋아요 리스트",
+            description = """
+                    게시글에 좋아요를 누른 사용자 목록을 조회합니다.
+
+                    - 리포트 당사자(본인 게시글)만 조회 가능합니다.
+                    - 최신순 정렬, 차단 관계 양방향 제외합니다.
+                    - isFriend=true인 경우 친구 삭제·차단 버튼 제공, false인 경우 친구 신청 버튼 제공합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = LikeListResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: DAILY_REPORT_LIKE_LIST_FORBIDDEN - 본인 게시글 아님", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<LikeListResponse>> getReportLikers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long dailyReportId
+    ) {
+        LikeListResponse response = likeQueryService.getReportLikers(dailyReportId, principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/comments/{commentId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글/대댓글 좋아요",
+            description = """
+                    댓글 또는 대댓글에 좋아요를 누릅니다.
+
+                    - 본인의 댓글에는 좋아요 불가 (400)
+                    - 열람 권한 없는 비밀 댓글에는 좋아요 불가 (403)
+                    - 이미 좋아요한 경우 204 반환 (멱등)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "좋아요 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: CANNOT_LIKE_OWN_CONTENT", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "ErrorCode: COMMENT_DELETED", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> likeComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId
+    ) {
+        likeCommandService.likeComment(commentId, principal.getId());
+        return ApiResponseEntity.noContent();
+    }
+
+    @DeleteMapping("/comments/{commentId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글/대댓글 좋아요 취소",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "취소 성공", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: LIKE_NOT_FOUND", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<Void>> unlikeComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId
+    ) {
+        likeCommandService.unlikeComment(commentId, principal.getId());
+        return ApiResponseEntity.noContent();
+    }
+
+    @GetMapping("/comments/{commentId}/likes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글/대댓글 좋아요 리스트",
+            description = """
+                    댓글 또는 대댓글에 좋아요를 누른 사용자 목록을 조회합니다.
+
+                    - 최신순 정렬, 차단 관계 양방향 제외합니다.
+                    - isFriend=true인 경우 친구 삭제·차단 버튼 제공, false인 경우 친구 신청 버튼 제공합니다.
+                    - 비밀 댓글은 열람 권한자(작성자·리포트 당사자)만 조회 가능합니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = LikeListResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 비밀 댓글 열람 권한 없음 또는 피드 접근 권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "ErrorCode: COMMENT_DELETED", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<LikeListResponse>> getCommentLikers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId
+    ) {
+        LikeListResponse response = likeQueryService.getCommentLikers(commentId, principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
@@ -40,7 +40,10 @@ public class LikeController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "좋아요 성공", content = @Content),
-                    @ApiResponse(responseCode = "400", description = "ErrorCode: CANNOT_LIKE_OWN_CONTENT", content = @Content),
+                    @ApiResponse(responseCode = "400", description = """
+                            - ErrorCode: CANNOT_LIKE_OWN_CONTENT - 본인 게시글 좋아요 불가
+                            - ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중
+                            """, content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED - 공유되지 않은 게시글이거나 친구가 아닌 경우", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: DAILY_REPORT_NOT_FOUND", content = @Content)
@@ -61,6 +64,7 @@ public class LikeController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "취소 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중", content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: LIKE_NOT_FOUND", content = @Content)
             }
@@ -115,7 +119,10 @@ public class LikeController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "좋아요 성공", content = @Content),
-                    @ApiResponse(responseCode = "400", description = "ErrorCode: CANNOT_LIKE_OWN_CONTENT", content = @Content),
+                    @ApiResponse(responseCode = "400", description = """
+                            - ErrorCode: CANNOT_LIKE_OWN_CONTENT - 본인 댓글 좋아요 불가
+                            - ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중
+                            """, content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "ErrorCode: AUTH_ACCESS_DENIED", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: COMMENT_NOT_FOUND", content = @Content),
@@ -137,6 +144,7 @@ public class LikeController {
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "취소 성공", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "ErrorCode: SOCIAL_SUSPENDED - 소셜 정지 중", content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(responseCode = "404", description = "ErrorCode: LIKE_NOT_FOUND", content = @Content)
             }

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikeListResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikeListResponse.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.domain.like.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "좋아요 리스트 응답")
+public record LikeListResponse(
+
+        @Schema(description = "좋아요 누른 사용자 목록 (최신순, 차단 관계 제외)")
+        List<LikerResponse> likers
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikerResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikerResponse.java
@@ -1,0 +1,20 @@
+package com.devkor.ifive.nadab.domain.like.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좋아요 누른 사용자")
+public record LikerResponse(
+
+        @Schema(description = "사용자 ID", example = "42")
+        Long userId,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(description = "닉네임", example = "모래")
+        String nickname,
+
+        @Schema(description = "친구 여부 (true: 친구 삭제·차단 버튼 제공, false: 친구 신청 버튼 제공)")
+        boolean isFriend
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
@@ -5,6 +5,7 @@ import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.like.core.entity.CommentLike;
 import com.devkor.ifive.nadab.domain.like.core.entity.DailyReportLike;
 import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
@@ -31,9 +32,10 @@ public class LikeCommandService {
     private final CommentRepository commentRepository;
     private final FriendshipRepository friendshipRepository;
     private final UserRepository userRepository;
+    private final SharingSuspensionService sharingSuspensionService;
 
     public void likeReport(Long dailyReportId, Long userId) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(userId);
         Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
 
@@ -53,13 +55,14 @@ public class LikeCommandService {
     }
 
     public void unlikeReport(Long dailyReportId, Long userId) {
+        checkNotSuspended(userId);
         DailyReportLike like = dailyReportLikeRepository.findByUserIdAndDailyReportId(userId, dailyReportId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.LIKE_NOT_FOUND));
         dailyReportLikeRepository.delete(like);
     }
 
     public void likeComment(Long commentId, Long userId) {
-        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        checkNotSuspended(userId);
         Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
                 .orElseThrow(() -> commentRepository.existsById(commentId)
                         ? new ConflictException(ErrorCode.COMMENT_DELETED)
@@ -96,9 +99,16 @@ public class LikeCommandService {
     }
 
     public void unlikeComment(Long commentId, Long userId) {
+        checkNotSuspended(userId);
         CommentLike like = commentLikeRepository.findByUserIdAndCommentId(userId, commentId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.LIKE_NOT_FOUND));
         commentLikeRepository.delete(like);
+    }
+
+    private void checkNotSuspended(Long userId) {
+        if (sharingSuspensionService.isSharingSuspended(userId)) {
+            throw new BadRequestException(ErrorCode.SOCIAL_SUSPENDED);
+        }
     }
 
     private void checkReportLikeAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
@@ -1,0 +1,126 @@
+package com.devkor.ifive.nadab.domain.like.application;
+
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.like.core.entity.CommentLike;
+import com.devkor.ifive.nadab.domain.like.core.entity.DailyReportLike;
+import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
+import com.devkor.ifive.nadab.domain.like.core.repository.DailyReportLikeRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.ForbiddenException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeCommandService {
+
+    private final DailyReportLikeRepository dailyReportLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final DailyReportRepository dailyReportRepository;
+    private final CommentRepository commentRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserRepository userRepository;
+
+    public void likeReport(Long dailyReportId, Long userId) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+
+        if (userId.equals(reportOwnerId)) {
+            throw new BadRequestException(ErrorCode.CANNOT_LIKE_OWN_CONTENT);
+        }
+
+        checkReportLikeAccess(dailyReportId, reportOwnerId, userId);
+
+        if (dailyReportLikeRepository.existsByUserIdAndDailyReportId(userId, dailyReportId)) {
+            return; // 이미 좋아요 — 멱등 처리
+        }
+
+        User user = userRepository.getReferenceById(userId);
+        DailyReport dailyReport = dailyReportRepository.getReferenceById(dailyReportId);
+        dailyReportLikeRepository.save(DailyReportLike.create(user, dailyReport));
+    }
+
+    public void unlikeReport(Long dailyReportId, Long userId) {
+        DailyReportLike like = dailyReportLikeRepository.findByUserIdAndDailyReportId(userId, dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.LIKE_NOT_FOUND));
+        dailyReportLikeRepository.delete(like);
+    }
+
+    public void likeComment(Long commentId, Long userId) {
+        // TODO: 소셜 정지 중이면 SOCIAL_SUSPENDED 에러 응답
+        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> commentRepository.existsById(commentId)
+                        ? new ConflictException(ErrorCode.COMMENT_DELETED)
+                        : new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (userId.equals(comment.getAuthor().getId())) {
+            throw new BadRequestException(ErrorCode.CANNOT_LIKE_OWN_CONTENT);
+        }
+
+        Long dailyReportId = comment.getDailyReport().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentLikeAccess(dailyReportId, reportOwnerId, userId);
+
+        if (comment.isSecret()) {
+            boolean isParentAuthor = !comment.isTopLevel() &&
+                    commentRepository.findParentAuthorIdById(commentId)
+                            .map(id -> id.equals(userId))
+                            .orElse(false);
+            boolean canView = comment.getAuthor().getId().equals(userId)
+                    || reportOwnerId.equals(userId)
+                    || isParentAuthor;
+            if (!canView) {
+                throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+            }
+        }
+
+        if (commentLikeRepository.existsByUserIdAndCommentId(userId, commentId)) {
+            return; // 이미 좋아요 — 멱등 처리
+        }
+
+        User user = userRepository.getReferenceById(userId);
+        commentLikeRepository.save(CommentLike.create(user, comment));
+    }
+
+    public void unlikeComment(Long commentId, Long userId) {
+        CommentLike like = commentLikeRepository.findByUserIdAndCommentId(userId, commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.LIKE_NOT_FOUND));
+        commentLikeRepository.delete(like);
+    }
+
+    private void checkReportLikeAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(currentUserId, reportOwnerId);
+        long largerId = Math.max(currentUserId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+    }
+
+    private void checkCommentLikeAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
+        if (currentUserId.equals(reportOwnerId)) return;
+        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(currentUserId, reportOwnerId);
+        long largerId = Math.max(currentUserId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
@@ -1,0 +1,129 @@
+package com.devkor.ifive.nadab.domain.like.application;
+
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.core.entity.Friendship;
+import com.devkor.ifive.nadab.domain.friend.core.entity.FriendshipStatus;
+import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
+import com.devkor.ifive.nadab.domain.like.api.dto.response.LikeListResponse;
+import com.devkor.ifive.nadab.domain.like.api.dto.response.LikerResponse;
+import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
+import com.devkor.ifive.nadab.domain.like.core.repository.DailyReportLikeRepository;
+import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.ForbiddenException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeQueryService {
+
+    private final DailyReportLikeRepository dailyReportLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final DailyReportRepository dailyReportRepository;
+    private final CommentRepository commentRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserBlockRepository userBlockRepository;
+    private final ProfileImageUrlBuilder profileImageUrlBuilder;
+
+    public LikeListResponse getReportLikers(Long dailyReportId, Long currentUserId) {
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+
+        if (!currentUserId.equals(reportOwnerId)) {
+            throw new ForbiddenException(ErrorCode.DAILY_REPORT_LIKE_LIST_FORBIDDEN);
+        }
+
+        List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
+        List<User> likers = dailyReportLikeRepository.findLikersByReportId(dailyReportId, excludedUserIds);
+
+        Set<Long> friendIds = getAcceptedFriendIds(currentUserId);
+        List<LikerResponse> responses = likers.stream()
+                .map(u -> new LikerResponse(
+                        u.getId(),
+                        profileImageUrlBuilder.buildUserProfileUrl(u),
+                        u.getNickname(),
+                        friendIds.contains(u.getId())
+                ))
+                .toList();
+
+        return new LikeListResponse(responses);
+    }
+
+    public LikeListResponse getCommentLikers(Long commentId, Long currentUserId) {
+        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> commentRepository.existsById(commentId)
+                        ? new ConflictException(ErrorCode.COMMENT_DELETED)
+                        : new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+
+        Long dailyReportId = comment.getDailyReport().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkCommentViewAccess(dailyReportId, reportOwnerId, currentUserId);
+
+        if (comment.isSecret()) {
+            boolean isParentAuthor = !comment.isTopLevel() &&
+                    commentRepository.findParentAuthorIdById(commentId)
+                            .map(id -> id.equals(currentUserId))
+                            .orElse(false);
+            boolean canView = comment.getAuthor().getId().equals(currentUserId)
+                    || reportOwnerId.equals(currentUserId)
+                    || isParentAuthor;
+            if (!canView) {
+                throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+            }
+        }
+
+        List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
+        List<User> likers = commentLikeRepository.findLikersByCommentId(commentId, excludedUserIds);
+
+        Set<Long> friendIds = getAcceptedFriendIds(currentUserId);
+        List<LikerResponse> responses = likers.stream()
+                .map(u -> new LikerResponse(
+                        u.getId(),
+                        profileImageUrlBuilder.buildUserProfileUrl(u),
+                        u.getNickname(),
+                        friendIds.contains(u.getId())
+                ))
+                .toList();
+
+        return new LikeListResponse(responses);
+    }
+
+    private void checkCommentViewAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
+        if (currentUserId.equals(reportOwnerId)) return;
+        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(currentUserId, reportOwnerId);
+        long largerId = Math.max(currentUserId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+    }
+
+    private Set<Long> getAcceptedFriendIds(Long userId) {
+        return friendshipRepository.findByUserIdAndStatusWithUsers(userId, FriendshipStatus.ACCEPTED)
+                .stream()
+                .map(f -> f.getOtherUserId(userId))
+                .collect(Collectors.toSet());
+    }
+
+    private List<Long> getExcludedUserIds(Long userId) {
+        // TODO: 소셜 정지 중인 유저 ID도 포함
+        List<Long> blocked = userBlockRepository.findBlockedUserIdsBidirectional(userId);
+        return blocked.isEmpty() ? List.of(-1L) : blocked;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
@@ -10,6 +10,7 @@ import com.devkor.ifive.nadab.domain.like.api.dto.response.LikeListResponse;
 import com.devkor.ifive.nadab.domain.like.api.dto.response.LikerResponse;
 import com.devkor.ifive.nadab.domain.like.core.repository.CommentLikeRepository;
 import com.devkor.ifive.nadab.domain.like.core.repository.DailyReportLikeRepository;
+import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
@@ -21,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,6 +40,7 @@ public class LikeQueryService {
     private final FriendshipRepository friendshipRepository;
     private final UserBlockRepository userBlockRepository;
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
+    private final SharingSuspensionService sharingSuspensionService;
 
     public LikeListResponse getReportLikers(Long dailyReportId, Long currentUserId) {
         Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
@@ -122,8 +126,13 @@ public class LikeQueryService {
     }
 
     private List<Long> getExcludedUserIds(Long userId) {
-        // TODO: 소셜 정지 중인 유저 ID도 포함
         List<Long> blocked = userBlockRepository.findBlockedUserIdsBidirectional(userId);
-        return blocked.isEmpty() ? List.of(-1L) : blocked;
+        List<Long> suspended = sharingSuspensionService.getAllActiveSuspendedUserIds();
+
+        Set<Long> combined = new HashSet<>(blocked);
+        combined.addAll(suspended);
+        combined.remove(userId);
+
+        return combined.isEmpty() ? List.of(-1L) : new ArrayList<>(combined);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/entity/CommentLike.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/entity/CommentLike.java
@@ -1,0 +1,35 @@
+package com.devkor.ifive.nadab.domain.like.core.entity;
+
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    public static CommentLike create(User user, Comment comment) {
+        CommentLike like = new CommentLike();
+        like.user = user;
+        like.comment = comment;
+        return like;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/entity/DailyReportLike.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/entity/DailyReportLike.java
@@ -1,0 +1,35 @@
+package com.devkor.ifive.nadab.domain.like.core.entity;
+
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_report_likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyReportLike extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "daily_report_id", nullable = false)
+    private DailyReport dailyReport;
+
+    public static DailyReportLike create(User user, DailyReport dailyReport) {
+        DailyReportLike like = new DailyReportLike();
+        like.user = user;
+        like.dailyReport = dailyReport;
+        return like;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/CommentLikeRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/CommentLikeRepository.java
@@ -1,0 +1,42 @@
+package com.devkor.ifive.nadab.domain.like.core.repository;
+
+import com.devkor.ifive.nadab.domain.like.core.entity.CommentLike;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    Optional<CommentLike> findByUserIdAndCommentId(Long userId, Long commentId);
+
+    boolean existsByUserIdAndCommentId(Long userId, Long commentId);
+
+    @Query("""
+            select l.comment.id
+            from CommentLike l
+            where l.comment.id in :commentIds
+              and l.user.id = :userId
+            """)
+    List<Long> findLikedCommentIds(@Param("commentIds") List<Long> commentIds, @Param("userId") Long userId);
+
+    @Query("""
+            select distinct l.comment.id
+            from CommentLike l
+            where l.comment.id in :commentIds
+            """)
+    List<Long> findCommentIdsWithLikes(@Param("commentIds") List<Long> commentIds);
+
+    @Query("""
+            select l.user
+            from CommentLike l
+            where l.comment.id = :commentId
+              and l.user.id not in :excludedUserIds
+              and l.user.deletedAt is null
+            order by l.createdAt desc
+            """)
+    List<User> findLikersByCommentId(@Param("commentId") Long commentId, @Param("excludedUserIds") List<Long> excludedUserIds);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/DailyReportLikeRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/DailyReportLikeRepository.java
@@ -1,0 +1,42 @@
+package com.devkor.ifive.nadab.domain.like.core.repository;
+
+import com.devkor.ifive.nadab.domain.like.core.entity.DailyReportLike;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyReportLikeRepository extends JpaRepository<DailyReportLike, Long> {
+
+    Optional<DailyReportLike> findByUserIdAndDailyReportId(Long userId, Long dailyReportId);
+
+    boolean existsByUserIdAndDailyReportId(Long userId, Long dailyReportId);
+
+    @Query("""
+            select l.dailyReport.id
+            from DailyReportLike l
+            where l.dailyReport.id in :reportIds
+              and l.user.id = :userId
+            """)
+    List<Long> findLikedReportIds(@Param("reportIds") List<Long> reportIds, @Param("userId") Long userId);
+
+    @Query("""
+            select distinct l.dailyReport.id
+            from DailyReportLike l
+            where l.dailyReport.id in :reportIds
+            """)
+    List<Long> findReportIdsWithLikes(@Param("reportIds") List<Long> reportIds);
+
+    @Query("""
+            select l.user
+            from DailyReportLike l
+            where l.dailyReport.id = :reportId
+              and l.user.id not in :excludedUserIds
+              and l.user.deletedAt is null
+            order by l.createdAt desc
+            """)
+    List<User> findLikersByReportId(@Param("reportId") Long reportId, @Param("excludedUserIds") List<Long> excludedUserIds);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/ModerationController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/ModerationController.java
@@ -3,7 +3,9 @@ package com.devkor.ifive.nadab.domain.moderation.api;
 import com.devkor.ifive.nadab.domain.moderation.api.dto.request.BlockUserRequest;
 import com.devkor.ifive.nadab.domain.moderation.api.dto.request.ReportContentRequest;
 import com.devkor.ifive.nadab.domain.moderation.api.dto.response.BlockedUserListResponse;
+import com.devkor.ifive.nadab.domain.moderation.api.dto.response.SuspensionStatusResponse;
 import com.devkor.ifive.nadab.domain.moderation.application.ContentReportCommandService;
+import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.moderation.application.UserBlockCommandService;
 import com.devkor.ifive.nadab.domain.moderation.application.UserBlockQueryService;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
@@ -22,7 +24,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "신고 및 차단 API", description = "공유글 신고, 사용자 차단 관련 API")
+
+@Tag(name = "신고 및 차단 API", description = "공유글/댓글 신고, 사용자 차단, 소셜 정지 관련 API")
 @RestController
 @RequestMapping("${api_prefix}/moderation")
 @RequiredArgsConstructor
@@ -31,16 +34,17 @@ public class ModerationController {
     private final ContentReportCommandService contentReportCommandService;
     private final UserBlockCommandService userBlockCommandService;
     private final UserBlockQueryService userBlockQueryService;
+    private final SharingSuspensionService sharingSuspensionService;
 
     @PostMapping("/reports")
     @PreAuthorize("isAuthenticated()")
     @Operation(
-            summary = "공유글 신고 API",
+            summary = "신고 API",
             description = """
-                    공유된 DailyReport를 신고합니다.
+                    공유글 또는 댓글/대댓글을 신고합니다.
 
                     요청 필드:
-                    - dailyReportId (필수): 신고할 공유글의 DailyReport ID(GET /api/v1/feed 호출 시 필드에서 확인 가능)
+                    - dailyReportId / commentId: 둘 중 하나만 필수 (동시 입력 불가)
                     - reason (필수): 신고 사유
                       - PROFANITY_HATE_SPEECH: 욕설 / 혐오 표현
                       - SEXUAL_CONTENT: 성적으로 부적절한 언행
@@ -49,35 +53,36 @@ public class ModerationController {
                     - customReason: reason이 OTHER일 때만 필수, 200자 이하
 
                     신고 후 동작:
-                    - 동일 공유글 중복 신고 불가
+                    - 동일 대상 중복 신고 불가
                     - 신고한 공유글은 신고자의 피드에서 숨겨짐
-                    - 누적 신고 10건 이상 & 신고자 2명 이상 시 작성자의 소셜 활동 자동 중지(공유하기 시도 시 status로 SUSPENDED 반환)
+                    - 누적 신고 20건 이상 & 신고자 3명 이상 시 소셜 활동 자동 정지 (720시간)
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
-                    @ApiResponse(
-                            responseCode = "204",
-                            description = "신고 성공",
-                            content = @Content
-                    ),
+                    @ApiResponse(responseCode = "204", description = "신고 성공", content = @Content),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "ErrorCode: CONTENT_REPORT_INVALID - 잘못된 신고 요청 (기타 사유 미입력 또는 200자 초과)",
+                            description = """
+                                    - ErrorCode: CONTENT_REPORT_INVALID - 잘못된 신고 요청 (대상 미입력/중복 입력, 기타 사유 미입력 또는 200자 초과)
+                                    - ErrorCode: CONTENT_REPORT_SELF_REPORT_FORBIDDEN - 본인 신고 불가
+                                    """,
                             content = @Content
                     ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "인증 실패",
-                            content = @Content
-                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(
                             responseCode = "404",
-                            description = "ErrorCode: DAILY_REPORT_NOT_FOUND - 공유글을 찾을 수 없음",
+                            description = """
+                                    - ErrorCode: DAILY_REPORT_NOT_FOUND - 공유글을 찾을 수 없음
+                                    - ErrorCode: COMMENT_NOT_FOUND - 댓글을 찾을 수 없음
+                                    """,
                             content = @Content
                     ),
                     @ApiResponse(
                             responseCode = "409",
-                            description = "ErrorCode: CONTENT_REPORT_ALREADY_EXISTS - 이미 신고한 공유글",
+                            description = """
+                                    - ErrorCode: CONTENT_REPORT_ALREADY_EXISTS - 이미 신고한 대상
+                                    - ErrorCode: COMMENT_DELETED - 이미 삭제된 댓글
+                                    """,
                             content = @Content
                     )
             }
@@ -89,10 +94,38 @@ public class ModerationController {
         contentReportCommandService.reportContent(
                 principal.getId(),
                 request.dailyReportId(),
+                request.commentId(),
                 request.reason(),
                 request.customReason()
         );
         return ApiResponseEntity.noContent();
+    }
+
+    @GetMapping("/suspension/status")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "소셜 정지 상태 조회",
+            description = """
+                    내 소셜 정지 여부와 해제 시각을 반환합니다. (팝업 표시용)
+
+                    - isSuspended: 정지 중이면 true
+                    - expiresAt: 정지 중일 때만 반환 (정지 해제 시각, ISO 8601)
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = SuspensionStatusResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<SuspensionStatusResponse>> getSuspensionStatus(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SuspensionStatusResponse response = sharingSuspensionService.getSuspensionStatus(principal.getId());
+        return ApiResponseEntity.ok(response);
     }
 
     @PostMapping("/blocks")

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/dto/request/ReportContentRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/dto/request/ReportContentRequest.java
@@ -4,12 +4,14 @@ import com.devkor.ifive.nadab.domain.moderation.core.entity.ReportReason;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "공유글 신고 요청")
+@Schema(description = "신고 요청 — dailyReportId / commentId 중 하나만 필수")
 public record ReportContentRequest(
 
-        @NotNull(message = "신고할 공유글 ID는 필수입니다")
-        @Schema(description = "신고할 DailyReport ID", example = "123")
+        @Schema(description = "신고할 DailyReport ID (게시글 신고 시 필수)", example = "123", nullable = true)
         Long dailyReportId,
+
+        @Schema(description = "신고할 Comment ID (댓글/대댓글 신고 시 필수)", example = "456", nullable = true)
+        Long commentId,
 
         @NotNull(message = "신고 사유는 필수입니다")
         @Schema(

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/dto/response/SuspensionStatusResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/dto/response/SuspensionStatusResponse.java
@@ -1,0 +1,23 @@
+package com.devkor.ifive.nadab.domain.moderation.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "소셜 정지 상태 응답")
+public record SuspensionStatusResponse(
+
+        @Schema(description = "소셜 정지 여부")
+        boolean isSuspended,
+
+        @Schema(description = "정지 해제 시각 (정지 중일 때만 반환)", nullable = true)
+        OffsetDateTime expiresAt
+) {
+    public static SuspensionStatusResponse notSuspended() {
+        return new SuspensionStatusResponse(false, null);
+    }
+
+    public static SuspensionStatusResponse suspended(OffsetDateTime expiresAt) {
+        return new SuspensionStatusResponse(true, expiresAt);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/ContentReportCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/ContentReportCommandService.java
@@ -1,5 +1,7 @@
 package com.devkor.ifive.nadab.domain.moderation.application;
 
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
 import com.devkor.ifive.nadab.domain.moderation.core.entity.ContentReport;
@@ -23,46 +25,85 @@ public class ContentReportCommandService {
 
     private final ContentReportRepository contentReportRepository;
     private final DailyReportRepository dailyReportRepository;
+    private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final SharingSuspensionService sharingSuspensionService;
 
-    public void reportContent(Long reporterId, Long dailyReportId, ReportReason reason, String customReason) {
-        // 1. customReason 검증
+    public void reportContent(Long reporterId, Long dailyReportId, Long commentId,
+                              ReportReason reason, String customReason) {
+        // 1. 입력값 검증
         validateCustomReason(reason, customReason);
+        validateTarget(dailyReportId, commentId);
 
-        // 2. 중복 신고 검증
+        // 2. 신고 생성
+        User reporter = userRepository.getReferenceById(reporterId);
+        ContentReport report = commentId != null
+                ? buildCommentReport(reporter, reporterId, commentId, reason, customReason)
+                : buildDailyReportReport(reporter, reporterId, dailyReportId, reason, customReason);
+
+        // 3. 신고 저장 (동시성 예외 처리)
+        try {
+            contentReportRepository.save(report);
+        } catch (DataIntegrityViolationException e) {
+            boolean isDuplicate = commentId != null
+                    ? contentReportRepository.existsByReporterIdAndCommentId(reporterId, commentId)
+                    : contentReportRepository.existsByReporterIdAndDailyReportId(reporterId, dailyReportId);
+            if (isDuplicate) {
+                throw new ConflictException(ErrorCode.CONTENT_REPORT_ALREADY_EXISTS);
+            }
+            throw e;
+        }
+
+        // 4. 자동 정지 조건 체크
+        sharingSuspensionService.checkAndTriggerSuspension(report.getReportedUser().getId());
+    }
+
+    private ContentReport buildDailyReportReport(User reporter, Long reporterId, Long dailyReportId,
+                                                  ReportReason reason, String customReason) {
+        // 중복 신고 검증
         if (contentReportRepository.existsByReporterIdAndDailyReportId(reporterId, dailyReportId)) {
             throw new ConflictException(ErrorCode.CONTENT_REPORT_ALREADY_EXISTS);
         }
 
-        // 3. DailyReport 조회
+        // DailyReport 조회
         DailyReport dailyReport = dailyReportRepository.findById(dailyReportId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
 
-        // 4. 자기 신고 방지 검증
+        // 자기 신고 방지 검증
         User reportedUser = dailyReport.getAnswerEntry().getUser();
         if (reporterId.equals(reportedUser.getId())) {
             throw new BadRequestException(ErrorCode.CONTENT_REPORT_SELF_REPORT_FORBIDDEN);
         }
+        return ContentReport.createForDailyReport(reporter, dailyReport, reportedUser, reason, customReason);
+    }
 
-        // 5. 신고 저장 (동시성 예외 처리)
-        User reporter = userRepository.getReferenceById(reporterId);
+    private ContentReport buildCommentReport(User reporter, Long reporterId, Long commentId,
+                                              ReportReason reason, String customReason) {
+        // 중복 신고 검증
+        if (contentReportRepository.existsByReporterIdAndCommentId(reporterId, commentId)) {
+            throw new ConflictException(ErrorCode.CONTENT_REPORT_ALREADY_EXISTS);
+        }
 
-        ContentReport report = ContentReport.create(
-                reporter, dailyReport, reportedUser, reason, customReason
-        );
+        // 댓글 조회
+        Comment comment = commentRepository.findByIdWithAuthorAndDailyReport(commentId)
+                .orElseThrow(() -> commentRepository.existsById(commentId)
+                        ? new ConflictException(ErrorCode.COMMENT_DELETED)
+                        : new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
 
-        try {
-            contentReportRepository.save(report);
-        } catch (DataIntegrityViolationException e) {
-            // UNIQUE 제약 위반인지 재조회로 확인
-            boolean isDuplicate = contentReportRepository
-                    .existsByReporterIdAndDailyReportId(reporterId, dailyReportId);
+        // 자기 신고 방지 검증
+        User reportedUser = comment.getAuthor();
+        if (reporterId.equals(reportedUser.getId())) {
+            throw new BadRequestException(ErrorCode.CONTENT_REPORT_SELF_REPORT_FORBIDDEN);
+        }
+        return ContentReport.createForComment(reporter, comment, reportedUser, reason, customReason);
+    }
 
-            if (isDuplicate) {
-                throw new ConflictException(ErrorCode.CONTENT_REPORT_ALREADY_EXISTS);
-            }
-
-            throw e;
+    private void validateTarget(Long dailyReportId, Long commentId) {
+        if (dailyReportId == null && commentId == null) {
+            throw new BadRequestException(ErrorCode.CONTENT_REPORT_INVALID);
+        }
+        if (dailyReportId != null && commentId != null) {
+            throw new BadRequestException(ErrorCode.CONTENT_REPORT_INVALID);
         }
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/SharingSuspensionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/SharingSuspensionService.java
@@ -62,18 +62,22 @@ public class SharingSuspensionService {
             return;
         }
 
-        // 가장 최근 정지의 expires_at을 기준점으로 사용 (null이면 전체 누적)
+        // 가장 최근 정지의 expires_at을 기준점으로 사용 (없으면 전체 누적)
         OffsetDateTime since = socialSuspensionRepository
                 .findFirstByUserIdOrderByStartedAtDesc(reportedUserId)
                 .map(SocialSuspension::getExpiresAt)
                 .orElse(null);
 
-        long reportCount = contentReportRepository.countReportsSince(reportedUserId, since);
+        long reportCount = since == null
+                ? contentReportRepository.countAllReports(reportedUserId)
+                : contentReportRepository.countReportsSince(reportedUserId, since);
         if (reportCount < REPORT_COUNT_THRESHOLD) {
             return;
         }
 
-        long reporterCount = contentReportRepository.countDistinctReportersSince(reportedUserId, since);
+        long reporterCount = since == null
+                ? contentReportRepository.countAllDistinctReporters(reportedUserId)
+                : contentReportRepository.countDistinctReportersSince(reportedUserId, since);
         if (reporterCount < REPORTER_COUNT_THRESHOLD) {
             return;
         }

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/SharingSuspensionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/SharingSuspensionService.java
@@ -1,45 +1,87 @@
 package com.devkor.ifive.nadab.domain.moderation.application;
 
+import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.moderation.api.dto.response.SuspensionStatusResponse;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
+import com.devkor.ifive.nadab.domain.moderation.core.entity.SocialSuspension;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.ContentReportRepository;
+import com.devkor.ifive.nadab.domain.moderation.core.repository.SocialSuspensionRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
-/**
- * 공유 활동 중지 판단 서비스
- */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SharingSuspensionService {
 
-    private static final long REPORT_COUNT_THRESHOLD = 10L;
-    private static final long REPORTER_COUNT_THRESHOLD = 2L;
+    private static final long REPORT_COUNT_THRESHOLD = 20L;
+    private static final long REPORTER_COUNT_THRESHOLD = 3L;
+    static final long SUSPENSION_HOURS = 720L;
 
     private final ContentReportRepository contentReportRepository;
+    private final SocialSuspensionRepository socialSuspensionRepository;
+    private final DailyReportRepository dailyReportRepository;
+    private final UserRepository userRepository;
 
-    /**
-     * 특정 유저가 공유 활동 중지 상태인지 확인 (신고 10건 이상 && 신고자 2명 이상)
-     */
     public boolean isSharingSuspended(Long userId) {
-        long reportCount = contentReportRepository.countByReportedUserId(userId);
-        if (reportCount < REPORT_COUNT_THRESHOLD) {
-            return false;
-        }
-
-        long reporterCount = contentReportRepository.countDistinctReportersByReportedUserId(userId);
-        return reporterCount >= REPORTER_COUNT_THRESHOLD;
+        return socialSuspensionRepository.existsByUserIdAndExpiresAtAfter(userId, OffsetDateTime.now());
     }
 
-    /**
-     * 여러 유저 중 공유 활동 중지된 유저 ID 조회
-     */
     public List<Long> getSharingSuspendedUserIds(List<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) {
             return List.of();
         }
-        return contentReportRepository.findSharingSuspendedUserIds(userIds);
+        return socialSuspensionRepository.findActiveSuspendedUserIds(userIds, OffsetDateTime.now());
+    }
+
+    public SuspensionStatusResponse getSuspensionStatus(Long userId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return socialSuspensionRepository.findFirstByUserIdOrderByStartedAtDesc(userId)
+                .filter(s -> s.getExpiresAt().isAfter(now))
+                .map(s -> SuspensionStatusResponse.suspended(s.getExpiresAt()))
+                .orElse(SuspensionStatusResponse.notSuspended());
+    }
+
+    public List<Long> getAllActiveSuspendedUserIds() {
+        return socialSuspensionRepository.findAllActiveSuspendedUserIds(OffsetDateTime.now());
+    }
+
+    /**
+     * 신고 저장 후 호출. 정지 조건(친구 신고 20건 이상 + 신고자 3명 이상) 충족 시 정지 발동.
+     * 정지 중이면 조건 체크를 건너뜀.
+     */
+    @Transactional
+    public void checkAndTriggerSuspension(Long reportedUserId) {
+        if (isSharingSuspended(reportedUserId)) {
+            return;
+        }
+
+        // 가장 최근 정지의 expires_at을 기준점으로 사용 (null이면 전체 누적)
+        OffsetDateTime since = socialSuspensionRepository
+                .findFirstByUserIdOrderByStartedAtDesc(reportedUserId)
+                .map(SocialSuspension::getExpiresAt)
+                .orElse(null);
+
+        long reportCount = contentReportRepository.countReportsSince(reportedUserId, since);
+        if (reportCount < REPORT_COUNT_THRESHOLD) {
+            return;
+        }
+
+        long reporterCount = contentReportRepository.countDistinctReportersSince(reportedUserId, since);
+        if (reporterCount < REPORTER_COUNT_THRESHOLD) {
+            return;
+        }
+
+        // 정지 발동
+        OffsetDateTime now = OffsetDateTime.now();
+        User user = userRepository.getReferenceById(reportedUserId);
+        socialSuspensionRepository.save(SocialSuspension.create(user, now, now.plusHours(SUSPENSION_HOURS)));
+        dailyReportRepository.stopSharingByUserIdAndDate(reportedUserId, TodayDateTimeProvider.getTodayDate());
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/entity/ContentReport.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/entity/ContentReport.java
@@ -1,5 +1,6 @@
 package com.devkor.ifive.nadab.domain.moderation.core.entity;
 
+import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
@@ -26,9 +27,13 @@ public class ContentReport extends CreatableEntity {
     @JoinColumn(name = "reported_user_id", nullable = false)
     private User reportedUser;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "daily_report_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_report_id")
     private DailyReport dailyReport;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "reason", nullable = false, length = 50)
@@ -37,7 +42,7 @@ public class ContentReport extends CreatableEntity {
     @Column(name = "custom_reason", length = 200)
     private String customReason;
 
-    public static ContentReport create(
+    public static ContentReport createForDailyReport(
             User reporter,
             DailyReport dailyReport,
             User reportedUser,
@@ -49,7 +54,23 @@ public class ContentReport extends CreatableEntity {
         report.dailyReport = dailyReport;
         report.reportedUser = reportedUser;
         report.reason = reason;
-        report.customReason = customReason; // 기타 사유 (OTHER일 때만)
+        report.customReason = customReason;
+        return report;
+    }
+
+    public static ContentReport createForComment(
+            User reporter,
+            Comment comment,
+            User reportedUser,
+            ReportReason reason,
+            String customReason
+    ) {
+        ContentReport report = new ContentReport();
+        report.reporter = reporter;
+        report.comment = comment;
+        report.reportedUser = reportedUser;
+        report.reason = reason;
+        report.customReason = customReason;
         return report;
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/entity/SocialSuspension.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/entity/SocialSuspension.java
@@ -1,0 +1,39 @@
+package com.devkor.ifive.nadab.domain.moderation.core.entity;
+
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "social_suspensions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialSuspension {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "started_at", nullable = false)
+    private OffsetDateTime startedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    public static SocialSuspension create(User user, OffsetDateTime startedAt, OffsetDateTime expiresAt) {
+        SocialSuspension s = new SocialSuspension();
+        s.user = user;
+        s.startedAt = startedAt;
+        s.expiresAt = expiresAt;
+        return s;
+    }
+
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/ContentReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/ContentReportRepository.java
@@ -5,42 +5,38 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface ContentReportRepository extends JpaRepository<ContentReport, Long> {
 
-    /**
-     * 중복 신고 체크
-     */
     boolean existsByReporterIdAndDailyReportId(Long reporterId, Long dailyReportId);
 
-    /**
-     * 특정 유저에 대한 신고 건수 조회
-     */
-    long countByReportedUserId(Long reportedUserId);
+    boolean existsByReporterIdAndCommentId(Long reporterId, Long commentId);
 
     /**
-     * 특정 유저를 신고한 사람 수 (중복 제거)
+     * reportedUser를 신고한 건수 (since 이후 누적, since가 null이면 전체 누적)
+     */
+    @Query("""
+        SELECT COUNT(cr.id)
+        FROM ContentReport cr
+        WHERE cr.reportedUser.id = :reportedUserId
+          AND (:since IS NULL OR cr.createdAt > :since)
+        """)
+    long countReportsSince(@Param("reportedUserId") Long reportedUserId,
+                           @Param("since") OffsetDateTime since);
+
+    /**
+     * reportedUser를 신고한 distinct 신고자 수 (since 이후 누적)
      */
     @Query("""
         SELECT COUNT(DISTINCT cr.reporter.id)
         FROM ContentReport cr
         WHERE cr.reportedUser.id = :reportedUserId
+          AND (:since IS NULL OR cr.createdAt > :since)
         """)
-    long countDistinctReportersByReportedUserId(@Param("reportedUserId") Long reportedUserId);
-
-    /**
-     * 공유 활동 중지 대상 유저 ID 조회 (신고 10건 이상 && 신고자 2명 이상)
-     */
-    @Query("""
-        SELECT cr.reportedUser.id
-        FROM ContentReport cr
-        WHERE cr.reportedUser.id IN :userIds
-        GROUP BY cr.reportedUser.id
-        HAVING COUNT(cr.id) >= 10
-           AND COUNT(DISTINCT cr.reporter.id) >= 2
-        """)
-    List<Long> findSharingSuspendedUserIds(@Param("userIds") List<Long> userIds);
+    long countDistinctReportersSince(@Param("reportedUserId") Long reportedUserId,
+                                     @Param("since") OffsetDateTime since);
 
     /**
      * 내가 신고한 DailyReport ID 목록 조회

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/ContentReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/ContentReportRepository.java
@@ -15,13 +15,33 @@ public interface ContentReportRepository extends JpaRepository<ContentReport, Lo
     boolean existsByReporterIdAndCommentId(Long reporterId, Long commentId);
 
     /**
-     * reportedUser를 신고한 건수 (since 이후 누적, since가 null이면 전체 누적)
+     * reportedUser를 신고한 전체 누적 건수
      */
     @Query("""
         SELECT COUNT(cr.id)
         FROM ContentReport cr
         WHERE cr.reportedUser.id = :reportedUserId
-          AND (:since IS NULL OR cr.createdAt > :since)
+        """)
+    long countAllReports(@Param("reportedUserId") Long reportedUserId);
+
+    /**
+     * reportedUser를 신고한 전체 누적 distinct 신고자 수
+     */
+    @Query("""
+        SELECT COUNT(DISTINCT cr.reporter.id)
+        FROM ContentReport cr
+        WHERE cr.reportedUser.id = :reportedUserId
+        """)
+    long countAllDistinctReporters(@Param("reportedUserId") Long reportedUserId);
+
+    /**
+     * reportedUser를 신고한 건수 (since 이후 누적)
+     */
+    @Query("""
+        SELECT COUNT(cr.id)
+        FROM ContentReport cr
+        WHERE cr.reportedUser.id = :reportedUserId
+          AND cr.createdAt > :since
         """)
     long countReportsSince(@Param("reportedUserId") Long reportedUserId,
                            @Param("since") OffsetDateTime since);
@@ -33,7 +53,7 @@ public interface ContentReportRepository extends JpaRepository<ContentReport, Lo
         SELECT COUNT(DISTINCT cr.reporter.id)
         FROM ContentReport cr
         WHERE cr.reportedUser.id = :reportedUserId
-          AND (:since IS NULL OR cr.createdAt > :since)
+          AND cr.createdAt > :since
         """)
     long countDistinctReportersSince(@Param("reportedUserId") Long reportedUserId,
                                      @Param("since") OffsetDateTime since);

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/SocialSuspensionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/SocialSuspensionRepository.java
@@ -1,0 +1,36 @@
+package com.devkor.ifive.nadab.domain.moderation.core.repository;
+
+import com.devkor.ifive.nadab.domain.moderation.core.entity.SocialSuspension;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SocialSuspensionRepository extends JpaRepository<SocialSuspension, Long> {
+
+    boolean existsByUserIdAndExpiresAtAfter(Long userId, OffsetDateTime now);
+
+    @Query("""
+        SELECT DISTINCT ss.user.id
+        FROM SocialSuspension ss
+        WHERE ss.user.id IN :userIds
+          AND ss.expiresAt > :now
+        """)
+    List<Long> findActiveSuspendedUserIds(@Param("userIds") List<Long> userIds,
+                                          @Param("now") OffsetDateTime now);
+
+    @Query("""
+        SELECT DISTINCT ss.user.id
+        FROM SocialSuspension ss
+        WHERE ss.expiresAt > :now
+        """)
+    List<Long> findAllActiveSuspendedUserIds(@Param("now") OffsetDateTime now);
+
+    /**
+     * 가장 최근 정지 레코드 조회 — 신고 누적 기준점(expires_at)으로 사용
+     */
+    Optional<SocialSuspension> findFirstByUserIdOrderByStartedAtDesc(Long userId);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/UserBlockRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/core/repository/UserBlockRepository.java
@@ -33,4 +33,12 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
         ) then true else false end
     """)
     boolean existsAnyBlockBetweenUsers(@Param("userId") Long userId, @Param("otherUserId") Long otherUserId);
+
+    @Query("""
+        select case when ub.blocker.id = :userId then ub.blocked.id
+                    else ub.blocker.id end
+        from UserBlock ub
+        where ub.blocker.id = :userId or ub.blocked.id = :userId
+    """)
+    List<Long> findBlockedUserIdsBidirectional(@Param("userId") Long userId);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
@@ -163,6 +163,6 @@ public class CommentNotificationEventListener {
 
     private String truncate(String content) {
         if (content == null) return "";
-        return content.length() > 20 ? content.substring(0, 20) + "..." : content;
+        return content.length() > 20 ? content.substring(0, 20).stripTrailing() + "..." : content;
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
@@ -1,0 +1,168 @@
+package com.devkor.ifive.nadab.domain.notification.application.event.social;
+
+import com.devkor.ifive.nadab.domain.comment.application.event.CommentCreatedEvent;
+import com.devkor.ifive.nadab.domain.comment.application.event.SubCommentCreatedEvent;
+import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.notification.application.NotificationCommandService;
+import com.devkor.ifive.nadab.domain.notification.core.entity.NotificationType;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.notification.message.NotificationContent;
+import com.devkor.ifive.nadab.global.core.notification.message.NotificationMessageFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CommentNotificationEventListener {
+
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final NotificationMessageFactory messageFactory;
+    private final NotificationCommandService notificationCommandService;
+
+    @Async("notificationTaskExecutor")
+    @EventListener
+    public void handleCommentCreated(CommentCreatedEvent event) {
+        try {
+            if (event.getAuthorId().equals(event.getReportOwnerId())) {
+                log.debug("Self-comment, skip notification: commentId={}", event.getCommentId());
+                return;
+            }
+
+            User author = userRepository.findById(event.getAuthorId()).orElse(null);
+            if (author == null || author.getDeletedAt() != null) {
+                log.debug("Author not found or deleted, skip notification: authorId={}", event.getAuthorId());
+                return;
+            }
+
+            User reportOwner = userRepository.findById(event.getReportOwnerId()).orElse(null);
+            if (reportOwner == null || reportOwner.getDeletedAt() != null) {
+                log.debug("Report owner not found or deleted, skip notification: reportOwnerId={}", event.getReportOwnerId());
+                return;
+            }
+
+            Map<String, String> params = Map.of(
+                    "senderName", author.getNickname(),
+                    "commentContent", truncate(event.getContent())
+            );
+            NotificationContent content = messageFactory.createMessage(NotificationType.COMMENT_ON_MY_REPORT, params);
+
+            String idempotencyKey = String.format("COMMENT_%d_REPORT_OWNER", event.getCommentId());
+            notificationCommandService.sendNotification(
+                    event.getReportOwnerId(),
+                    NotificationType.COMMENT_ON_MY_REPORT,
+                    content.title(),
+                    content.body(),
+                    content.inboxMessage(),
+                    event.getDailyReportId().toString(),
+                    idempotencyKey
+            );
+            log.debug("Comment notification sent: commentId={}, reportOwnerId={}", event.getCommentId(), event.getReportOwnerId());
+        } catch (Exception e) {
+            log.error("Failed to handle CommentCreatedEvent: commentId={}, error={}",
+                    event.getCommentId(), e.getMessage(), e);
+        }
+    }
+
+    @Async("notificationTaskExecutor")
+    @EventListener
+    public void handleSubCommentCreated(SubCommentCreatedEvent event) {
+        try {
+            User author = userRepository.findById(event.getAuthorId()).orElse(null);
+            if (author == null || author.getDeletedAt() != null) {
+                log.debug("Author not found or deleted, skip notification: authorId={}", event.getAuthorId());
+                return;
+            }
+
+            Map<String, String> params = Map.of(
+                    "senderName", author.getNickname(),
+                    "commentContent", truncate(event.getContent())
+            );
+
+            // 1. 부모 댓글 작성자 알림 (author 제외, 역할 무관 최우선)
+            if (!event.getAuthorId().equals(event.getParentCommentAuthorId())) {
+                User parentCommentAuthor = userRepository.findById(event.getParentCommentAuthorId()).orElse(null);
+                if (parentCommentAuthor == null || parentCommentAuthor.getDeletedAt() != null) {
+                    log.debug("Parent comment author not found or deleted, skip notification: parentCommentAuthorId={}", event.getParentCommentAuthorId());
+                } else {
+                    NotificationContent replyContent = messageFactory.createMessage(
+                            NotificationType.REPLY_ON_MY_COMMENT, params);
+                    notificationCommandService.sendNotification(
+                            event.getParentCommentAuthorId(),
+                            NotificationType.REPLY_ON_MY_COMMENT,
+                            replyContent.title(),
+                            replyContent.body(),
+                            replyContent.inboxMessage(),
+                            event.getDailyReportId().toString(),
+                            String.format("COMMENT_%d_PARENT_AUTHOR", event.getSubCommentId())
+                    );
+                    log.debug("Sub-comment notification sent to parent author: subCommentId={}, parentCommentAuthorId={}", event.getSubCommentId(), event.getParentCommentAuthorId());
+                }
+            }
+
+            // 2. 참여자 알림 (author, 부모 댓글 작성자 제외) — 리포트 당사자도 참여자면 여기서 처리
+            List<Long> excludeFromParticipants = List.of(
+                    event.getAuthorId(),
+                    event.getParentCommentAuthorId()
+            );
+            List<Long> participantIds = commentRepository.findDistinctSubCommentAuthorIds(
+                    event.getParentCommentId(), excludeFromParticipants);
+
+            // 3. 리포트 당사자가 참여자가 아닌 경우에만 COMMENT_ON_MY_REPORT
+            boolean reportOwnerIsParentAuthor = event.getReportOwnerId().equals(event.getParentCommentAuthorId());
+            boolean reportOwnerIsParticipant = participantIds.contains(event.getReportOwnerId());
+            boolean reportOwnerIsAuthor = event.getReportOwnerId().equals(event.getAuthorId());
+
+            if (!reportOwnerIsAuthor && !reportOwnerIsParentAuthor && !reportOwnerIsParticipant) {
+                User reportOwner = userRepository.findById(event.getReportOwnerId()).orElse(null);
+                if (reportOwner == null || reportOwner.getDeletedAt() != null) {
+                    log.debug("Report owner not found or deleted, skip notification: reportOwnerId={}", event.getReportOwnerId());
+                } else {
+                    NotificationContent reportOwnerContent = messageFactory.createMessage(
+                            NotificationType.COMMENT_ON_MY_REPORT, params);
+                    notificationCommandService.sendNotification(
+                            event.getReportOwnerId(),
+                            NotificationType.COMMENT_ON_MY_REPORT,
+                            reportOwnerContent.title(),
+                            reportOwnerContent.body(),
+                            reportOwnerContent.inboxMessage(),
+                            event.getDailyReportId().toString(),
+                            String.format("COMMENT_%d_REPORT_OWNER", event.getSubCommentId())
+                    );
+                    log.debug("Sub-comment notification sent to report owner: subCommentId={}, reportOwnerId={}", event.getSubCommentId(), event.getReportOwnerId());
+                }
+            }
+
+            NotificationContent participantContent = messageFactory.createMessage(
+                    NotificationType.REPLY_ON_PARTICIPATED_COMMENT, params);
+            for (Long participantId : participantIds) {
+                notificationCommandService.sendNotification(
+                        participantId,
+                        NotificationType.REPLY_ON_PARTICIPATED_COMMENT,
+                        participantContent.title(),
+                        participantContent.body(),
+                        participantContent.inboxMessage(),
+                        event.getDailyReportId().toString(),
+                        String.format("COMMENT_%d_PARTICIPANT_%d", event.getSubCommentId(), participantId)
+                );
+            }
+            log.debug("Sub-comment notifications sent: subCommentId={}, participantCount={}", event.getSubCommentId(), participantIds.size());
+        } catch (Exception e) {
+            log.error("Failed to handle SubCommentCreatedEvent: subCommentId={}, error={}",
+                    event.getSubCommentId(), e.getMessage(), e);
+        }
+    }
+
+    private String truncate(String content) {
+        if (content == null) return "";
+        return content.length() > 20 ? content.substring(0, 20) + "..." : content;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/FriendNotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/FriendNotificationEventListener.java
@@ -1,4 +1,4 @@
-package com.devkor.ifive.nadab.domain.notification.application.event.friend;
+package com.devkor.ifive.nadab.domain.notification.application.event.social;
 
 import com.devkor.ifive.nadab.domain.friend.application.event.FriendRequestAcceptedEvent;
 import com.devkor.ifive.nadab.domain.friend.application.event.FriendRequestReceivedEvent;

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/core/entity/NotificationType.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/core/entity/NotificationType.java
@@ -22,7 +22,10 @@ public enum NotificationType {
 
     // 소셜 알림
     FRIEND_REQUEST_RECEIVED("친구 요청", NotificationGroup.SOCIAL),
-    FRIEND_REQUEST_ACCEPTED("친구 수락", NotificationGroup.SOCIAL);
+    FRIEND_REQUEST_ACCEPTED("친구 수락", NotificationGroup.SOCIAL),
+    COMMENT_ON_MY_REPORT("내 리포트에 댓글/대댓글", NotificationGroup.SOCIAL),
+    REPLY_ON_MY_COMMENT("내 댓글에 대댓글", NotificationGroup.SOCIAL),
+    REPLY_ON_PARTICIPATED_COMMENT("참여 댓글에 대댓글", NotificationGroup.SOCIAL);
 
     private final String description;
     private final NotificationGroup group;

--- a/src/main/java/com/devkor/ifive/nadab/global/core/notification/message/NotificationMessageFactory.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/notification/message/NotificationMessageFactory.java
@@ -50,7 +50,8 @@ public class NotificationMessageFactory {
             "senderName", "테스트",
             "categoryName", "테스트",
             "daysInactive", "5",
-            "milestone", "30"
+            "milestone", "30",
+            "commentContent", "테스트 댓글 내용"
         );
 
         for (NotificationType type : NotificationType.values()) {

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -392,7 +392,27 @@ public enum ErrorCode {
     CONTENT_REPORT_SELF_REPORT_FORBIDDEN(HttpStatus.BAD_REQUEST, "자신의 게시글은 신고할 수 없습니다"),
 
     // 409 Conflict
-    CONTENT_REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 신고한 게시글입니다");
+    CONTENT_REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 신고한 게시글입니다"),
+
+    // ==================== COMMENT (댓글) ====================
+    // 400 Bad Request
+    COMMENT_NOT_TOP_LEVEL(HttpStatus.BAD_REQUEST, "대댓글에는 답글을 달 수 없습니다"),
+
+    // 404 Not Found
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
+
+    // 409 Conflict
+    COMMENT_DELETED(HttpStatus.CONFLICT, "이미 삭제된 댓글입니다"),
+
+    // ==================== LIKE (좋아요) ====================
+    // 400 Bad Request
+    CANNOT_LIKE_OWN_CONTENT(HttpStatus.BAD_REQUEST, "본인의 게시글/댓글에는 좋아요를 누를 수 없습니다"),
+
+    // 403 Forbidden
+    DAILY_REPORT_LIKE_LIST_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 게시글 좋아요 리스트만 조회할 수 있습니다"),
+
+    // 404 Not Found
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요를 찾을 수 없습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -394,6 +394,10 @@ public enum ErrorCode {
     // 409 Conflict
     CONTENT_REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 신고한 게시글입니다"),
 
+    // ==================== MODERATION (소셜 정지) ====================
+    // 400 Bad Request
+    SOCIAL_SUSPENDED(HttpStatus.BAD_REQUEST, "소셜 활동이 정지된 상태입니다"),
+
     // ==================== COMMENT (댓글) ====================
     // 400 Bad Request
     COMMENT_NOT_TOP_LEVEL(HttpStatus.BAD_REQUEST, "대댓글에는 답글을 달 수 없습니다"),

--- a/src/main/resources/db/migration/V20260512_1312__CH_create_comments_table.sql
+++ b/src/main/resources/db/migration/V20260512_1312__CH_create_comments_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE comments (
+    id                BIGSERIAL    PRIMARY KEY,
+    daily_report_id   BIGINT       NOT NULL,
+    author_id         BIGINT       NOT NULL,
+    parent_comment_id BIGINT,
+    content           VARCHAR(500) NOT NULL,
+    is_secret         BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_comments_daily_report    FOREIGN KEY (daily_report_id)   REFERENCES daily_reports(id) ON DELETE CASCADE,
+    CONSTRAINT fk_comments_author          FOREIGN KEY (author_id)          REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_comments_parent_comment  FOREIGN KEY (parent_comment_id)  REFERENCES comments(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_comments_daily_report_id   ON comments (daily_report_id);
+CREATE INDEX idx_comments_parent_comment_id ON comments (parent_comment_id);

--- a/src/main/resources/db/migration/V20260515_1730__CH_create_comments_table.sql
+++ b/src/main/resources/db/migration/V20260515_1730__CH_create_comments_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE comments (
     is_secret         BOOLEAN      NOT NULL DEFAULT FALSE,
     created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    deleted_at        TIMESTAMPTZ,
 
     CONSTRAINT fk_comments_daily_report    FOREIGN KEY (daily_report_id)   REFERENCES daily_reports(id) ON DELETE CASCADE,
     CONSTRAINT fk_comments_author          FOREIGN KEY (author_id)          REFERENCES users(id) ON DELETE CASCADE,

--- a/src/main/resources/db/migration/V20260515_1735__CH_create_likes_tables.sql
+++ b/src/main/resources/db/migration/V20260515_1735__CH_create_likes_tables.sql
@@ -1,0 +1,19 @@
+CREATE TABLE daily_report_likes (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    daily_report_id BIGINT NOT NULL REFERENCES daily_reports(id) ON DELETE CASCADE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_daily_report_likes_user_report UNIQUE (user_id, daily_report_id)
+);
+
+CREATE INDEX idx_daily_report_likes_report ON daily_report_likes (daily_report_id);
+
+CREATE TABLE comment_likes (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    comment_id  BIGINT NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_comment_likes_user_comment UNIQUE (user_id, comment_id)
+);
+
+CREATE INDEX idx_comment_likes_comment ON comment_likes (comment_id);

--- a/src/main/resources/db/migration/V20260518_1500__CH_create_social_suspensions_table.sql
+++ b/src/main/resources/db/migration/V20260518_1500__CH_create_social_suspensions_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE social_suspensions (
+    id         BIGSERIAL    PRIMARY KEY,
+    user_id    BIGINT       NOT NULL,
+    started_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ  NOT NULL,
+
+    CONSTRAINT fk_social_suspensions_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_social_suspensions_user_expires ON social_suspensions(user_id, expires_at);
+CREATE INDEX idx_social_suspensions_expires ON social_suspensions(expires_at);

--- a/src/main/resources/db/migration/V20260518_1503__CH_alter_content_reports_for_comments.sql
+++ b/src/main/resources/db/migration/V20260518_1503__CH_alter_content_reports_for_comments.sql
@@ -1,0 +1,29 @@
+-- comment_id 컬럼 추가
+ALTER TABLE content_reports ADD COLUMN comment_id BIGINT;
+
+-- daily_report_id NOT NULL → nullable
+ALTER TABLE content_reports ALTER COLUMN daily_report_id DROP NOT NULL;
+
+-- 기존 UNIQUE 제약 제거
+ALTER TABLE content_reports DROP CONSTRAINT uq_content_reports_reporter_daily_report;
+
+-- daily_report_id FK: ON DELETE CASCADE → ON DELETE SET NULL
+ALTER TABLE content_reports DROP CONSTRAINT fk_content_reports_daily_report;
+ALTER TABLE content_reports
+    ADD CONSTRAINT fk_content_reports_daily_report
+        FOREIGN KEY (daily_report_id) REFERENCES daily_reports(id) ON DELETE SET NULL;
+
+-- comment_id FK
+ALTER TABLE content_reports
+    ADD CONSTRAINT fk_content_reports_comment
+        FOREIGN KEY (comment_id) REFERENCES comments(id) ON DELETE SET NULL;
+
+-- 게시글 신고 partial unique (게시글 신고에서 중복 방지)
+CREATE UNIQUE INDEX uq_content_reports_reporter_daily_report
+    ON content_reports(reporter_id, daily_report_id)
+    WHERE daily_report_id IS NOT NULL AND comment_id IS NULL;
+
+-- 댓글 신고 partial unique (댓글 신고에서 중복 방지)
+CREATE UNIQUE INDEX uq_content_reports_reporter_comment
+    ON content_reports(reporter_id, comment_id)
+    WHERE comment_id IS NOT NULL;


### PR DESCRIPTION
## 📝 요약(Summary)
친구 피드 기반 소셜 기능(댓글/대댓글·좋아요·신고 개편)을 구현했습니다.

1. 댓글/대댓글
  
  - comments 테이블: daily_report_id, author_id, parent_comment_id(null=댓글, non-null=대댓글), content, is_secret, deleted_at
  - 2레벨 구조(댓글-대댓글)만 지원. 대댓글의 부모는 반드시 top-level 댓글이어야하며 아닐 경우 COMMENT_NOT_TOP_LEVEL 반환

  API

  Method: GET
  Path: /api/v1/comments?dailyReportId={id}
  설명: 댓글 목록 (커서 기반, 최신순)
  ────────────────────────────────────────
  Method: POST
  Path: /api/v1/comments
  설명: 댓글 작성
  ────────────────────────────────────────
  Method: GET
  Path: /api/v1/comments/{commentId}/sub-comments
  설명: 대댓글 목록 (커서 기반)
  ────────────────────────────────────────
  Method: POST
  Path: /api/v1/comments/{commentId}/sub-comments
  설명: 대댓글 작성
  ────────────────────────────────────────
  Method: PATCH
  Path: /api/v1/comments/{commentId}
  설명: 내용 수정 (작성자 본인만, isSecret 변경 불가)
  ────────────────────────────────────────
  Method: DELETE
  Path: /api/v1/comments/{commentId}
  설명: 삭제 (작성자 본인 또는 리포트 당사자)

  접근 제어
  - 본인 리포트: 항상 허용
  - 타인 리포트: isShared=true AND 친구 관계(ACCEPTED) 두 조건 모두 충족 필요

  비밀 댓글
  - 열람 권한: 댓글 작성자 + 리포트 당사자. 대댓글은 부모 댓글 작성자도 추가 허용
  - 권한 없는 경우 canViewContent=false 플래그로 내려줌 (프로필, 닉네임, 내용 마스킹은 프론트 처리)
  - 비밀 댓글 하위 대댓글은 무조건 비밀 강제
  - 비밀 부모 댓글: 열람 권한 없으면 대댓글 목록 조회/작성 403 반환

  조회 필터링 (getExcludedUserIds)
  - 내가 차단한 / 나를 차단한 사용자
  - 소셜 정지 중인 사용자
  - 탈퇴한 사용자 (author.deletedAt is null 쿼리 조건)
  - 내가 신고한 댓글 (NOT EXISTS ContentReport 서브쿼리)

  visibleSubCommentCount
  전체 대댓글 수에서 위 필터 대상 + 열람 권한 없는 비밀 대댓글을 제외한 값. 단일 집계 쿼리(countVisibleSubCommentsByParentIds)로 처리

  소프트딜리트
  - 댓글 삭제 시 대댓글 Modifying(clearAutomatically = true) bulk UPDATE로 일괄 소프트딜리트
  - 신고 이력 남겨놓기 위해서 소프트딜리트 채택

  알림 (즉시 FCM)
  - 내 리포트에 댓글 달림 → COMMENT_ON_MY_REPORT
  - 내 댓글에 대댓글 달림 → REPLY_ON_MY_COMMENT
  - 내가 참여한 댓글에 다른 대댓글 달림 → REPLY_ON_PARTICIPATED_COMMENT
  - targetId로 dailyReportId 전달

  피드 응답 변경
  GET /api/v1/feed 응답에 myReport(오늘 내 공유 리포트, 미공유 시 null) 필드 추가 

  ---
  2. 좋아요

  API

  Method: POST
  Path: /api/v1/feed/{dailyReportId}/likes
  설명: 게시글 좋아요
  ────────────────────────────────────────
  Method: DELETE
  Path: /api/v1/feed/{dailyReportId}/likes
  설명: 게시글 좋아요 취소
  ────────────────────────────────────────
  Method: GET
  Path: /api/v1/feed/{dailyReportId}/likes
  설명: 게시글 좋아요 리스트 (리포트 당사자만)
  ────────────────────────────────────────
  Method: POST
  Path: /api/v1/comments/{commentId}/likes
  설명: 댓글/대댓글 좋아요
  ────────────────────────────────────────
  Method: DELETE
  Path: /api/v1/comments/{commentId}/likes
  설명: 댓글/대댓글 좋아요 취소
  ────────────────────────────────────────
  Method: GET
  Path: /api/v1/comments/{commentId}/likes
  설명: 댓글/대댓글 좋아요 리스트

  제약 조건
  - 본인 게시글/댓글/대댓글 좋아요 불가 → CANNOT_LIKE_OWN_CONTENT(400)
  - 중복 좋아요 멱등 처리 (이미 좋아요한 경우 에러 없이 204 반환)
  - 비밀 대댓글 좋아요/좋아요 리스트: 열람 권한자(작성자·리포트 당사자·부모 댓글 작성자)만 허용
  - unlike는 정지 체크 포함

  좋아요 리스트 응답
  최신순, 차단 관계 양방향 + 정지 유저 제외. isFriend 플래그로 친구 여부 전달(친구면 삭제/차단, 아니면 친구 신청 버튼)

  피드·댓글 응답 변경
  - 피드 항목, 댓글/대댓글 응답에 isLiked, hasLikes 필드 추가

  ---
  3. 신고 개편 + 소셜 정지

  DB 변경
  - content_reports: comment_id 컬럼 추가(nullable), daily_report_id NOT NULL → nullable, fk_content_reports_daily_report ON DELETE CASCADE → ON DELETE SET NULL (게시글 삭제 후에도 신고 이력 보존), partial unique index 2개로 중복 신고 방지
  - social_suspensions 신규 테이블: user_id, started_at, expires_at

  신고 API 변경
  POST /api/v1/moderation/reports에 commentId 추가 (nullable). dailyReportId / commentId 중 하나 필수. 게시글·댓글 신고 단일 테이블 통합

  소셜 정지 자동 발동
  - 조건: 가장 최근 정지 만료 이후 신고 20건 이상 + 신고자 3명 이상
  - 발동 시 단일 트랜잭션: 정지 레코드 생성 + 오늘 공유 게시글 일괄 비공개
  - 만료 체크 Lazy (API 호출 시 expiresAt > NOW() 확인). 레코드 삭제 금지 (다음 정지 집계 기준점으로 사용)

  정지 중 차단 API
  댓글 작성·수정·삭제, 게시글/댓글 좋아요·취소 → SOCIAL_SUSPENDED(400)

  신규 API
  GET /api/v1/moderation/suspension/status — 정지 여부 및 해제일 반환 (팝업용)


## 🔗 Related Issue
- Closes: 

## 💬 공유사항
- isLiked / hasLikes / myReport 신규 필드: 구버전 앱은 JSON unknown field를 무시하므로 하위 호환 문제 없습니다.
- 이외에도 다른 API 변경점들에 대해서도 호환 문제는 발생하지 않을 것 같습니다.
- 리포트 상세보기 API에는 isLiked / hasLikes 필드 추가 안했습니다. 어짜피 내 예전 리포트 보는데 좋아요 리스트 조회하면 되니까 굳이 좋아요가 1개 이상인지와 같은 정보는 필요 없다고 생각했습니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.