### PR TITLE
fix(infra): 운영 CORS 허용 origin 추가

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -117,6 +117,7 @@ jobs:
             DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             JWT_SECRET="${{ secrets.JWT_SECRET }}" \
             FRONTEND_PROD_URL="${{ secrets.FRONTEND_PROD_URL }}" \
+            FRONTEND_PROD_URL_2="${{ secrets.FRONTEND_PROD_URL_2 }}" \
             NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
             NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
             NAVER_REDIRECT_URI="${{ secrets.NAVER_REDIRECT_URI }}" \

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -55,3 +55,4 @@ app:
 cors:
   allowed-origins:
     - ${FRONTEND_PROD_URL}
+    - ${FRONTEND_PROD_URL_2}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 배경

운영 `/admin/login`에서 `/admin/api/login` 요청이 `Invalid CORS request`로 403 응답을 반환하는 문제가 있었습니다. 브라우저가 보내는 `Origin` 값이 기존 `FRONTEND_PROD_URL`과 달라 운영 CORS 허용 목록에 포함되지 않아 발생한 문제로 확인했습니다.

- prod 프로필의 CORS 허용 origin에 `FRONTEND_PROD_URL_2` 추가
- 운영 배포 워크플로에서 `FRONTEND_PROD_URL_2` 환경 변수 주입 추가

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.