### PR TITLE
feat(report): 답변 상세 조회 응답에 dailyReportId 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/AnswerController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/AnswerController.java
@@ -99,6 +99,7 @@ public class AnswerController {
             description = """
                     답변 ID로 해당 답변의 상세 정보와 리포트를 조회합니다.
 
+                    - 일간 리포트 ID (dailyReportId, 리포트 없으면 null)
                     - 질문 내용 (questionText)
                     - 질문 카테고리 (interestCode)
                     - 답변 작성일 (answerDate)
@@ -206,6 +207,7 @@ public class AnswerController {
                     특정 날짜의 답변 전체 정보를 조회합니다.
 
                     응답 데이터:
+                    - 일간 리포트 ID (dailyReportId, 리포트 없으면 null)
                     - 질문 내용 (questionText)
                     - 질문 카테고리 (interestCode)
                     - 답변 작성일 (answerDate)

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/AnswerDetailResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/api/dto/response/AnswerDetailResponse.java
@@ -8,6 +8,9 @@ import java.time.LocalDate;
 @Schema(description = "답변 상세 조회 응답")
 public record AnswerDetailResponse(
 
+        @Schema(description = "일간 리포트 ID (댓글·좋아요 조회 시 사용)", example = "42")
+        Long dailyReportId,
+
         @Schema(description = "질문 내용", example = "오늘 가장 기뻤던 순간은?")
         String questionText,
 
@@ -31,6 +34,7 @@ public record AnswerDetailResponse(
 ) {
     public static AnswerDetailResponse from(AnswerDetailDto dto, String imageUrl) {
         return new AnswerDetailResponse(
+                dto.dailyReportId(),
                 dto.questionText(),
                 dto.interestCode() != null ? dto.interestCode().name() : null,
                 dto.answerDate(),

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/AnswerDetailDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/dto/AnswerDetailDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
  * Repository 쿼리 결과를 담는 DTO
  */
 public record AnswerDetailDto(
+        Long dailyReportId,
         String questionText,
         InterestCode interestCode,
         LocalDate answerDate,

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/AnswerEntryQueryRepository.java
@@ -108,7 +108,7 @@ public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long
      */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
-            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
+            dr.id, ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
         )
         from AnswerEntry ae
         left join DailyReport dr on dr.answerEntry = ae and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED
@@ -126,7 +126,7 @@ public interface AnswerEntryQueryRepository extends Repository<AnswerEntry, Long
      */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
-            ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
+            dr.id, ae.question.questionText, ae.question.interest.code, ae.date, ae.content, dr.content, e.code, ae.imageKey
         )
         from AnswerEntry ae
         left join DailyReport dr on dr.answerEntry = ae and dr.status = com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReportStatus.COMPLETED

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -44,6 +44,7 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
      */
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AnswerDetailDto(
+            dr.id,
             q.questionText,
             i.code,
             ae.date,


### PR DESCRIPTION
## 📝 요약(Summary)
캘린더·답변 상세 화면에서 댓글·좋아요 기능 진입 시 dailyReportId가 필요한데 기존 응답에 없어서 추가
  - GET /api/v1/answers/{answerId}
  - GET /api/v1/answers/calendar/{date}
  - GET /api/v1/daily-reports/{reportId}

## 🔗 Related Issue
- Closes: 

## 💬 공유사항
마지막 엔드포인트 GET /api/v1/daily-reports/{reportId}를 호출하려면 dailyreportId가 애초에 필요해서 사실 응답에 dailyReportId를 추가할 필요는 없지만 같은 DTO를 사용하기 때문에 중복 코드로 새 파일들을 만드는 것보다 기존 코드를 활용하는게 낫다고 생각해서 이런 식으로 구현했습니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.