### PR TITLE
feat(social): 좋아요 목록 응답에 friendshipId와 relationshipStatus 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/friend/core/repository/FriendshipRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
@@ -76,6 +77,16 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             @Param("userId") Long userId,
             @Param("keyword") String keyword
     );
+
+    @Query("""
+        select f from Friendship f
+        join fetch f.user1
+        join fetch f.user2
+        where ((f.user1.id = :userId and f.user2.id in :otherIds)
+            or (f.user2.id = :userId and f.user1.id in :otherIds))
+          and f.user1.deletedAt is null and f.user2.deletedAt is null
+        """)
+    List<Friendship> findByUserIdAndOtherUserIds(@Param("userId") Long userId, @Param("otherIds") Collection<Long> otherIds);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/LikeController.java
@@ -86,7 +86,12 @@ public class LikeController {
 
                     - 리포트 당사자(본인 게시글)만 조회 가능합니다.
                     - 최신순 정렬, 차단 관계 양방향 제외합니다.
-                    - isFriend=true인 경우 친구 삭제·차단 버튼 제공, false인 경우 친구 신청 버튼 제공합니다.
+                    - relationshipStatus
+                      - FRIEND: 이미 친구, 친구 삭제·차단 버튼 표시
+                      - REQUEST_SENT: 내가 신청 보낸 상태, 신청 취소 버튼 표시
+                      - REQUEST_RECEIVED: 상대가 나에게 신청 보낸 상태, 수락·거절 버튼 표시
+                      - NONE: 아무 관계 없음, 친구 신청 버튼 표시
+                    - friendshipId: NONE 상태일 땐 null, 그 외 친구 관계 ID
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
@@ -165,7 +170,12 @@ public class LikeController {
                     댓글 또는 대댓글에 좋아요를 누른 사용자 목록을 조회합니다.
 
                     - 최신순 정렬, 차단 관계 양방향 제외합니다.
-                    - isFriend=true인 경우 친구 삭제·차단 버튼 제공, false인 경우 친구 신청 버튼 제공합니다.
+                    - relationshipStatus
+                      - FRIEND: 이미 친구, 친구 삭제·차단 버튼 표시
+                      - REQUEST_SENT: 내가 신청 보낸 상태, 신청 취소 버튼 표시
+                      - REQUEST_RECEIVED: 상대가 나에게 신청 보낸 상태, 수락·거절 버튼 표시
+                      - NONE: 아무 관계 없음, 친구 신청 버튼 표시
+                    - friendshipId: NONE 상태일 땐 null, 그 외 친구 관계 ID
                     - 비밀 댓글은 열람 권한자(작성자·리포트 당사자)만 조회 가능합니다.
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikerResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/api/dto/response/LikerResponse.java
@@ -1,5 +1,6 @@
 package com.devkor.ifive.nadab.domain.like.api.dto.response;
 
+import com.devkor.ifive.nadab.domain.friend.api.dto.response.RelationshipStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "좋아요 누른 사용자")
@@ -14,7 +15,10 @@ public record LikerResponse(
         @Schema(description = "닉네임", example = "모래")
         String nickname,
 
-        @Schema(description = "친구 여부 (true: 친구 삭제·차단 버튼 제공, false: 친구 신청 버튼 제공)")
-        boolean isFriend
+        @Schema(description = "친구 관계 ID (친구 신청 취소·삭제 시 사용, NONE 상태일 땐 null)", example = "123")
+        Long friendshipId,
+
+        @Schema(description = "친구 관계 상태 (FRIEND: 친구 삭제·차단 버튼 표시, REQUEST_SENT: 신청 취소 버튼 표시, REQUEST_RECEIVED: 수락·거절 버튼 표시, NONE: 친구 신청 버튼 표시)")
+        RelationshipStatus relationshipStatus
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.like.application;
 import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
 import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.api.dto.response.RelationshipStatus;
 import com.devkor.ifive.nadab.domain.friend.core.entity.Friendship;
 import com.devkor.ifive.nadab.domain.friend.core.entity.FriendshipStatus;
 import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,14 +55,9 @@ public class LikeQueryService {
         List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
         List<User> likers = dailyReportLikeRepository.findLikersByReportId(dailyReportId, excludedUserIds);
 
-        Set<Long> friendIds = getAcceptedFriendIds(currentUserId);
+        Map<Long, FriendshipInfo> friendshipInfoMap = buildFriendshipInfoMap(likers, currentUserId);
         List<LikerResponse> responses = likers.stream()
-                .map(u -> new LikerResponse(
-                        u.getId(),
-                        profileImageUrlBuilder.buildUserProfileUrl(u),
-                        u.getNickname(),
-                        friendIds.contains(u.getId())
-                ))
+                .map(u -> toLikerResponse(u, friendshipInfoMap))
                 .toList();
 
         return new LikeListResponse(responses);
@@ -93,14 +90,9 @@ public class LikeQueryService {
         List<Long> excludedUserIds = getExcludedUserIds(currentUserId);
         List<User> likers = commentLikeRepository.findLikersByCommentId(commentId, excludedUserIds);
 
-        Set<Long> friendIds = getAcceptedFriendIds(currentUserId);
+        Map<Long, FriendshipInfo> friendshipInfoMap = buildFriendshipInfoMap(likers, currentUserId);
         List<LikerResponse> responses = likers.stream()
-                .map(u -> new LikerResponse(
-                        u.getId(),
-                        profileImageUrlBuilder.buildUserProfileUrl(u),
-                        u.getNickname(),
-                        friendIds.contains(u.getId())
-                ))
+                .map(u -> toLikerResponse(u, friendshipInfoMap))
                 .toList();
 
         return new LikeListResponse(responses);
@@ -118,11 +110,32 @@ public class LikeQueryService {
         }
     }
 
-    private Set<Long> getAcceptedFriendIds(Long userId) {
-        return friendshipRepository.findByUserIdAndStatusWithUsers(userId, FriendshipStatus.ACCEPTED)
-                .stream()
-                .map(f -> f.getOtherUserId(userId))
-                .collect(Collectors.toSet());
+    private record FriendshipInfo(Long friendshipId, RelationshipStatus status) {}
+
+    private Map<Long, FriendshipInfo> buildFriendshipInfoMap(List<User> likers, Long currentUserId) {
+        if (likers.isEmpty()) return Map.of();
+        List<Long> likerIds = likers.stream().map(User::getId).toList();
+        List<Friendship> friendships = friendshipRepository.findByUserIdAndOtherUserIds(currentUserId, likerIds);
+        return friendships.stream().collect(Collectors.toMap(
+                f -> f.getOtherUserId(currentUserId),
+                f -> new FriendshipInfo(
+                        f.getId(),
+                        f.getStatus() == FriendshipStatus.ACCEPTED ? RelationshipStatus.FRIEND
+                                : f.isRequester(currentUserId) ? RelationshipStatus.REQUEST_SENT
+                                : RelationshipStatus.REQUEST_RECEIVED
+                )
+        ));
+    }
+
+    private LikerResponse toLikerResponse(User user, Map<Long, FriendshipInfo> friendshipInfoMap) {
+        FriendshipInfo info = friendshipInfoMap.get(user.getId());
+        return new LikerResponse(
+                user.getId(),
+                profileImageUrlBuilder.buildUserProfileUrl(user),
+                user.getNickname(),
+                info != null ? info.friendshipId() : null,
+                info != null ? info.status() : RelationshipStatus.NONE
+        );
     }
 
     private List<Long> getExcludedUserIds(Long userId) {


### PR DESCRIPTION
## 📝 요약(Summary)
기존 isFriend 필드를 제거하고 상태(FRIEND/REQUEST_SENT/REQUEST_RECEIVED/NONE)와 friendshipId를 내려줘서 프론트에서 친구 신청 취소 등 모든 친구 관계 액션을 별도 조회 없이 처리하도록 변경

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.