### PR TITLE
fix(user): 테스트 사용자 온보딩 기본값 보완

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestUserService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/test/application/TestUserService.java
@@ -3,9 +3,11 @@ package com.devkor.ifive.nadab.domain.test.application;
 import com.devkor.ifive.nadab.domain.terms.application.TermsCommandService;
 import com.devkor.ifive.nadab.domain.test.api.dto.request.CreateTestUserRequest;
 import com.devkor.ifive.nadab.domain.test.api.dto.response.CreateTestUserResponse;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
 import com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.UserInterestService;
 import com.devkor.ifive.nadab.domain.user.core.service.UserProfileUpdateService;
 import com.devkor.ifive.nadab.domain.wallet.core.entity.UserWallet;
 import com.devkor.ifive.nadab.domain.wallet.core.repository.UserWalletRepository;
@@ -25,9 +27,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TestUserService {
 
+    private static final long DEFAULT_CRYSTAL_BALANCE = 1_000L;
+
     private final UserRepository userRepository;
     private final UserWalletRepository userWalletRepository;
     private final UserProfileUpdateService userProfileUpdateService;
+    private final UserInterestService userInterestService;
     private final TermsCommandService termsCommandService;
     private final PasswordEncoder passwordEncoder;
 
@@ -47,9 +52,10 @@ public class TestUserService {
         userRepository.save(user);
 
         userProfileUpdateService.updateNickname(user, request.nickname());
+        userInterestService.updateUserInterest(user, InterestCode.PREFERENCE);
         user.updateSignupStatus(SignupStatusType.COMPLETED);
 
-        userWalletRepository.save(UserWallet.create(user));
+        userWalletRepository.save(UserWallet.create(user, DEFAULT_CRYSTAL_BALANCE));
         termsCommandService.saveConsents(user.getId(), true, true, true, false);
 
         return new CreateTestUserResponse(

--- a/src/main/java/com/devkor/ifive/nadab/domain/wallet/core/entity/UserWallet.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/wallet/core/entity/UserWallet.java
@@ -34,9 +34,13 @@ public class UserWallet extends AuditableEntity {
     private long version;
 
     public static UserWallet create(User user) {
+        return create(user, 0L);
+    }
+
+    public static UserWallet create(User user, long initialCrystalBalance) {
         UserWallet wallet = new UserWallet();
         wallet.user = user;
-        wallet.crystalBalance = 0L;
+        wallet.crystalBalance = initialCrystalBalance;
         return wallet;
     }
 }

--- a/src/test/java/com/devkor/ifive/nadab/domain/test/application/TestUserServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/test/application/TestUserServiceTest.java
@@ -1,0 +1,84 @@
+package com.devkor.ifive.nadab.domain.test.application;
+
+import com.devkor.ifive.nadab.domain.terms.application.TermsCommandService;
+import com.devkor.ifive.nadab.domain.test.api.dto.request.CreateTestUserRequest;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.domain.user.core.entity.SignupStatusType;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.UserInterestService;
+import com.devkor.ifive.nadab.domain.user.core.service.UserProfileUpdateService;
+import com.devkor.ifive.nadab.domain.wallet.core.entity.UserWallet;
+import com.devkor.ifive.nadab.domain.wallet.core.repository.UserWalletRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestUserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserWalletRepository userWalletRepository;
+    @Mock
+    private UserProfileUpdateService userProfileUpdateService;
+    @Mock
+    private UserInterestService userInterestService;
+    @Mock
+    private TermsCommandService termsCommandService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private TestUserService testUserService;
+
+    @BeforeEach
+    void setUp() {
+        testUserService = new TestUserService(
+                userRepository,
+                userWalletRepository,
+                userProfileUpdateService,
+                userInterestService,
+                termsCommandService,
+                passwordEncoder
+        );
+        ReflectionTestUtils.setField(testUserService, "testUserPassword", "test-password");
+    }
+
+    @Test
+    void createTestUser_sets_terms_interest_and_default_crystals() {
+        CreateTestUserRequest request = new CreateTestUserRequest(
+                "test@example.com",
+                "tester"
+        );
+        when(passwordEncoder.encode("test-password")).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", 1L);
+            return user;
+        });
+
+        var response = testUserService.createTestUser(request);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userInterestService).updateUserInterest(userCaptor.capture(), eq(InterestCode.PREFERENCE));
+        verify(termsCommandService).saveConsents(1L, true, true, true, false);
+
+        ArgumentCaptor<UserWallet> walletCaptor = ArgumentCaptor.forClass(UserWallet.class);
+        verify(userWalletRepository).save(walletCaptor.capture());
+        assertThat(walletCaptor.getValue().getCrystalBalance()).isEqualTo(1_000L);
+        assertThat(userCaptor.getValue().getSignupStatus()).isEqualTo(SignupStatusType.COMPLETED);
+        assertThat(response.signupStatus()).isEqualTo(SignupStatusType.COMPLETED.name());
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

테스트 사용자 생성 API가 별도의 온보딩 과정 없이 바로 사용 가능한 계정을 생성하도록 기본 데이터를 보완했습니다.

- 관심 주제를 `PREFERENCE`로 고정
- 초기 크리스탈 1,000 지급
- 일반 사용자 지갑의 초기 잔액 0 유지
- 테스트 사용자 생성 동작에 대한 단위 테스트 추가

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.