### PR TITLE
feat: 개발용 테스트 계정 생성 API 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -148,6 +148,7 @@ jobs:
             GOOGLE_GENAI_API_KEY="${{ secrets.GOOGLE_GENAI_API_KEY }}" \
             FIREBASE_ADMIN_KEY="${{ secrets.FIREBASE_ADMIN_KEY }}" \
             ADMIN_PAGE_PASSWORD="${{ secrets.ADMIN_PAGE_PASSWORD }}" \
+            DEV_TEST_ACCOUNT_PASSWORD="${{ secrets.DEV_TEST_ACCOUNT_PASSWORD }}" \
             nohup java -jar "$JAR_PATH" \
               --spring.profiles.active=dev > app.log 2>&1 &
             

--- a/src/main/java/com/devkor/ifive/nadab/domain/test/api/TestController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/api/TestController.java
@@ -1,11 +1,14 @@
 package com.devkor.ifive.nadab.domain.test.api;
 
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.DailyReportResponse;
+import com.devkor.ifive.nadab.domain.test.api.dto.request.CreateTestUserRequest;
 import com.devkor.ifive.nadab.domain.test.api.dto.request.PromptTestDailyReportRequest;
 import com.devkor.ifive.nadab.domain.test.api.dto.request.TestDailyReportRequest;
 import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateDailyReportResponse;
+import com.devkor.ifive.nadab.domain.test.api.dto.response.CreateTestUserResponse;
 import com.devkor.ifive.nadab.domain.test.api.dto.response.TestDailyReportResponse;
 import com.devkor.ifive.nadab.domain.test.application.TestReportService;
+import com.devkor.ifive.nadab.domain.test.application.TestUserService;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
 import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
@@ -33,6 +36,17 @@ import org.springframework.web.bind.annotation.*;
 public class TestController {
 
     private final TestReportService testReportService;
+    private final TestUserService testUserService;
+
+    @Hidden
+    @PostMapping("/users")
+    @PermitAll
+    public ResponseEntity<ApiResponseDto<CreateTestUserResponse>> createTestUser(
+            @Valid @RequestBody CreateTestUserRequest request
+    ) {
+        CreateTestUserResponse response = testUserService.createTestUser(request);
+        return ApiResponseEntity.ok(response);
+    }
 
     @PostMapping("/generate/daily-report")
     @PermitAll

--- a/src/main/java/com/devkor/ifive/nadab/domain/test/api/dto/request/CreateTestUserRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/api/dto/request/CreateTestUserRequest.java
@@ -1,0 +1,16 @@
+package com.devkor.ifive.nadab.domain.test.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateTestUserRequest(
+        @NotBlank(message = "email is required")
+        @Email(message = "email format is invalid")
+        String email,
+
+        @NotBlank(message = "nickname is required")
+        @Size(min = 2, max = 10, message = "nickname must be between 2 and 10 characters")
+        String nickname
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/test/api/dto/response/CreateTestUserResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/api/dto/response/CreateTestUserResponse.java
@@ -1,0 +1,9 @@
+package com.devkor.ifive.nadab.domain.test.api.dto.response;
+
+public record CreateTestUserResponse(
+        Long userId,
+        String email,
+        String nickname,
+        String signupStatus
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestUserService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestUserService.java
@@ -1,0 +1,62 @@
+package com.devkor.ifive.nadab.domain.test.application;
+
+import com.devkor.ifive.nadab.domain.terms.application.TermsCommandService;
+import com.devkor.ifive.nadab.domain.test.api.dto.request.CreateTestUserRequest;
+import com.devkor.ifive.nadab.domain.test.api.dto.response.CreateTestUserResponse;
+import com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.UserProfileUpdateService;
+import com.devkor.ifive.nadab.domain.wallet.core.entity.UserWallet;
+import com.devkor.ifive.nadab.domain.wallet.core.repository.UserWalletRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile({"local", "dev"})
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TestUserService {
+
+    private final UserRepository userRepository;
+    private final UserWalletRepository userWalletRepository;
+    private final UserProfileUpdateService userProfileUpdateService;
+    private final TermsCommandService termsCommandService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${test.account.password:}")
+    private String testUserPassword;
+
+    public CreateTestUserResponse createTestUser(CreateTestUserRequest request) {
+        if (testUserPassword == null || testUserPassword.isBlank()) {
+            throw new BadRequestException(ErrorCode.TEST_USER_PASSWORD_NOT_CONFIGURED);
+        }
+        if (userRepository.existsByEmail(request.email())) {
+            throw new ConflictException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        String passwordHash = passwordEncoder.encode(testUserPassword);
+        User user = User.createUser(request.email(), passwordHash);
+        userRepository.save(user);
+
+        userProfileUpdateService.updateNickname(user, request.nickname());
+        user.updateSignupStatus(SignupStatusType.COMPLETED);
+
+        userWalletRepository.save(UserWallet.create(user));
+        termsCommandService.saveConsents(user.getId(), true, true, true, false);
+
+        return new CreateTestUserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getSignupStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
     FILE_STORAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "스토리지에서 해당 파일을 찾을 수 없습니다"), // S3 등 스토리지에 실제 파일 객체가 없는 경우
+    TEST_USER_PASSWORD_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "테스트 계정 비밀번호가 설정되지 않았습니다"),
 
     // ==================== AUTH (인증) ====================
     // 400 Bad Request

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -48,6 +48,10 @@ profile-image:
   env: dev
   base-url: ${PROFILE_IMAGE_BASE_URL}
 
+test:
+  account:
+    password: ${DEV_TEST_ACCOUNT_PASSWORD:}
+
 app:
   cookie:
     secure: true


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 개발 서버 전용 테스트 계정 생성 API를 추가했습니다.
- `POST /api/v1/test/users` 요청으로 이메일과 닉네임을 받아 테스트 계정을 생성합니다.
- 비밀번호는 `DEV_TEST_ACCOUNT_PASSWORD` 환경변수 값을 사용합니다.
- 생성 시 사용자, 지갑, 약관 동의 데이터를 함께 초기화합니다.
- Swagger 문서에는 노출되지 않도록 `@Hidden`을 적용했습니다.

Postman에서 이렇게 호출하면 됩니다.
Headers 설정 -  Content-Type: application/json
Body 설정 - Postman에서 Body → raw → JSON 선택 후:
```
{
  "email": "tester1@example.com",
  "nickname": "테스터1"
}
```

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.