### PR TITLE
fix(social): 대댓글 카운트·좋아요 아이콘 노출 정합성 수정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/application/CommentQueryService.java
@@ -55,13 +55,13 @@ public class CommentQueryService {
         }
         Long nextCursor = hasNext ? comments.get(comments.size() - 1).getId() : null;
 
-        Map<Long, Long> subCountMap = buildSubCountMap(comments, excludedUserIds, currentUserId, reportOwnerId);
+        Map<Long, Long> subCountMap = buildSubCountMap(comments, excludedUserIds, currentUserId);
 
         List<Long> commentIds = comments.stream().map(Comment::getId).toList();
         Set<Long> likedCommentIds = commentIds.isEmpty() ? Set.of()
                 : new HashSet<>(commentLikeRepository.findLikedCommentIds(commentIds, currentUserId));
         Set<Long> commentIdsWithLikes = commentIds.isEmpty() ? Set.of()
-                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(commentIds));
+                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(commentIds, excludedUserIds));
 
         List<CommentResponse> responses = comments.stream()
                 .map(c -> {
@@ -127,7 +127,7 @@ public class CommentQueryService {
         Set<Long> likedSubCommentIds = subCommentIds.isEmpty() ? Set.of()
                 : new HashSet<>(commentLikeRepository.findLikedCommentIds(subCommentIds, currentUserId));
         Set<Long> subCommentIdsWithLikes = subCommentIds.isEmpty() ? Set.of()
-                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(subCommentIds));
+                : new HashSet<>(commentLikeRepository.findCommentIdsWithLikes(subCommentIds, excludedUserIds));
 
         List<CommentResponse> responses = subComments.stream()
                 .map(c -> {
@@ -157,31 +157,14 @@ public class CommentQueryService {
         return new CommentListResponse(responses, nextCursor, hasNext);
     }
 
-    private Map<Long, Long> buildSubCountMap(List<Comment> comments, List<Long> excludedUserIds,
-                                              Long currentUserId, Long reportOwnerId) {
+    private Map<Long, Long> buildSubCountMap(List<Comment> comments, List<Long> excludedUserIds, Long currentUserId) {
         if (comments.isEmpty()) {
             return Map.of();
         }
         List<Long> parentIds = comments.stream().map(Comment::getId).toList();
 
-        // 현재 사용자가 비밀 대댓글을 열람할 수 있는 부모 댓글 ID 목록
-        // - 리포트 소유자: 모든 부모 댓글의 비밀 대댓글 열람 가능
-        // - 그 외: 자신이 작성한 부모 댓글의 비밀 대댓글만 열람 가능
-        List<Long> visibleSecretParentIds;
-        if (currentUserId.equals(reportOwnerId)) {
-            visibleSecretParentIds = parentIds;
-        } else {
-            visibleSecretParentIds = comments.stream()
-                    .filter(c -> c.getAuthor().getId().equals(currentUserId))
-                    .map(Comment::getId)
-                    .toList();
-            if (visibleSecretParentIds.isEmpty()) {
-                visibleSecretParentIds = List.of(-1L);
-            }
-        }
-
         return commentRepository.countVisibleSubCommentsByParentIds(
-                        parentIds, excludedUserIds, currentUserId, visibleSecretParentIds)
+                        parentIds, excludedUserIds, currentUserId)
                 .stream()
                 .collect(Collectors.toMap(SubCommentCountDto::parentCommentId, SubCommentCountDto::count));
     }

--- a/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/comment/core/repository/CommentRepository.java
@@ -88,18 +88,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
               select 1 from ContentReport cr
               where cr.reporter.id = :currentUserId and cr.comment = c
           )
-          and (
-            c.secret = false
-            or c.author.id = :currentUserId
-            or c.parentComment.id in :visibleSecretParentIds
-          )
         group by c.parentComment.id
     """)
     List<SubCommentCountDto> countVisibleSubCommentsByParentIds(
             @Param("parentIds") List<Long> parentIds,
             @Param("excludedUserIds") List<Long> excludedUserIds,
-            @Param("currentUserId") Long currentUserId,
-            @Param("visibleSecretParentIds") List<Long> visibleSecretParentIds
+            @Param("currentUserId") Long currentUserId
     );
 
     @Query("""

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/FeedQueryService.java
@@ -11,6 +11,7 @@ import com.devkor.ifive.nadab.domain.friend.core.repository.FriendshipRepository
 import com.devkor.ifive.nadab.domain.like.core.repository.DailyReportLikeRepository;
 import com.devkor.ifive.nadab.domain.moderation.application.SharingSuspensionService;
 import com.devkor.ifive.nadab.domain.moderation.core.repository.ContentReportRepository;
+import com.devkor.ifive.nadab.domain.moderation.core.repository.UserBlockRepository;
 import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
 import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +38,7 @@ public class FeedQueryService {
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
     private final ContentReportRepository contentReportRepository;
     private final SharingSuspensionService sharingSuspensionService;
+    private final UserBlockRepository userBlockRepository;
 
     public FeedListResponse getFeeds(Long userId) {
         LocalDate today = TodayDateTimeProvider.getTodayDate();
@@ -97,7 +100,8 @@ public class FeedQueryService {
             reportIdsWithLikes = Set.of();
         } else {
             likedReportIds = new HashSet<>(dailyReportLikeRepository.findLikedReportIds(allReportIds, userId));
-            reportIdsWithLikes = new HashSet<>(dailyReportLikeRepository.findReportIdsWithLikes(allReportIds));
+            reportIdsWithLikes = new HashSet<>(
+                    dailyReportLikeRepository.findReportIdsWithLikes(allReportIds, getExcludedUserIds(userId)));
         }
 
         FeedResponse myReport = myFeedDto
@@ -133,6 +137,17 @@ public class FeedQueryService {
                 likedReportIds.contains(dto.dailyReportId()),
                 reportIdsWithLikes.contains(dto.dailyReportId())
         );
+    }
+
+    private List<Long> getExcludedUserIds(Long userId) {
+        List<Long> blocked = userBlockRepository.findBlockedUserIdsBidirectional(userId);
+        List<Long> suspended = sharingSuspensionService.getAllActiveSuspendedUserIds();
+
+        Set<Long> combined = new HashSet<>(blocked);
+        combined.addAll(suspended);
+        combined.remove(userId);
+
+        return combined.isEmpty() ? List.of(-1L) : new ArrayList<>(combined);
     }
 
     private String buildProfileUrl(String profileImageKey, DefaultProfileType defaultProfileType) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/CommentLikeRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/CommentLikeRepository.java
@@ -27,8 +27,13 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
             select distinct l.comment.id
             from CommentLike l
             where l.comment.id in :commentIds
+              and l.user.id not in :excludedUserIds
+              and l.user.deletedAt is null
             """)
-    List<Long> findCommentIdsWithLikes(@Param("commentIds") List<Long> commentIds);
+    List<Long> findCommentIdsWithLikes(
+            @Param("commentIds") List<Long> commentIds,
+            @Param("excludedUserIds") List<Long> excludedUserIds
+    );
 
     @Query("""
             select l.user

--- a/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/DailyReportLikeRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/like/core/repository/DailyReportLikeRepository.java
@@ -27,8 +27,13 @@ public interface DailyReportLikeRepository extends JpaRepository<DailyReportLike
             select distinct l.dailyReport.id
             from DailyReportLike l
             where l.dailyReport.id in :reportIds
+              and l.user.id not in :excludedUserIds
+              and l.user.deletedAt is null
             """)
-    List<Long> findReportIdsWithLikes(@Param("reportIds") List<Long> reportIds);
+    List<Long> findReportIdsWithLikes(
+            @Param("reportIds") List<Long> reportIds,
+            @Param("excludedUserIds") List<Long> excludedUserIds
+    );
 
     @Query("""
             select l.user


### PR DESCRIPTION
## 📝 요약(Summary)
"답글 N개 더보기"의 N과 펼친 결과 개수 불일치
좋아요 아이콘 상태(hasLikes)와 좋아요 리스트 결과 불일치 두 케이스 수정

1. visibleSubCommentCount ↔ 대댓글 목록 불일치
- 공개 부모 아래 비밀 대댓글이 카운트에서 빠지지만 목록에는 마스킹된 채로 노출되던 문제
- 카운트 쿼리(countVisibleSubCommentsByParentIds)에서 비밀 필터 절 제거
- 마스킹되어 노출되는 비밀 대댓글까지 카운트에 포함시켜 "펼친 결과 개수 = 카운트"로 정렬
- CommentQueryService.buildSubCountMap의 visibleSecretParentIds 계산 로직 제거

2. hasLikes ↔ 좋아요 리스트 불일치
- 차단·정지·탈퇴 사용자의 좋아요가 hasLikes에는 카운트되지만 좋아요 리스트에서는 빠져, 아이콘은 채워졌는데 펼치면 빈 리스트가 보이던 문제 (게시글·댓글·대댓글 전부 해당)
- findReportIdsWithLikes / findCommentIdsWithLikes에 user.id not in :excludedUserIds + user.deletedAt is null 필터 추가
- FeedQueryService에 getExcludedUserIds 헬퍼 + UserBlockRepository 주입 추가 (CommentQueryService·LikeQueryService와 동일 패턴)

## 🔗 Related Issue
- Closes: 

## 💬 공유사항

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.