### PR TITLE
fix(social): 댓글·좋아요 접근 제어, 신고 API 접근 제어에 오늘 공유 조건 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentCommandService.java
@@ -15,6 +15,7 @@ import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -103,7 +104,7 @@ public class CommentCommandService {
 
     private void checkCommentWriteAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
         if (currentUserId.equals(reportOwnerId)) return;
-        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
         long smallerId = Math.min(currentUserId, reportOwnerId);

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
@@ -16,6 +16,7 @@ import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -187,7 +188,7 @@ public class CommentQueryService {
 
     private void checkCommentViewAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
         if (currentUserId.equals(reportOwnerId)) return;
-        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
         long smallerId = Math.min(currentUserId, reportOwnerId);

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/core/repository/DailyReportRepository.java
@@ -164,7 +164,7 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
     @Query("select ae.user.id from DailyReport dr join dr.answerEntry ae where dr.id = :reportId")
     Optional<Long> findReportOwnerIdById(@Param("reportId") Long reportId);
 
-    boolean existsByIdAndIsSharedTrue(Long id);
+    boolean existsByIdAndIsSharedTrueAndDate(Long id, LocalDate date);
 
     @Query("""
         select new com.devkor.ifive.nadab.domain.dailyreport.core.dto.FeedDto(

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeCommandService.java
@@ -17,6 +17,7 @@ import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,7 +113,7 @@ public class LikeCommandService {
     }
 
     private void checkReportLikeAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
-        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
         long smallerId = Math.min(currentUserId, reportOwnerId);
@@ -124,7 +125,7 @@ public class LikeCommandService {
 
     private void checkCommentLikeAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
         if (currentUserId.equals(reportOwnerId)) return;
-        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
         long smallerId = Math.min(currentUserId, reportOwnerId);

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/application/LikeQueryService.java
@@ -19,6 +19,7 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -100,7 +101,7 @@ public class LikeQueryService {
 
     private void checkCommentViewAccess(Long dailyReportId, Long reportOwnerId, Long currentUserId) {
         if (currentUserId.equals(reportOwnerId)) return;
-        if (!dailyReportRepository.existsByIdAndIsSharedTrue(dailyReportId)) {
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
             throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
         }
         long smallerId = Math.min(currentUserId, reportOwnerId);

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/ModerationController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/api/ModerationController.java
@@ -70,6 +70,13 @@ public class ModerationController {
                     ),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
                     @ApiResponse(
+                            responseCode = "403",
+                            description = """
+                                    - ErrorCode: AUTH_ACCESS_DENIED - 신고 권한 없음 (친구가 아니거나, 오늘 공유된 게시글이 아님, 비밀 댓글 열람 권한 없음)
+                                    """,
+                            content = @Content
+                    ),
+                    @ApiResponse(
                             responseCode = "404",
                             description = """
                                     - ErrorCode: DAILY_REPORT_NOT_FOUND - 공유글을 찾을 수 없음

--- a/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/ContentReportCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/moderation/application/ContentReportCommandService.java
@@ -4,6 +4,7 @@ import com.devkor.ifive.nadab.domain.comment.core.entity.Comment;
 import com.devkor.ifive.nadab.domain.comment.core.repository.CommentRepository;
 import com.devkor.ifive.nadab.domain.dailyreport.core.entity.DailyReport;
 import com.devkor.ifive.nadab.domain.dailyreport.core.repository.DailyReportRepository;
+import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository;
 import com.devkor.ifive.nadab.domain.moderation.core.entity.ContentReport;
 import com.devkor.ifive.nadab.domain.moderation.core.entity.ReportReason;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.ContentReportRepository;
@@ -12,7 +13,9 @@ import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -27,6 +30,7 @@ public class ContentReportCommandService {
     private final DailyReportRepository dailyReportRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
     private final SharingSuspensionService sharingSuspensionService;
 
     public void reportContent(Long reporterId, Long dailyReportId, Long commentId,
@@ -74,6 +78,10 @@ public class ContentReportCommandService {
         if (reporterId.equals(reportedUser.getId())) {
             throw new BadRequestException(ErrorCode.CONTENT_REPORT_SELF_REPORT_FORBIDDEN);
         }
+
+        // 접근 권한 검증 (오늘 공유된 친구 리포트만 신고 가능, 본인 글은 early return)
+        checkReportAccess(dailyReportId, reportedUser.getId(), reporterId);
+
         return ContentReport.createForDailyReport(reporter, dailyReport, reportedUser, reason, customReason);
     }
 
@@ -95,7 +103,38 @@ public class ContentReportCommandService {
         if (reporterId.equals(reportedUser.getId())) {
             throw new BadRequestException(ErrorCode.CONTENT_REPORT_SELF_REPORT_FORBIDDEN);
         }
+
+        // 게시글 접근 권한 검증 (오늘 공유된 친구 리포트만 신고 가능, 본인 글은 early return)
+        Long dailyReportId = comment.getDailyReport().getId();
+        Long reportOwnerId = dailyReportRepository.findReportOwnerIdById(dailyReportId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DAILY_REPORT_NOT_FOUND));
+        checkReportAccess(dailyReportId, reportOwnerId, reporterId);
+
+        // 비밀 댓글은 열람 권한자만 신고 가능 (작성자는 자기 신고 방지로 이미 차단됨)
+        if (comment.isSecret()) {
+            boolean isParentAuthor = !comment.isTopLevel() &&
+                    commentRepository.findParentAuthorIdById(commentId)
+                            .map(id -> id.equals(reporterId))
+                            .orElse(false);
+            boolean canView = reportOwnerId.equals(reporterId) || isParentAuthor;
+            if (!canView) {
+                throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+            }
+        }
+
         return ContentReport.createForComment(reporter, comment, reportedUser, reason, customReason);
+    }
+
+    private void checkReportAccess(Long dailyReportId, Long reportOwnerId, Long reporterId) {
+        if (reporterId.equals(reportOwnerId)) return;
+        if (!dailyReportRepository.existsByIdAndIsSharedTrueAndDate(dailyReportId, TodayDateTimeProvider.getTodayDate())) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
+        long smallerId = Math.min(reporterId, reportOwnerId);
+        long largerId = Math.max(reporterId, reportOwnerId);
+        if (!friendshipRepository.existsAcceptedByUserIds(smallerId, largerId)) {
+            throw new ForbiddenException(ErrorCode.AUTH_ACCESS_DENIED);
+        }
     }
 
     private void validateTarget(Long dailyReportId, Long commentId) {


### PR DESCRIPTION
## 📝 요약(Summary)

### 문제
1. 기존 access check가 isShared=true만 검사해 친구가 어제 공유 후 끄지 않은 리포트는 dailyReportId 추측만으로 댓글·좋아요 진입이 가능하던 문제(웹에서는 URL에 dailyReportId가 노출되므로)
2. 신고 API에 access check가 없어 dailyReportId/commentId 추측만으로 임의 사용자 신고가 가능하던 어뷰징 경로 차단. 비밀 댓글은 본문 열람 권한자만 신고 가능하도록 체크하는 로직 부재

### 구현
- existsByIdAndIsSharedTrue → existsByIdAndIsSharedTrueAndDate 변경
- 호출처 5곳에 today 조건 적용:
    · CommentQueryService.checkCommentViewAccess
    · CommentCommandService.checkCommentWriteAccess
    · LikeQueryService.checkCommentViewAccess
    · LikeCommandService.checkReportLikeAccess, checkCommentLikeAccess
- 본인 리포트는 early return 유지 — 본인의 과거·비공유 글 댓글창 접근 보장

- ContentReportCommandService.checkReportAccess 헬퍼 신설: 본인 글 early return, 그 외 오늘 공유된 친구 리포트만 신고 가능
- 비밀 댓글 신고 시 추가 권한 체크 (리포트 소유자 또는 부모 댓글 작성자만 가능)
    · 자기 신고 방지가 위에서 작성자 본인을 차단하므로 실질 권한자는 owner·parentAuthor
- ModerationController Swagger 403 응답 명세 추가

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.