### PR TITLE
fix(notify): 대댓글 알림 비밀 처리 및 차단 관계 수신자 오류 수정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
@@ -87,7 +87,9 @@ public class CommentCommandService {
                 parentCommentId,
                 parentComment.getAuthor().getId(),
                 reportOwnerId,
-                content
+                content,
+                finalIsSecret,
+                parentComment.isSecret()
         ));
 
         return subComment.getId();

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/SubCommentCreatedEvent.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/event/SubCommentCreatedEvent.java
@@ -14,4 +14,6 @@ public class SubCommentCreatedEvent {
     private final Long parentCommentAuthorId;
     private final Long reportOwnerId;
     private final String content;
+    private final boolean secret;
+    private final boolean parentSecret;
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/notification/application/event/social/CommentNotificationEventListener.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.notification.application.event.social;
 import com.devkor.ifive.nadab.domain.comment.application.event.CommentCreatedEvent;
 import com.devkor.ifive.nadab.domain.comment.application.event.SubCommentCreatedEvent;
 import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
+import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
 import com.devkor.ifive.nadab.domain.notification.application.NotificationCommandService;
 import com.devkor.ifive.nadab.domain.notification.core.entity.NotificationType;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class CommentNotificationEventListener {
 
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final UserBlockRepository userBlockRepository;
     private final NotificationMessageFactory messageFactory;
     private final NotificationCommandService notificationCommandService;
 
@@ -87,8 +90,12 @@ public class CommentNotificationEventListener {
                     "commentContent", truncate(event.getContent())
             );
 
-            // 1. 부모 댓글 작성자 알림 (author 제외, 역할 무관 최우선)
-            if (!event.getAuthorId().equals(event.getParentCommentAuthorId())) {
+            Set<Long> blockedByAuthor = Set.copyOf(
+                    userBlockRepository.findBlockedUserIdsBidirectional(event.getAuthorId()));
+
+            // 1. 부모 댓글 작성자 알림 (author 제외, 역할 무관 최우선,차단 관계이면 skip)
+            if (!event.getAuthorId().equals(event.getParentCommentAuthorId())
+                    && !blockedByAuthor.contains(event.getParentCommentAuthorId())) {
                 User parentCommentAuthor = userRepository.findById(event.getParentCommentAuthorId()).orElse(null);
                 if (parentCommentAuthor == null || parentCommentAuthor.getDeletedAt() != null) {
                     log.debug("Parent comment author not found or deleted, skip notification: parentCommentAuthorId={}", event.getParentCommentAuthorId());
@@ -141,20 +148,49 @@ public class CommentNotificationEventListener {
                 }
             }
 
-            NotificationContent participantContent = messageFactory.createMessage(
-                    NotificationType.REPLY_ON_PARTICIPATED_COMMENT, params);
-            for (Long participantId : participantIds) {
-                notificationCommandService.sendNotification(
-                        participantId,
-                        NotificationType.REPLY_ON_PARTICIPATED_COMMENT,
-                        participantContent.title(),
-                        participantContent.body(),
-                        participantContent.inboxMessage(),
-                        event.getDailyReportId().toString(),
-                        String.format("COMMENT_%d_PARTICIPANT_%d", event.getSubCommentId(), participantId)
-                );
+            // 4. 참여자 알림
+            if (!participantIds.isEmpty()) {
+                if (!event.isSecret() || event.isParentSecret()) {
+                    // 공개 대댓글 or 비밀 부모 아래 대댓글: 참여자들 열람 가능 — 차단 관계 제외
+                    List<Long> notifiableParticipantIds = participantIds.stream()
+                            .filter(id -> !blockedByAuthor.contains(id))
+                            .toList();
+                    if (!notifiableParticipantIds.isEmpty()) {
+                        NotificationContent participantContent = messageFactory.createMessage(
+                                NotificationType.REPLY_ON_PARTICIPATED_COMMENT, params);
+                        for (Long participantId : notifiableParticipantIds) {
+                            notificationCommandService.sendNotification(
+                                    participantId,
+                                    NotificationType.REPLY_ON_PARTICIPATED_COMMENT,
+                                    participantContent.title(),
+                                    participantContent.body(),
+                                    participantContent.inboxMessage(),
+                                    event.getDailyReportId().toString(),
+                                    String.format("COMMENT_%d_PARTICIPANT_%d", event.getSubCommentId(), participantId)
+                            );
+                        }
+                        log.debug("Sub-comment notifications sent: subCommentId={}, participantCount={}", event.getSubCommentId(), notifiableParticipantIds.size());
+                    }
+                } else if (reportOwnerIsParticipant && !reportOwnerIsAuthor
+                        && !blockedByAuthor.contains(event.getReportOwnerId())) {
+                    // 공개 부모 댓글에 달린 비밀 대댓글 : 일반 참여자는 열람 불가하지만 리포트 당사자는 가능
+                    User reportOwner = userRepository.findById(event.getReportOwnerId()).orElse(null);
+                    if (reportOwner != null && reportOwner.getDeletedAt() == null) {
+                        NotificationContent participantContent = messageFactory.createMessage(
+                                NotificationType.REPLY_ON_PARTICIPATED_COMMENT, params);
+                        notificationCommandService.sendNotification(
+                                event.getReportOwnerId(),
+                                NotificationType.REPLY_ON_PARTICIPATED_COMMENT,
+                                participantContent.title(),
+                                participantContent.body(),
+                                participantContent.inboxMessage(),
+                                event.getDailyReportId().toString(),
+                                String.format("COMMENT_%d_PARTICIPANT_%d", event.getSubCommentId(), event.getReportOwnerId())
+                        );
+                        log.debug("Sub-comment notification sent to report owner (participant): subCommentId={}", event.getSubCommentId());
+                    }
+                }
             }
-            log.debug("Sub-comment notifications sent: subCommentId={}, participantCount={}", event.getSubCommentId(), participantIds.size());
         } catch (Exception e) {
             log.error("Failed to handle SubCommentCreatedEvent: subCommentId={}, error={}",
                     event.getSubCommentId(), e.getMessage(), e);


### PR DESCRIPTION
## 📝 요약(Summary)
문제: 
1. 비밀 대댓글 내용이 열람 권한 없는 참여자에게 알림으로 노출
- 공개 부모 댓글 아래 비밀 대댓글 작성 시, 일반 참여자들은 FCM 푸시 알림으로 내용이 노출됨.
2. 참여자인 리포트 당사자가 비밀 대댓글 알림 미수신
- 공개 부모 댓글 스레드에 리포트 당사자가 대댓글을 쓴 이후(참여자 등록), 누군가 비밀 대댓글을 달면 리포트 당사자는 열람 권한이 있음에도 COMMENT_ON_MY_REPORT(참여자라 skip) + REPLY_ON_PARTICIPATED_COMMENT(비밀이라 루프 skip) 모두 발송되지 않음.
3. 차단 관계인 부모 댓글 작성자·참여자에게 알림 발송
- A가 B를 차단해도 둘 다 리포트 당사자 C의 친구이면 같은 스레드에 참여 가능. B가 새 대댓글 작성 시 A(부모 댓글 작성자 또는 참여자)는 B의 대댓글을 앱에서 볼 수 없지만 알림은 수신됨.

수정:
- SubCommentCreatedEvent에 isSecret, parentSecret 필드 추가
- CommentCommandService: 이벤트에 finalIsSecret, parentComment.isSecret() 전달
- CommentNotificationEventListener:
    - 부모 댓글 작성자 알림에 차단 관계 체크 추가
    - 참여자 루프: isSecret && !parentSecret이면 skip
    - 단, 리포트 당사자가 참여자인 경우 REPLY_ON_PARTICIPATED_COMMENT 별도 발송 (열람 가능)
    - 비밀 부모 대댓글은 참여자가 원래부터 권한자뿐이므로 루프 유지

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.