### PR TITLE
fix: 테스트용 월간 리포트 테스트 삭제 API의 V1 fallback 처리 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestReportService.java
@@ -44,6 +44,8 @@ import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class TestReportService {
@@ -211,8 +213,13 @@ public class TestReportService {
 
         MonthRangeDto range = MonthRangeCalculator.getLastMonthRange();
 
-        MonthlyReportV2 report = monthlyReportV2Repository.findByUserIdAndMonthStartDate(user.getId(), range.monthStartDate())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.MONTHLY_REPORT_NOT_FOUND));
+        Optional<MonthlyReportV2> reportV2 = monthlyReportV2Repository.findByUserIdAndMonthStartDate(user.getId(), range.monthStartDate());
+        if (reportV2.isEmpty()) {
+            deleteMonthMonthlyReportV1(user.getEmail());
+            return;
+        }
+
+        MonthlyReportV2 report = reportV2.get();
 
         if (report.getStatus() != MonthlyReportStatus.COMPLETED) {
             throw new BadRequestException(ErrorCode.MONTHLY_REPORT_NOT_COMPLETED);


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 작업 내용

- `/api/v1/test/delete/monthly-report` 호출 시 V2 월간 리포트를 우선 조회하도록 기존 동작을 유지했습니다.
- V2 월간 리포트가 존재하지 않는 경우, 기존 V1 월간 리포트 삭제 로직을 호출하도록 fallback 처리를 추가했습니다.
- V2가 존재하는 경우에는 기존 V2 삭제 및 크리스탈 환불 흐름을 그대로 사용합니다.

## 변경 이유

기존에는 `/api/v1/test/delete/monthly-report`에서 V2 월간 리포트만 조회하고 삭제했기 때문에, V1이 존재하는 사용자의 월간 리포트는 삭제할 수 없었습니다.


## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.