### PR TITLE
fix(social): 댓글 삭제 미반영 및 알림 이모지 깨짐 버그 수정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -115,7 +115,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("excludeUserIds") List<Long> excludeUserIds
     );
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         update Comment c
         set c.deletedAt = :now, c.updatedAt = :now

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
@@ -163,6 +163,8 @@ public class CommentNotificationEventListener {
 
     private String truncate(String content) {
         if (content == null) return "";
-        return content.length() > 20 ? content.substring(0, 20).stripTrailing() + "..." : content;
+        int[] codePoints = content.codePoints().toArray();
+        if (codePoints.length <= 20) return content;
+        return new String(codePoints, 0, 20).stripTrailing() + "...";
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
1. 댓글 삭제 미반영 버그
- 댓글 삭제 API 호출 시 대댓글만 삭제되고 댓글 본체는 미삭제, Modifying(clearAutomatically = true)가 bulk UPDATE 후 1차 캐시를 clear하면서 앞서 로딩한 comment 엔티티가 detached 상태로 전환되어 comment.softDelete() 호출이 무시됨
- 따라서 clearAutomatically = true 제거

2. 알림 내용 20자 분할 방법 수정
- truncate()가 String.length(), substring() 기반 동작이라 이모지가 20번째에 걸리면 버그가 날 수도 있어서 Unicode code point 단위
기반으로 수정

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.