### PR TITLE
feat(admin): 앱 버전 수정 및 히스토리 조회 기능 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminPageController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminPageController.java
@@ -20,4 +20,9 @@ public class AdminPageController {
     public String adminVersionPage() {
         return "admin/version";
     }
+
+    @GetMapping("/admin/tabs/app-version-history")
+    public String adminVersionHistoryPage() {
+        return "admin/version-history";
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminVersionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminVersionController.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.admin.api;
 import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionCreateRequest;
 import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionItemUpsertRequest;
 import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionSummaryUpdateRequest;
+import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionUpdateRequest;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminLatestVersionsResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionCreateResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionItemCreateResponse;
@@ -53,6 +54,15 @@ public class AdminVersionController {
             @RequestBody @Valid AdminVersionSummaryUpdateRequest request
     ) {
         adminVersionCommandService.updateSummary(appVersionId, request.summary());
+        return ApiResponseEntity.noContent();
+    }
+
+    @PutMapping("/{appVersionId}/version")
+    public ResponseEntity<ApiResponseDto<Void>> updateVersion(
+            @PathVariable Long appVersionId,
+            @RequestBody @Valid AdminVersionUpdateRequest request
+    ) {
+        adminVersionCommandService.updateVersion(appVersionId, request.version());
         return ApiResponseEntity.noContent();
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminVersionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/AdminVersionController.java
@@ -5,8 +5,10 @@ import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionItemUpser
 import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionSummaryUpdateRequest;
 import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionUpdateRequest;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminLatestVersionsResponse;
+import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionHistoryResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionCreateResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionItemCreateResponse;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
 import com.devkor.ifive.nadab.domain.admin.application.AdminVersionCommandService;
 import com.devkor.ifive.nadab.domain.admin.application.AdminVersionItemCommandService;
 import com.devkor.ifive.nadab.domain.admin.application.AdminVersionQueryService;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Hidden
@@ -38,6 +41,13 @@ public class AdminVersionController {
     @GetMapping("/latest")
     public ResponseEntity<ApiResponseDto<AdminLatestVersionsResponse>> getLatestVersions() {
         return ApiResponseEntity.ok(adminVersionQueryService.getLatestVersions());
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponseDto<AdminVersionHistoryResponse>> getVersionHistory(
+            @RequestParam(required = false) AppPlatform platform
+    ) {
+        return ApiResponseEntity.ok(adminVersionQueryService.getVersionHistory(platform));
     }
 
     @PostMapping

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/request/AdminVersionCreateRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/request/AdminVersionCreateRequest.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.admin.api.dto.request;
 import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record AdminVersionCreateRequest(
@@ -11,6 +12,7 @@ public record AdminVersionCreateRequest(
 
         @NotBlank(message = "버전은 필수입니다.")
         @Size(max = 30, message = "버전은 30자 이하여야 합니다.")
+        @Pattern(regexp = "\\d+\\.\\d+\\.\\d+", message = "Version must use major.minor.patch format.")
         String version,
 
         @NotNull(message = "요약은 null일 수 없습니다.")

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/request/AdminVersionUpdateRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/request/AdminVersionUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.domain.admin.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AdminVersionUpdateRequest(
+        @NotBlank(message = "Version is required.")
+        @Size(max = 30, message = "Version must be 30 characters or less.")
+        @Pattern(regexp = "\\d+\\.\\d+\\.\\d+", message = "Version must use major.minor.patch format.")
+        String version
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/response/AdminVersionHistoryItemResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/response/AdminVersionHistoryItemResponse.java
@@ -1,0 +1,18 @@
+package com.devkor.ifive.nadab.domain.admin.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record AdminVersionHistoryItemResponse(
+        Long id,
+        AppPlatform platform,
+        String version,
+        Boolean isLatest,
+        String summary,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt,
+        List<AdminVersionItemResponse> items
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/response/AdminVersionHistoryResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/api/dto/response/AdminVersionHistoryResponse.java
@@ -1,0 +1,8 @@
+package com.devkor.ifive.nadab.domain.admin.api.dto.response;
+
+import java.util.List;
+
+public record AdminVersionHistoryResponse(
+        List<AdminVersionHistoryItemResponse> versions
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionCommandService.java
@@ -4,6 +4,7 @@ import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionCreateReq
 import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersion;
 import com.devkor.ifive.nadab.domain.appversion.core.repository.AppVersionRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,17 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AdminVersionCommandService {
+
+    private static final Pattern SEMANTIC_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
 
     private final AppVersionRepository appVersionRepository;
 
@@ -22,6 +30,12 @@ public class AdminVersionCommandService {
         if (appVersionRepository.existsByPlatformAndVersion(request.platform(), request.version())) {
             throw new ConflictException(ErrorCode.APP_VERSION_ALREADY_EXISTS);
         }
+
+        SemanticVersion newVersion = SemanticVersion.parse(request.version());
+        validateVersionGreaterThanOtherVersions(
+                newVersion,
+                appVersionRepository.findByPlatform(request.platform())
+        );
 
         appVersionRepository.findByPlatformAndIsLatestTrue(request.platform())
                 .ifPresent(AppVersion::markAsNotLatest);
@@ -44,5 +58,74 @@ public class AdminVersionCommandService {
         AppVersion appVersion = appVersionRepository.findById(appVersionId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.APP_VERSION_NOT_FOUND));
         appVersion.updateSummary(summary);
+    }
+
+    public void updateVersion(Long appVersionId, String version) {
+        AppVersion appVersion = appVersionRepository.findById(appVersionId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.APP_VERSION_NOT_FOUND));
+
+        if (appVersionRepository.existsByPlatformAndVersionAndIdNot(
+                appVersion.getPlatform(), version, appVersionId
+        )) {
+            throw new ConflictException(ErrorCode.APP_VERSION_ALREADY_EXISTS);
+        }
+
+        SemanticVersion newVersion = SemanticVersion.parse(version);
+        validateVersionGreaterThanOtherVersions(
+                newVersion,
+                appVersionRepository.findByPlatformAndIdNot(appVersion.getPlatform(), appVersionId)
+        );
+
+        try {
+            appVersion.updateVersion(version);
+            appVersionRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new ConflictException(ErrorCode.APP_VERSION_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateVersionGreaterThanOtherVersions(
+            SemanticVersion newVersion,
+            List<AppVersion> otherAppVersions
+    ) {
+        otherAppVersions.stream()
+                .map(versionEntity -> SemanticVersion.parse(versionEntity.getVersion()))
+                .max(Comparator.naturalOrder())
+                .filter(maxVersion -> newVersion.compareTo(maxVersion) <= 0)
+                .ifPresent(maxVersion -> {
+                    throw new ConflictException(ErrorCode.APP_VERSION_MUST_BE_GREATER_THAN_EXISTING);
+                });
+    }
+
+    private record SemanticVersion(BigInteger major, BigInteger minor, BigInteger patch)
+            implements Comparable<SemanticVersion> {
+
+        private static SemanticVersion parse(String version) {
+            if (!SEMANTIC_VERSION_PATTERN.matcher(version).matches()) {
+                throw new BadRequestException(ErrorCode.APP_VERSION_INVALID_FORMAT);
+            }
+
+            String[] parts = version.split("\\.");
+            return new SemanticVersion(
+                    new BigInteger(parts[0]),
+                    new BigInteger(parts[1]),
+                    new BigInteger(parts[2])
+            );
+        }
+
+        @Override
+        public int compareTo(SemanticVersion other) {
+            int majorComparison = major.compareTo(other.major);
+            if (majorComparison != 0) {
+                return majorComparison;
+            }
+
+            int minorComparison = minor.compareTo(other.minor);
+            if (minorComparison != 0) {
+                return minorComparison;
+            }
+
+            return patch.compareTo(other.patch);
+        }
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionQueryService.java
@@ -1,8 +1,11 @@
 package com.devkor.ifive.nadab.domain.admin.application;
 
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminLatestVersionsResponse;
+import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionHistoryItemResponse;
+import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionHistoryResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionItemResponse;
 import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionResponse;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
 import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersion;
 import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersionItem;
 import com.devkor.ifive.nadab.domain.appversion.core.repository.AppVersionItemRepository;
@@ -60,5 +63,47 @@ public class AdminVersionQueryService {
                 .toList();
 
         return new AdminLatestVersionsResponse(versions);
+    }
+
+    public AdminVersionHistoryResponse getVersionHistory(AppPlatform platform) {
+        List<AppVersion> appVersions = platform == null
+                ? appVersionRepository.findAllByOrderByCreatedAtDescIdDesc()
+                : appVersionRepository.findByPlatformOrderByCreatedAtDescIdDesc(platform);
+        List<Long> appVersionIds = appVersions.stream()
+                .map(AppVersion::getId)
+                .toList();
+
+        List<AppVersionItem> items = appVersionIds.isEmpty()
+                ? List.of()
+                : appVersionItemRepository.findByAppVersionIdInOrderByDisplayOrderAsc(appVersionIds);
+
+        Map<Long, List<AdminVersionItemResponse>> itemsByVersionId = items.stream()
+                .collect(Collectors.groupingBy(
+                        item -> item.getAppVersion().getId(),
+                        Collectors.mapping(
+                                item -> new AdminVersionItemResponse(
+                                        item.getId(),
+                                        item.getTitle(),
+                                        item.getDescription(),
+                                        item.getDisplayOrder()
+                                ),
+                                Collectors.toList()
+                        )
+                ));
+
+        List<AdminVersionHistoryItemResponse> versions = appVersions.stream()
+                .map(version -> new AdminVersionHistoryItemResponse(
+                        version.getId(),
+                        version.getPlatform(),
+                        version.getVersion(),
+                        version.getIsLatest(),
+                        version.getSummary(),
+                        version.getCreatedAt(),
+                        version.getUpdatedAt(),
+                        itemsByVersionId.getOrDefault(version.getId(), List.of())
+                ))
+                .toList();
+
+        return new AdminVersionHistoryResponse(versions);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/entity/AppVersion.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/entity/AppVersion.java
@@ -56,4 +56,8 @@ public class AppVersion extends AuditableEntity {
     public void updateSummary(String summary) {
         this.summary = summary;
     }
+
+    public void updateVersion(String version) {
+        this.version = version;
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/repository/AppVersionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/repository/AppVersionRepository.java
@@ -19,4 +19,8 @@ public interface AppVersionRepository extends JpaRepository<AppVersion, Long> {
     List<AppVersion> findByPlatform(AppPlatform platform);
 
     List<AppVersion> findByPlatformAndIdNot(AppPlatform platform, Long id);
+
+    List<AppVersion> findAllByOrderByCreatedAtDescIdDesc();
+
+    List<AppVersion> findByPlatformOrderByCreatedAtDescIdDesc(AppPlatform platform);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/repository/AppVersionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/appversion/core/repository/AppVersionRepository.java
@@ -13,4 +13,10 @@ public interface AppVersionRepository extends JpaRepository<AppVersion, Long> {
     Optional<AppVersion> findByPlatformAndIsLatestTrue(AppPlatform platform);
 
     boolean existsByPlatformAndVersion(AppPlatform platform, String version);
+
+    boolean existsByPlatformAndVersionAndIdNot(AppPlatform platform, String version, Long id);
+
+    List<AppVersion> findByPlatform(AppPlatform platform);
+
+    List<AppVersion> findByPlatformAndIdNot(AppPlatform platform, Long id);
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -432,8 +432,12 @@ public enum ErrorCode {
     APP_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "앱 버전을 찾을 수 없습니다"),
     APP_VERSION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "앱 버전 항목을 찾을 수 없습니다"),
 
+    // 400 Bad Request
+    APP_VERSION_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "앱 버전은 major.minor.patch 형식이어야 합니다"),
+
     // 409 Conflict
     APP_VERSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 플랫폼의 같은 버전이 이미 존재합니다"),
+    APP_VERSION_MUST_BE_GREATER_THAN_EXISTING(HttpStatus.CONFLICT, "앱 버전은 같은 플랫폼의 다른 모든 버전보다 높아야 합니다"),
     APP_VERSION_ITEM_DISPLAY_ORDER_DUPLICATED(HttpStatus.CONFLICT, "같은 버전 내 displayOrder가 중복됩니다"),
 
     // ==================== ADMIN (어드민) ====================

--- a/src/main/resources/templates/admin/version-history.html
+++ b/src/main/resources/templates/admin/version-history.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>NADAB Admin Version History</title>
+    <style>
+        :root {
+            --bg: #10141b;
+            --surface: #181e28;
+            --surface-2: #202837;
+            --border: #2e3748;
+            --text: #e8edf8;
+            --muted: #9ca5bc;
+            --primary: #4b8bff;
+            --success: #4caf7d;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        .page {
+            max-width: 1180px;
+            margin: 0 auto;
+            display: grid;
+            gap: 16px;
+        }
+
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .title {
+            margin: 0;
+            font-size: 22px;
+        }
+
+        .tabs {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .tab-link {
+            text-decoration: none;
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 8px 10px;
+            font-size: 13px;
+            background: var(--surface-2);
+        }
+
+        .tab-link.active {
+            border-color: var(--primary);
+            background: rgba(75, 139, 255, 0.2);
+        }
+
+        .panel {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .panel-title {
+            margin: 0;
+            font-size: 16px;
+            color: var(--muted);
+        }
+
+        .panel-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .toolbar {
+            display: grid;
+            grid-template-columns: minmax(180px, 240px) auto;
+            gap: 10px;
+            align-items: end;
+        }
+
+        .field-label {
+            display: block;
+            margin-bottom: 6px;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        select {
+            width: 100%;
+            background: #121823;
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 8px 10px;
+            font-size: 13px;
+        }
+
+        .btn-row {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            text-decoration: none;
+            border: 0;
+            border-radius: 6px;
+            padding: 8px 12px;
+            font-size: 13px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .btn-primary { background: var(--primary); color: #fff; }
+        .btn-ghost { background: var(--surface-2); color: var(--text); }
+
+        .history-table-wrap {
+            overflow-x: auto;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+        }
+
+        .history-table {
+            width: 100%;
+            min-width: 980px;
+            border-collapse: collapse;
+        }
+
+        .history-table th,
+        .history-table td {
+            border-bottom: 1px solid var(--border);
+            padding: 10px;
+            vertical-align: top;
+            font-size: 12px;
+            text-align: left;
+        }
+
+        .history-table th {
+            color: var(--muted);
+            font-weight: 700;
+            background: #121823;
+        }
+
+        .history-table tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .summary-cell {
+            max-width: 260px;
+            line-height: 1.45;
+            white-space: pre-wrap;
+        }
+
+        .items-cell {
+            min-width: 240px;
+        }
+
+        .items-list {
+            margin: 0;
+            padding-left: 16px;
+            display: grid;
+            gap: 6px;
+        }
+
+        .item-title {
+            color: var(--text);
+            font-weight: 700;
+        }
+
+        .item-description {
+            color: var(--muted);
+            margin-top: 2px;
+            line-height: 1.4;
+            white-space: pre-wrap;
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 3px 8px;
+            font-size: 12px;
+            color: var(--muted);
+            background: var(--surface-2);
+        }
+
+        .badge-latest {
+            border-color: var(--success);
+            color: #dff6ea;
+            background: rgba(76, 175, 125, 0.18);
+        }
+
+        .empty {
+            color: var(--muted);
+            font-size: 13px;
+            padding: 8px 0;
+        }
+
+        .popup-backdrop {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.55);
+            z-index: 9999;
+            padding: 16px;
+        }
+
+        .popup-backdrop.open {
+            display: flex;
+        }
+
+        .popup {
+            width: 100%;
+            max-width: 420px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            display: grid;
+            gap: 14px;
+        }
+
+        .popup-title {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .popup-message {
+            margin: 0;
+            color: var(--muted);
+            font-size: 14px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+        }
+
+        .popup-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+
+        @media (max-width: 700px) {
+            .toolbar {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="page">
+    <div class="header">
+        <h1 class="title">Admin Console</h1>
+        <button id="logoutBtn" class="btn btn-ghost" type="button">Logout</button>
+    </div>
+
+    <nav class="tabs">
+        <a href="/admin/tabs/app-versions" class="tab-link active">App Versions</a>
+    </nav>
+
+    <div class="panel">
+        <div class="panel-head">
+            <h2 class="panel-title">Version History</h2>
+            <a href="/admin/tabs/app-versions" class="btn btn-ghost">Back to App Versions</a>
+        </div>
+        <div class="toolbar">
+            <div>
+                <label class="field-label" for="platformFilter">Platform</label>
+                <select id="platformFilter">
+                    <option value="">All Platforms</option>
+                    <option value="IOS">IOS</option>
+                    <option value="ANDROID">ANDROID</option>
+                </select>
+            </div>
+            <div class="btn-row">
+                <button id="refreshBtn" class="btn btn-primary" type="button">Refresh</button>
+            </div>
+        </div>
+        <div id="historyContainer"></div>
+    </div>
+</div>
+
+<div id="popupBackdrop" class="popup-backdrop">
+    <div class="popup" role="dialog" aria-modal="true" aria-labelledby="popupTitle">
+        <h2 id="popupTitle" class="popup-title"></h2>
+        <p id="popupMessage" class="popup-message"></p>
+        <div class="popup-actions">
+            <button id="popupConfirmBtn" class="btn btn-primary" type="button">OK</button>
+        </div>
+    </div>
+</div>
+
+<script>
+    const historyContainerEl = document.getElementById('historyContainer');
+    const platformFilterEl = document.getElementById('platformFilter');
+    const refreshBtn = document.getElementById('refreshBtn');
+    const logoutBtn = document.getElementById('logoutBtn');
+    const popupBackdropEl = document.getElementById('popupBackdrop');
+    const popupTitleEl = document.getElementById('popupTitle');
+    const popupMessageEl = document.getElementById('popupMessage');
+    const popupConfirmBtn = document.getElementById('popupConfirmBtn');
+
+    function escapeHtml(value) {
+        return String(value ?? '')
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+    }
+
+    function showResultPopup(message, isError = false) {
+        popupTitleEl.textContent = isError ? 'Error' : 'Done';
+        popupMessageEl.textContent = message;
+        popupBackdropEl.classList.add('open');
+
+        return new Promise((resolve) => {
+            popupConfirmBtn.onclick = () => {
+                popupBackdropEl.classList.remove('open');
+                popupConfirmBtn.onclick = null;
+                resolve(true);
+            };
+        });
+    }
+
+    async function request(method, url) {
+        const response = await fetch(url, {
+            method,
+            headers: {'Content-Type': 'application/json'}
+        });
+
+        if (response.status === 401) {
+            location.replace('/admin/login');
+            return null;
+        }
+
+        if (!response.ok) {
+            let message = 'Request failed.';
+            try {
+                const errorBody = await response.json();
+                if (errorBody && errorBody.message) {
+                    message = errorBody.message;
+                }
+            } catch (e) {
+                // ignore
+            }
+            throw new Error(message);
+        }
+
+        return response.json();
+    }
+
+    function formatDateTime(value) {
+        if (!value) {
+            return '-';
+        }
+        return new Date(value).toLocaleString('ko-KR', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+    }
+
+    function renderItems(items) {
+        if (!items.length) {
+            return '<span class="empty">No items</span>';
+        }
+
+        return `
+            <ol class="items-list">
+                ${items.map((item) => `
+                    <li>
+                        <div class="item-title">${escapeHtml(item.displayOrder)}. ${escapeHtml(item.title)}</div>
+                        <div class="item-description">${escapeHtml(item.description)}</div>
+                    </li>
+                `).join('')}
+            </ol>
+        `;
+    }
+
+    function renderHistory(versions) {
+        if (!versions.length) {
+            historyContainerEl.innerHTML = '<div class="empty">No version history records.</div>';
+            return;
+        }
+
+        historyContainerEl.innerHTML = `
+            <div class="history-table-wrap">
+                <table class="history-table">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Platform</th>
+                        <th>Version</th>
+                        <th>Status</th>
+                        <th>Summary</th>
+                        <th>Items</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    ${versions.map((version) => `
+                        <tr>
+                            <td>${escapeHtml(version.id)}</td>
+                            <td>${escapeHtml(version.platform)}</td>
+                            <td><strong>${escapeHtml(version.version)}</strong></td>
+                            <td>
+                                <span class="badge ${version.isLatest ? 'badge-latest' : ''}">
+                                    ${version.isLatest ? 'Latest' : 'History'}
+                                </span>
+                            </td>
+                            <td class="summary-cell">${escapeHtml(version.summary)}</td>
+                            <td class="items-cell">${renderItems(version.items || [])}</td>
+                            <td>${escapeHtml(formatDateTime(version.createdAt))}</td>
+                            <td>${escapeHtml(formatDateTime(version.updatedAt))}</td>
+                        </tr>
+                    `).join('')}
+                    </tbody>
+                </table>
+            </div>
+        `;
+    }
+
+    async function loadHistory() {
+        const platform = platformFilterEl.value;
+        const query = platform ? `?platform=${encodeURIComponent(platform)}` : '';
+        const body = await request('GET', `/admin/api/versions/history${query}`);
+        if (!body) {
+            return;
+        }
+        renderHistory(body.data?.versions || []);
+    }
+
+    refreshBtn.addEventListener('click', async () => {
+        try {
+            await loadHistory();
+        } catch (e) {
+            await showResultPopup(e.message, true);
+        }
+    });
+
+    platformFilterEl.addEventListener('change', async () => {
+        try {
+            await loadHistory();
+        } catch (e) {
+            await showResultPopup(e.message, true);
+        }
+    });
+
+    logoutBtn.addEventListener('click', async () => {
+        try {
+            await fetch('/admin/api/logout', {method: 'POST'});
+        } finally {
+            location.replace('/admin/login');
+        }
+    });
+
+    loadHistory().catch(async (e) => {
+        await showResultPopup(e.message, true);
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/version.html
+++ b/src/main/resources/templates/admin/version.html
@@ -78,6 +78,19 @@
             color: var(--muted);
         }
 
+        .panel-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin-bottom: 12px;
+        }
+
+        .panel-head .panel-title {
+            margin: 0;
+        }
+
         .grid {
             display: grid;
             gap: 10px;
@@ -318,7 +331,10 @@
     </div>
 
     <div class="panel">
-        <h2 class="panel-title">Current Latest Versions</h2>
+        <div class="panel-head">
+            <h2 class="panel-title">Current Latest Versions</h2>
+            <a href="/admin/tabs/app-version-history" class="btn btn-ghost">View History</a>
+        </div>
         <div id="versionList" class="version-list"></div>
     </div>
 </div>

--- a/src/main/resources/templates/admin/version.html
+++ b/src/main/resources/templates/admin/version.html
@@ -177,6 +177,24 @@
             font-size: 15px;
         }
 
+        .version-editor {
+            display: grid;
+            grid-template-columns: minmax(140px, 220px) auto;
+            gap: 8px;
+            align-items: end;
+        }
+
+        .version-editor.confirmed-ui input {
+            opacity: 0.58;
+        }
+
+        @media (max-width: 640px) {
+            .version-editor {
+                grid-template-columns: 1fr;
+                width: 100%;
+            }
+        }
+
         .items-table {
             width: 100%;
             border-collapse: collapse;
@@ -287,7 +305,7 @@
             </div>
             <div>
                 <label class="field-label" for="version">Version</label>
-                <input id="version" type="text" maxlength="30" placeholder="e.g. 1.2.1" required/>
+                <input id="version" type="text" maxlength="30" pattern="\d+\.\d+\.\d+" title="Use major.minor.patch format." placeholder="e.g. 1.2.1" required/>
             </div>
             <div>
                 <label class="field-label" for="createSummary">Summary</label>
@@ -449,7 +467,18 @@
         versionListEl.innerHTML = versions.map((version) => `
             <section class="version-card" data-version-id="${version.id}">
                 <div class="version-head">
-                    <strong>${escapeHtml(version.platform)} / ${escapeHtml(version.version)}</strong>
+                    <strong>${escapeHtml(version.platform)}</strong>
+                    <div class="version-editor confirmed-ui">
+                        <div>
+                            <label class="field-label">Version</label>
+                            <input class="version-value" type="text" maxlength="30" pattern="\\d+\\.\\d+\\.\\d+" title="Use major.minor.patch format." value="${escapeHtml(version.version)}" data-original="${escapeHtml(version.version)}" disabled/>
+                        </div>
+                        <div class="btn-row">
+                            <button type="button" class="btn btn-ghost" data-action="edit-version">Edit</button>
+                            <button type="button" class="btn btn-primary is-hidden" data-action="save-version">Save Version</button>
+                            <button type="button" class="btn btn-ghost is-hidden" data-action="cancel-version">Cancel</button>
+                        </div>
+                    </div>
                 </div>
                 <div class="summary-editor confirmed-ui">
                     <label class="field-label">Summary</label>
@@ -509,6 +538,27 @@
         }
     }
 
+    function toggleVersionEditMode(versionEditor, editing) {
+        const versionInput = versionEditor.querySelector('.version-value');
+        const editBtn = versionEditor.querySelector('[data-action="edit-version"]');
+        const saveBtn = versionEditor.querySelector('[data-action="save-version"]');
+        const cancelBtn = versionEditor.querySelector('[data-action="cancel-version"]');
+
+        versionInput.disabled = !editing;
+        editBtn.classList.toggle('is-hidden', editing);
+        saveBtn.classList.toggle('is-hidden', !editing);
+        cancelBtn.classList.toggle('is-hidden', !editing);
+
+        if (editing) {
+            versionEditor.classList.remove('confirmed-ui');
+            versionEditor.classList.add('draft-ui');
+            versionInput.focus();
+        } else {
+            versionEditor.classList.remove('draft-ui');
+            versionEditor.classList.add('confirmed-ui');
+        }
+    }
+
     function toggleItemEditMode(row, editing) {
         const titleInput = row.querySelector('.item-title');
         const descriptionInput = row.querySelector('.item-description');
@@ -561,6 +611,12 @@
             summaryEditor.classList.add('draft-ui');
         }
 
+        const versionEditor = target.closest('.version-editor');
+        if (versionEditor) {
+            versionEditor.classList.remove('confirmed-ui');
+            versionEditor.classList.add('draft-ui');
+        }
+
         const row = target.closest('tr[data-item-id], tr[data-new-item]');
         if (row) {
             row.classList.remove('confirmed-ui');
@@ -610,6 +666,32 @@
         const appVersionId = Number(versionCard.dataset.versionId);
 
         try {
+            if (action === 'edit-version') {
+                const versionEditor = versionCard.querySelector('.version-editor');
+                toggleVersionEditMode(versionEditor, true);
+                return;
+            }
+
+            if (action === 'cancel-version') {
+                const versionEditor = versionCard.querySelector('.version-editor');
+                const versionInput = versionEditor.querySelector('.version-value');
+                versionInput.value = versionInput.dataset.original ?? '';
+                toggleVersionEditMode(versionEditor, false);
+                return;
+            }
+
+            if (action === 'save-version') {
+                const confirmed = await showConfirmPopup('Save version?');
+                if (!confirmed) {
+                    return;
+                }
+                const version = versionCard.querySelector('.version-value').value.trim();
+                await request('PUT', `/admin/api/versions/${appVersionId}/version`, {version});
+                await loadVersions();
+                await showResultPopup('Version saved.');
+                return;
+            }
+
             if (action === 'edit-summary') {
                 const summaryEditor = versionCard.querySelector('.summary-editor');
                 toggleSummaryEditMode(summaryEditor, true);

--- a/src/test/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionCommandServiceTest.java
@@ -1,0 +1,144 @@
+package com.devkor.ifive.nadab.domain.admin.application;
+
+import com.devkor.ifive.nadab.domain.admin.api.dto.request.AdminVersionCreateRequest;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersion;
+import com.devkor.ifive.nadab.domain.appversion.core.repository.AppVersionRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminVersionCommandServiceTest {
+
+    @Mock
+    AppVersionRepository appVersionRepository;
+
+    AdminVersionCommandService adminVersionCommandService;
+
+    @BeforeEach
+    void setUp() {
+        adminVersionCommandService = new AdminVersionCommandService(appVersionRepository);
+    }
+
+    @Test
+    void updateVersion_updates_when_new_version_is_greater_than_other_versions() {
+        AppVersion target = AppVersion.create(AppPlatform.ANDROID, "1.3.0", "summary");
+        when(appVersionRepository.findById(1L)).thenReturn(Optional.of(target));
+        when(appVersionRepository.existsByPlatformAndVersionAndIdNot(AppPlatform.ANDROID, "1.10.0", 1L))
+                .thenReturn(false);
+        when(appVersionRepository.findByPlatformAndIdNot(AppPlatform.ANDROID, 1L))
+                .thenReturn(List.of(
+                        AppVersion.create(AppPlatform.ANDROID, "1.2.0", "old"),
+                        AppVersion.create(AppPlatform.ANDROID, "1.9.0", "old")
+                ));
+
+        adminVersionCommandService.updateVersion(1L, "1.10.0");
+
+        assertThat(target.getVersion()).isEqualTo("1.10.0");
+        verify(appVersionRepository).flush();
+    }
+
+    @Test
+    void updateVersion_rejects_version_equal_to_highest_other_version() {
+        AppVersion target = AppVersion.create(AppPlatform.IOS, "1.3.0", "summary");
+        when(appVersionRepository.findById(1L)).thenReturn(Optional.of(target));
+        when(appVersionRepository.existsByPlatformAndVersionAndIdNot(AppPlatform.IOS, "1.2.0", 1L))
+                .thenReturn(false);
+        when(appVersionRepository.findByPlatformAndIdNot(AppPlatform.IOS, 1L))
+                .thenReturn(List.of(AppVersion.create(AppPlatform.IOS, "1.2.0", "old")));
+
+        assertThatThrownBy(() -> adminVersionCommandService.updateVersion(1L, "1.2.0"))
+                .isInstanceOfSatisfying(ConflictException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.APP_VERSION_MUST_BE_GREATER_THAN_EXISTING)
+                );
+
+        assertThat(target.getVersion()).isEqualTo("1.3.0");
+        verify(appVersionRepository, never()).flush();
+    }
+
+    @Test
+    void updateVersion_rejects_version_lower_than_highest_other_version() {
+        AppVersion target = AppVersion.create(AppPlatform.IOS, "1.3.0", "summary");
+        when(appVersionRepository.findById(1L)).thenReturn(Optional.of(target));
+        when(appVersionRepository.existsByPlatformAndVersionAndIdNot(AppPlatform.IOS, "1.1.2", 1L))
+                .thenReturn(false);
+        when(appVersionRepository.findByPlatformAndIdNot(AppPlatform.IOS, 1L))
+                .thenReturn(List.of(AppVersion.create(AppPlatform.IOS, "1.2.0", "old")));
+
+        assertThatThrownBy(() -> adminVersionCommandService.updateVersion(1L, "1.1.2"))
+                .isInstanceOfSatisfying(ConflictException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.APP_VERSION_MUST_BE_GREATER_THAN_EXISTING)
+                );
+
+        assertThat(target.getVersion()).isEqualTo("1.3.0");
+        verify(appVersionRepository, never()).flush();
+    }
+
+    @Test
+    void updateVersion_rejects_duplicate_version_before_comparing_order() {
+        AppVersion target = AppVersion.create(AppPlatform.ANDROID, "1.3.0", "summary");
+        when(appVersionRepository.findById(1L)).thenReturn(Optional.of(target));
+        when(appVersionRepository.existsByPlatformAndVersionAndIdNot(AppPlatform.ANDROID, "1.4.0", 1L))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> adminVersionCommandService.updateVersion(1L, "1.4.0"))
+                .isInstanceOfSatisfying(ConflictException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.APP_VERSION_ALREADY_EXISTS)
+                );
+
+        verify(appVersionRepository, never()).findByPlatformAndIdNot(AppPlatform.ANDROID, 1L);
+        verify(appVersionRepository, never()).flush();
+    }
+
+    @Test
+    void updateVersion_rejects_invalid_version_format() {
+        AppVersion target = AppVersion.create(AppPlatform.ANDROID, "1.3.0", "summary");
+        when(appVersionRepository.findById(1L)).thenReturn(Optional.of(target));
+        when(appVersionRepository.existsByPlatformAndVersionAndIdNot(AppPlatform.ANDROID, "1.4", 1L))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> adminVersionCommandService.updateVersion(1L, "1.4"))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.APP_VERSION_INVALID_FORMAT)
+                );
+
+        verify(appVersionRepository, never()).findByPlatformAndIdNot(AppPlatform.ANDROID, 1L);
+        verify(appVersionRepository, never()).flush();
+    }
+
+    @Test
+    void createVersion_rejects_version_lower_than_existing_platform_version() {
+        AdminVersionCreateRequest request = new AdminVersionCreateRequest(
+                AppPlatform.ANDROID,
+                "1.1.2",
+                "summary"
+        );
+        when(appVersionRepository.existsByPlatformAndVersion(AppPlatform.ANDROID, "1.1.2"))
+                .thenReturn(false);
+        when(appVersionRepository.findByPlatform(AppPlatform.ANDROID))
+                .thenReturn(List.of(AppVersion.create(AppPlatform.ANDROID, "1.2.0", "old")));
+
+        assertThatThrownBy(() -> adminVersionCommandService.createVersion(request))
+                .isInstanceOfSatisfying(ConflictException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.APP_VERSION_MUST_BE_GREATER_THAN_EXISTING)
+                );
+
+        verify(appVersionRepository, never()).findByPlatformAndIsLatestTrue(AppPlatform.ANDROID);
+        verify(appVersionRepository, never()).saveAndFlush(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionQueryServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/admin/application/AdminVersionQueryServiceTest.java
@@ -1,0 +1,84 @@
+package com.devkor.ifive.nadab.domain.admin.application;
+
+import com.devkor.ifive.nadab.domain.admin.api.dto.response.AdminVersionHistoryResponse;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppPlatform;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersion;
+import com.devkor.ifive.nadab.domain.appversion.core.entity.AppVersionItem;
+import com.devkor.ifive.nadab.domain.appversion.core.repository.AppVersionItemRepository;
+import com.devkor.ifive.nadab.domain.appversion.core.repository.AppVersionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminVersionQueryServiceTest {
+
+    @Mock
+    AppVersionRepository appVersionRepository;
+
+    @Mock
+    AppVersionItemRepository appVersionItemRepository;
+
+    AdminVersionQueryService adminVersionQueryService;
+
+    @BeforeEach
+    void setUp() {
+        adminVersionQueryService = new AdminVersionQueryService(
+                appVersionRepository,
+                appVersionItemRepository
+        );
+    }
+
+    @Test
+    void getVersionHistory_returns_all_versions_with_items() {
+        AppVersion android = appVersion(1L, AppPlatform.ANDROID, "1.2.0", "android summary");
+        AppVersion ios = appVersion(2L, AppPlatform.IOS, "1.1.0", "ios summary");
+        AppVersionItem item = AppVersionItem.create(android, "Title", "Description", 1);
+        ReflectionTestUtils.setField(item, "id", 10L);
+
+        when(appVersionRepository.findAllByOrderByCreatedAtDescIdDesc())
+                .thenReturn(List.of(android, ios));
+        when(appVersionItemRepository.findByAppVersionIdInOrderByDisplayOrderAsc(List.of(1L, 2L)))
+                .thenReturn(List.of(item));
+
+        AdminVersionHistoryResponse response = adminVersionQueryService.getVersionHistory(null);
+
+        assertThat(response.versions()).hasSize(2);
+        assertThat(response.versions().get(0).id()).isEqualTo(1L);
+        assertThat(response.versions().get(0).items()).hasSize(1);
+        assertThat(response.versions().get(0).items().get(0).title()).isEqualTo("Title");
+        assertThat(response.versions().get(1).id()).isEqualTo(2L);
+        assertThat(response.versions().get(1).items()).isEmpty();
+    }
+
+    @Test
+    void getVersionHistory_uses_platform_filter_when_platform_exists() {
+        AppVersion ios = appVersion(2L, AppPlatform.IOS, "1.1.0", "ios summary");
+        when(appVersionRepository.findByPlatformOrderByCreatedAtDescIdDesc(AppPlatform.IOS))
+                .thenReturn(List.of(ios));
+        when(appVersionItemRepository.findByAppVersionIdInOrderByDisplayOrderAsc(List.of(2L)))
+                .thenReturn(List.of());
+
+        AdminVersionHistoryResponse response = adminVersionQueryService.getVersionHistory(AppPlatform.IOS);
+
+        assertThat(response.versions()).hasSize(1);
+        assertThat(response.versions().get(0).platform()).isEqualTo(AppPlatform.IOS);
+        verify(appVersionRepository, never()).findAllByOrderByCreatedAtDescIdDesc();
+    }
+
+    private AppVersion appVersion(Long id, AppPlatform platform, String version, String summary) {
+        AppVersion appVersion = AppVersion.create(platform, version, summary);
+        ReflectionTestUtils.setField(appVersion, "id", id);
+        return appVersion;
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 개요

어드민 App Version 관리 기능을 확장하여 현재 노출 중인 앱 버전의 버전 값을 수정할 수 있도록 하고, 
그동안 등록된 앱 버전 히스토리를 조회할 수 있는 관리자 페이지를 추가했습니다.

### 주요 변경사항

- App Version 관리 화면에서 버전 값 수정 기능 추가
- 수정 대상 버전 외의 기존 버전들과 비교해 의미상 낮거나 같은 버전으로 변경되는 케이스 방지
- 앱 버전 히스토리 조회 API 추가
- 플랫폼별 버전 히스토리 조회 페이지 추가
- App Version 화면에서 Version History를 하위/보조 기능으로 접근하도록 UI 계층 조정
- 관련 서비스 로직 테스트 추가

### 검증

- `git diff --check`
- `.\gradlew.bat compileJava`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.admin.application.AdminVersionCommandServiceTest" --tests "com.devkor.ifive.nadab.domain.admin.application.AdminVersionQueryServiceTest"`

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.