### PR TITLE
feat(report): 리포트 생성 로그에 LLM 토큰 사용량 기록 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -114,7 +114,8 @@ public class DailyReportService {
                     generationLogId,
                     tokenUsage.inputTokens(),
                     tokenUsage.outputTokens(),
-                    tokenUsage.totalTokens()
+                    tokenUsage.totalTokens(),
+                    tokenUsage.thinkingTokens()
             );
             reportGenerationLogRecorder.succeed(generationLogId);
         } catch (Exception e) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportService.java
@@ -28,7 +28,9 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -104,7 +106,16 @@ public class DailyReportService {
 
         AiDailyReportResultDto dto;
         try {
-            dto = dailyReportLlmClient.generate(question.getQuestionText(), answerEntry);
+            LlmGenerationResult<AiDailyReportResultDto> generationResult =
+                    dailyReportLlmClient.generate(question.getQuestionText(), answerEntry);
+            dto = generationResult.content();
+            LlmTokenUsage tokenUsage = generationResult.tokenUsage();
+            reportGenerationLogRecorder.recordTokenUsage(
+                    generationLogId,
+                    tokenUsage.inputTokens(),
+                    tokenUsage.outputTokens(),
+                    tokenUsage.totalTokens()
+            );
             reportGenerationLogRecorder.succeed(generationLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(generationLogId, e);

--- a/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClient.java
@@ -10,12 +10,16 @@ import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
@@ -36,7 +40,7 @@ public class DailyReportLlmClient {
 
     private final LlmProvider provider = LlmProvider.OPENAI;
 
-    public AiDailyReportResultDto generate(String question, AnswerEntry answerEntry) {
+    public LlmGenerationResult<AiDailyReportResultDto> generate(String question, AnswerEntry answerEntry) {
 
         String answer = answerEntry.getContent();
 
@@ -59,12 +63,15 @@ public class DailyReportLlmClient {
         UserMessage userMessage = buildUserMessage(prompt, withImagePrompt,answerEntry);
 
         String content;
+        LlmTokenUsage tokenUsage;
         try {
-            content = chatClient.prompt()
+            ChatResponse response = chatClient.prompt()
                     .messages(userMessage)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            content = extractContent(response);
+            tokenUsage = LlmTokenUsageExtractor.extract(response);
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
@@ -85,15 +92,25 @@ public class DailyReportLlmClient {
                 throw new AiResponseParseException(ErrorCode.AI_RESPONSE_FORMAT_INVALID);
             }
 
-            return new AiDailyReportResultDto(
-                    message,
-                    emotion
+            return new LlmGenerationResult<>(
+                    new AiDailyReportResultDto(
+                            message,
+                            emotion
+                    ),
+                    tokenUsage
             );
 
         } catch (Exception e) {
             // GPT가 JSON 형식을 지키지 못했을 경우 대비
             throw new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 
     private UserMessage buildUserMessage(String prompt, String withImagePrompt, AnswerEntry answerEntry) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListener.java
@@ -12,7 +12,9 @@ import com.devkor.ifive.nadab.domain.reportlog.core.entity.ReportGenerationStep;
 import com.devkor.ifive.nadab.domain.reportlog.core.entity.ReportGenerationType;
 import com.devkor.ifive.nadab.domain.weeklyreport.application.helper.WeeklyEntriesAssembler;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.devkor.ifive.nadab.global.shared.reportcontent.AiReportResultDto;
 import com.devkor.ifive.nadab.global.shared.util.MonthRangeCalculator;
 import com.devkor.ifive.nadab.global.shared.util.dto.MonthRangeDto;
@@ -66,11 +68,20 @@ public class MonthlyReportGenerationListener {
         );
         try {
             // 트랜잭션 밖(백그라운드)에서 LLM 호출
-            dto = monthlyReportLlmClient.generate(
+            LlmGenerationResult<AiReportResultDto> generationResult = monthlyReportLlmClient.generate(
                     range.monthStartDate().toString(),
                     range.monthEndDate().toString(),
                     weeklySummaries,
                     representativeEntries
+            );
+            dto = generationResult.content();
+            LlmTokenUsage tokenUsage = generationResult.tokenUsage();
+            reportGenerationLogRecorder.recordTokenUsage(
+                    generationLogId,
+                    tokenUsage.inputTokens(),
+                    tokenUsage.outputTokens(),
+                    tokenUsage.totalTokens(),
+                    tokenUsage.thinkingTokens()
             );
             reportGenerationLogRecorder.succeed(generationLogId);
         } catch (Exception e) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2.java
@@ -29,7 +29,9 @@ import com.devkor.ifive.nadab.domain.typereport.application.helper.TypeEmotionSt
 import com.devkor.ifive.nadab.domain.typereport.core.content.TypeEmotionStatsContent;
 import com.devkor.ifive.nadab.domain.weeklyreport.application.helper.WeeklyEntriesAssembler;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.devkor.ifive.nadab.global.shared.util.MonthRangeCalculator;
 import com.devkor.ifive.nadab.global.shared.util.dto.MonthRangeDto;
 import lombok.RequiredArgsConstructor;
@@ -168,13 +170,22 @@ public class MonthlyReportGenerationListenerV2 {
         );
         try {
             // 트랜잭션 밖(백그라운드)에서 LLM 호출
-            dto = monthlyReportLlmClientV2.generate(
+            LlmGenerationResult<AiMonthlyReportResultDto> generationResult = monthlyReportLlmClientV2.generate(
                     range.monthStartDate().toString(),
                     range.monthEndDate().toString(),
                     weeklySummaries,
                     representativeEntries,
                     emotionStats,
                     comparisonInput
+            );
+            dto = generationResult.content();
+            LlmTokenUsage tokenUsage = generationResult.tokenUsage();
+            reportGenerationLogRecorder.recordTokenUsage(
+                    generationLogId,
+                    tokenUsage.inputTokens(),
+                    tokenUsage.outputTokens(),
+                    tokenUsage.totalTokens(),
+                    tokenUsage.thinkingTokens()
             );
             reportGenerationLogRecorder.succeed(generationLogId);
         } catch (Exception e) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/infra/MonthlyReportLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/infra/MonthlyReportLlmClient.java
@@ -5,8 +5,11 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.devkor.ifive.nadab.global.shared.reportcontent.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.anthropic.api.AnthropicApi;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.openai.OpenAiChatOptions;
@@ -47,7 +51,7 @@ public class MonthlyReportLlmClient {
     private static final int MIN_SUMMARY = 8;
     private static final int MAX_SUMMARY = 30;
 
-    public AiReportResultDto generate(
+    public LlmGenerationResult<AiReportResultDto> generate(
             String monthStartDate, String monthEndDate, String weeklySummaries, String representativeEntries) {
         String prompt = monthlyReportPromptLoader.loadV1Prompt()
                 .replace("{monthStartDate}", monthStartDate)
@@ -57,11 +61,13 @@ public class MonthlyReportLlmClient {
 
         ChatClient client = llmRouter.route(provider);
 
-        String content = switch (provider) {
+        LlmGenerationResult<String> generationResult = switch (provider) {
             case OPENAI -> callOpenAi(client, prompt);
             case CLAUDE -> callClaude(client, prompt);
             case GEMINI -> callGemini(client, prompt);
         };
+        String content = generationResult.content();
+        LlmTokenUsage tokenUsage = generationResult.tokenUsage();
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_NO_RESPONSE);
@@ -97,11 +103,14 @@ public class MonthlyReportLlmClient {
                 throw new AiResponseParseException(ErrorCode.MONTHLY_REPORT_AI_JSON_MISSING_FIELDS);
             }
 
-            AiReportResultDto dto = enforceLength(new AiReportResultDto(reportContent, discovered, improve));
+            LlmGenerationResult<AiReportResultDto> lengthResult =
+                    enforceLength(new AiReportResultDto(reportContent, discovered, improve));
+            AiReportResultDto dto = lengthResult.content();
+            tokenUsage = tokenUsage.plus(lengthResult.tokenUsage());
 
             validateLength(dto);
 
-            return dto;
+            return new LlmGenerationResult<>(dto, tokenUsage);
 
         } catch (AiResponseParseException e) {
             throw e;
@@ -110,7 +119,7 @@ public class MonthlyReportLlmClient {
         }
     }
 
-    private String callOpenAi(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callOpenAi(ChatClient client, String prompt) {
         OpenAiChatOptions options = OpenAiChatOptions.builder()
                 .model(OpenAiApi.ChatModel.GPT_5_MINI)
                 .reasoningEffort("medium")
@@ -118,34 +127,36 @@ public class MonthlyReportLlmClient {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callClaude(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callClaude(ChatClient client, String prompt) {
         AnthropicChatOptions options = AnthropicChatOptions.builder()
                 .model(AnthropicApi.ChatModel.CLAUDE_3_HAIKU)
                 .temperature(0.3)
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callGemini(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callGemini(ChatClient client, String prompt) {
         GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
                 .model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH)
                 .responseMimeType("application/json")
@@ -153,17 +164,18 @@ public class MonthlyReportLlmClient {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private AiReportResultDto enforceLength(AiReportResultDto dto) {
+    private LlmGenerationResult<AiReportResultDto> enforceLength(AiReportResultDto dto) {
         ReportContent c = dto.content();
 
         int dLen = dto.discovered().length();
@@ -172,15 +184,24 @@ public class MonthlyReportLlmClient {
         boolean badD = dLen < MIN_DISCOVERED || dLen > MAX_DISCOVERED;
         boolean badI = iLen < MIN_IMPROVE || iLen > MAX_IMPROVE;
 
-        if (!badD && !badI) return dto;
+        if (!badD && !badI) return new LlmGenerationResult<>(dto, LlmTokenUsage.empty());
 
         ChatClient rewriteClient = llmRouter.route(REWRITE_PROVIDER);
 
         StyledText d = c.discovered();
         StyledText i = c.improve();
+        LlmTokenUsage tokenUsage = LlmTokenUsage.empty();
 
-        if (badD) d = rewriteStyled(rewriteClient, d, true);
-        if (badI) i = rewriteStyled(rewriteClient, i, false);
+        if (badD) {
+            LlmGenerationResult<StyledText> rewriteResult = rewriteStyled(rewriteClient, d, true);
+            d = rewriteResult.content();
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
+        }
+        if (badI) {
+            LlmGenerationResult<StyledText> rewriteResult = rewriteStyled(rewriteClient, i, false);
+            i = rewriteResult.content();
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
+        }
 
         ReportContent newContent = new ReportContent(c.summary(), d, i);
         String newD = newContent.discovered().plainText();
@@ -193,10 +214,10 @@ public class MonthlyReportLlmClient {
             throw new AiResponseParseException(ErrorCode.MONTHLY_REPORT_REWRITE_FORMAT_INVALID);
         }
 
-        return new AiReportResultDto(newContent, newD, newI);
+        return new LlmGenerationResult<>(new AiReportResultDto(newContent, newD, newI), tokenUsage);
     }
 
-    private StyledText rewriteStyled(ChatClient client, StyledText in, boolean isDiscovered) {
+    private LlmGenerationResult<StyledText> rewriteStyled(ChatClient client, StyledText in, boolean isDiscovered) {
         int min = isDiscovered ? MIN_DISCOVERED : MIN_IMPROVE;
         int max = isDiscovered ? MAX_DISCOVERED : MAX_IMPROVE;
         int maxHl = isDiscovered ? MAX_HL_DISCOVERED : MAX_HL_IMPROVE;
@@ -229,19 +250,21 @@ public class MonthlyReportLlmClient {
                     .temperature(0.0)
                     .build();
 
-            String out;
+            ChatResponse response;
             try {
-                out = client.prompt().user(prompt).options(options).call().content();
+                response = client.prompt().user(prompt).options(options).call().chatResponse();
             } catch (Exception e) {
                 throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_REWRITE_NO_RESPONSE, e);
             }
+            String out = extractContent(response);
+            LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
             if (out == null || out.isBlank()) {
                 throw new AiServiceUnavailableException(ErrorCode.AI_REWRITE_NO_RESPONSE);
             }
 
             try {
-                return objectMapper.readValue(out, StyledText.class);
+                return new LlmGenerationResult<>(objectMapper.readValue(out, StyledText.class), tokenUsage);
             } catch (Exception e) {
                 throw new AiResponseParseException(ErrorCode.MONTHLY_REPORT_REWRITE_JSON_MAPPING_FAILED);
             }
@@ -251,6 +274,13 @@ public class MonthlyReportLlmClient {
         } catch (JsonProcessingException e) {
             throw new AiResponseParseException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 
     private boolean isBlank(String s) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/infra/MonthlyReportLlmClientV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/infra/MonthlyReportLlmClientV2.java
@@ -11,8 +11,11 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.devkor.ifive.nadab.global.shared.reportcontent.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.anthropic.api.AnthropicApi;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.openai.OpenAiChatOptions;
@@ -59,7 +63,7 @@ public class MonthlyReportLlmClientV2 {
     private static final int MAX_COMPARISON_EMOTION = 150;
     private static final int MAX_COMPARISON_BOLD_SEGMENTS = 4;
 
-    public AiMonthlyReportResultDto generate(
+    public LlmGenerationResult<AiMonthlyReportResultDto> generate(
             String monthStartDate,
             String monthEndDate,
             String weeklySummaries,
@@ -77,11 +81,13 @@ public class MonthlyReportLlmClientV2 {
 
         ChatClient client = llmRouter.route(provider);
 
-        String content = switch (provider) {
+        LlmGenerationResult<String> generationResult = switch (provider) {
             case OPENAI -> callOpenAi(client, prompt);
             case CLAUDE -> callClaude(client, prompt);
             case GEMINI -> callGemini(client, prompt);
         };
+        String content = generationResult.content();
+        LlmTokenUsage tokenUsage = generationResult.tokenUsage();
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_NO_RESPONSE);
@@ -142,9 +148,12 @@ public class MonthlyReportLlmClientV2 {
                     discoveredStyled,
                     commentStyled
             );
-            return new AiMonthlyReportResultDto(
-                    normalizedContent,
-                    new TypeTextContent(styledText)
+            return new LlmGenerationResult<>(
+                    new AiMonthlyReportResultDto(
+                            normalizedContent,
+                            new TypeTextContent(styledText)
+                    ),
+                    tokenUsage
             );
 
         } catch (AiResponseParseException e) {
@@ -188,7 +197,7 @@ public class MonthlyReportLlmClientV2 {
         }
     }
 
-    private String callOpenAi(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callOpenAi(ChatClient client, String prompt) {
         OpenAiChatOptions options = OpenAiChatOptions.builder()
                 .model(OpenAiApi.ChatModel.GPT_5_MINI)
                 .reasoningEffort("medium")
@@ -196,34 +205,36 @@ public class MonthlyReportLlmClientV2 {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callClaude(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callClaude(ChatClient client, String prompt) {
         AnthropicChatOptions options = AnthropicChatOptions.builder()
                 .model(AnthropicApi.ChatModel.CLAUDE_3_HAIKU)
                 .temperature(0.3)
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callGemini(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callGemini(ChatClient client, String prompt) {
         GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
                 .model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH)
                 .responseMimeType("application/json")
@@ -231,11 +242,12 @@ public class MonthlyReportLlmClientV2 {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
@@ -333,6 +345,13 @@ public class MonthlyReportLlmClientV2 {
     }
 
      */
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
+    }
 
     private boolean isBlank(String s) {
         return s == null || s.trim().isEmpty();

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogRecorder.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogRecorder.java
@@ -56,14 +56,15 @@ public class ReportGenerationLogRecorder {
             Long logId,
             Long inputTokens,
             Long outputTokens,
-            Long totalTokens
+            Long totalTokens,
+            Long thinkingTokens
     ) {
         if (logId == null) {
             return;
         }
 
         try {
-            reportGenerationLogService.recordTokenUsage(logId, inputTokens, outputTokens, totalTokens);
+            reportGenerationLogService.recordTokenUsage(logId, inputTokens, outputTokens, totalTokens, thinkingTokens);
         } catch (Exception e) {
             log.warn("[REPORT_GENERATION_LOG][TOKEN_USAGE_FAILED] logId={}", logId, e);
         }

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogRecorder.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogRecorder.java
@@ -52,6 +52,23 @@ public class ReportGenerationLogRecorder {
         }
     }
 
+    public void recordTokenUsage(
+            Long logId,
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens
+    ) {
+        if (logId == null) {
+            return;
+        }
+
+        try {
+            reportGenerationLogService.recordTokenUsage(logId, inputTokens, outputTokens, totalTokens);
+        } catch (Exception e) {
+            log.warn("[REPORT_GENERATION_LOG][TOKEN_USAGE_FAILED] logId={}", logId, e);
+        }
+    }
+
     public void fail(Long logId, Exception exception) {
         if (logId == null) {
             return;

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogService.java
@@ -52,6 +52,17 @@ public class ReportGenerationLogService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordTokenUsage(
+            Long logId,
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens
+    ) {
+        reportGenerationLogRepository.findById(logId)
+                .ifPresent(log -> log.recordTokenUsage(inputTokens, outputTokens, totalTokens));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void fail(Long logId, Exception exception) {
         Integer externalHttpStatus = extractExternalHttpStatus(exception);
         String externalErrorCode = extractExternalErrorCode(exception);

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogService.java
@@ -56,10 +56,11 @@ public class ReportGenerationLogService {
             Long logId,
             Long inputTokens,
             Long outputTokens,
-            Long totalTokens
+            Long totalTokens,
+            Long thinkingTokens
     ) {
         reportGenerationLogRepository.findById(logId)
-                .ifPresent(log -> log.recordTokenUsage(inputTokens, outputTokens, totalTokens));
+                .ifPresent(log -> log.recordTokenUsage(inputTokens, outputTokens, totalTokens, thinkingTokens));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/core/entity/ReportGenerationLog.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/core/entity/ReportGenerationLog.java
@@ -76,6 +76,15 @@ public class ReportGenerationLog extends CreatableEntity {
     @Column(name = "elapsed_ms")
     private Long elapsedMs;
 
+    @Column(name = "input_tokens")
+    private Long inputTokens;
+
+    @Column(name = "output_tokens")
+    private Long outputTokens;
+
+    @Column(name = "total_tokens")
+    private Long totalTokens;
+
     @Column(name = "started_at", nullable = false)
     private OffsetDateTime startedAt;
 
@@ -105,6 +114,16 @@ public class ReportGenerationLog extends CreatableEntity {
     public void succeed() {
         this.status = ReportGenerationLogStatus.SUCCEEDED;
         finish();
+    }
+
+    public void recordTokenUsage(
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens
+    ) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        this.totalTokens = totalTokens;
     }
 
     public void fail(

--- a/src/main/java/com/devkor/ifive/nadab/domain/reportlog/core/entity/ReportGenerationLog.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/reportlog/core/entity/ReportGenerationLog.java
@@ -85,6 +85,9 @@ public class ReportGenerationLog extends CreatableEntity {
     @Column(name = "total_tokens")
     private Long totalTokens;
 
+    @Column(name = "thinking_tokens")
+    private Long thinkingTokens;
+
     @Column(name = "started_at", nullable = false)
     private OffsetDateTime startedAt;
 
@@ -119,11 +122,13 @@ public class ReportGenerationLog extends CreatableEntity {
     public void recordTokenUsage(
             Long inputTokens,
             Long outputTokens,
-            Long totalTokens
+            Long totalTokens,
+            Long thinkingTokens
     ) {
         this.inputTokens = inputTokens;
         this.outputTokens = outputTokens;
         this.totalTokens = totalTokens;
+        this.thinkingTokens = thinkingTokens;
     }
 
     public void fail(

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/application/listener/TypeReportGenerationListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/application/listener/TypeReportGenerationListener.java
@@ -24,7 +24,9 @@ import com.devkor.ifive.nadab.domain.typereport.core.service.TypeReportContentGe
 import com.devkor.ifive.nadab.domain.typereport.core.service.TypeSelectionService;
 import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -125,7 +127,10 @@ public class TypeReportGenerationListener {
                 TYPE_REPORT_OPENAI_MODEL
         );
         try {
-            cards = evidenceCardGenerationService.generate(recentEntries);
+            LlmGenerationResult<List<EvidenceCardDto>> generationResult =
+                    evidenceCardGenerationService.generate(recentEntries);
+            cards = generationResult.content();
+            recordTokenUsage(evidenceLogId, generationResult.tokenUsage());
             reportGenerationLogRecorder.succeed(evidenceLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(evidenceLogId, e);
@@ -146,7 +151,10 @@ public class TypeReportGenerationListener {
                 TYPE_REPORT_OPENAI_MODEL
         );
         try {
-            patterns = patternExtractionService.extract(cards);
+            LlmGenerationResult<PatternExtractionResultDto> generationResult =
+                    patternExtractionService.extract(cards);
+            patterns = generationResult.content();
+            recordTokenUsage(patternLogId, generationResult.tokenUsage());
             reportGenerationLogRecorder.succeed(patternLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(patternLogId, e);
@@ -179,7 +187,10 @@ public class TypeReportGenerationListener {
                 TYPE_REPORT_OPENAI_MODEL
         );
         try {
-            selection = typeSelectionService.select(candidates, patterns);
+            LlmGenerationResult<TypeSelectionResultDto> generationResult =
+                    typeSelectionService.select(candidates, patterns);
+            selection = generationResult.content();
+            recordTokenUsage(selectionLogId, generationResult.tokenUsage());
             reportGenerationLogRecorder.succeed(selectionLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(selectionLogId, e);
@@ -213,13 +224,15 @@ public class TypeReportGenerationListener {
                 TYPE_REPORT_GEMINI_MODEL
         );
         try {
-            content = typeReportContentGenerationService.generate(
+            LlmGenerationResult<TypeReportContentDto> generationResult = typeReportContentGenerationService.generate(
                     selectedType,
                     patterns,
                     cards,
                     emotionStats,
                     selection.analysisTypeCode()
             );
+            content = generationResult.content();
+            recordTokenUsage(contentLogId, generationResult.tokenUsage());
             reportGenerationLogRecorder.succeed(contentLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(contentLogId, e);
@@ -281,5 +294,15 @@ public class TypeReportGenerationListener {
             case LOVE -> "사랑";
             case VALUES -> "가치관";
         };
+    }
+
+    private void recordTokenUsage(Long logId, LlmTokenUsage tokenUsage) {
+        reportGenerationLogRecorder.recordTokenUsage(
+                logId,
+                tokenUsage.inputTokens(),
+                tokenUsage.outputTokens(),
+                tokenUsage.totalTokens(),
+                tokenUsage.thinkingTokens()
+        );
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/EvidenceCardGenerationService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/EvidenceCardGenerationService.java
@@ -7,6 +7,8 @@ import com.devkor.ifive.nadab.domain.typereport.infra.TypeEvidenceCardLlmClient;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,17 +23,17 @@ public class EvidenceCardGenerationService {
 
     private final TypeEvidenceCardLlmClient llmClient;
 
-    public List<EvidenceCardDto> generate(List<DailyEntryDto> recentEntries) {
+    public LlmGenerationResult<List<EvidenceCardDto>> generate(List<DailyEntryDto> recentEntries) {
         List<DailyEntryWithIdDto> withIds = EvidenceEntriesAssembler.attachIds(recentEntries);
-        if (withIds.isEmpty()) return List.of();
+        if (withIds.isEmpty()) return new LlmGenerationResult<>(List.of(), LlmTokenUsage.empty());
 
         String entriesText = EvidenceEntriesAssembler.assembleForPrompt(withIds);
 
-        List<Map<String, String>> raw = llmClient.generateRawCardsJsonArray(entriesText);
+        LlmGenerationResult<List<Map<String, String>>> rawResult = llmClient.generateRawCardsJsonArray(entriesText);
 
-        List<EvidenceCardDto> cards = mapAndValidate(withIds, raw);
+        List<EvidenceCardDto> cards = mapAndValidate(withIds, rawResult.content());
 
-        return cards;
+        return new LlmGenerationResult<>(cards, rawResult.tokenUsage());
     }
 
     private List<EvidenceCardDto> mapAndValidate(List<DailyEntryWithIdDto> withIds, List<Map<String, String>> raw) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/PatternExtractionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/PatternExtractionService.java
@@ -6,6 +6,7 @@ import com.devkor.ifive.nadab.domain.typereport.core.dto.PatternExtractionResult
 import com.devkor.ifive.nadab.domain.typereport.infra.TypePatternExtractLlmClient;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class PatternExtractionService {
 
     private final TypePatternExtractLlmClient llmClient;
 
-    public PatternExtractionResultDto extract(List<EvidenceCardDto> cards) {
+    public LlmGenerationResult<PatternExtractionResultDto> extract(List<EvidenceCardDto> cards) {
         if (cards == null || cards.isEmpty()) {
             throw new AiResponseParseException(ErrorCode.PATTERN_RESULT_EMPTY);
         }
@@ -37,12 +38,12 @@ public class PatternExtractionService {
                 .collect(Collectors.toSet());
 
         String cardsText = EvidenceCardsAssembler.assembleForPrompt(cards);
-        JsonNode raw = llmClient.extractPatternsRawJson(cardsText);
+        LlmGenerationResult<JsonNode> rawResult = llmClient.extractPatternsRawJson(cardsText);
 
-        PatternExtractionResultDto dto = toDto(raw);
+        PatternExtractionResultDto dto = toDto(rawResult.content());
         validate(dto, validIds);
 
-        return dto;
+        return new LlmGenerationResult<>(dto, rawResult.tokenUsage());
     }
 
     private PatternExtractionResultDto toDto(JsonNode raw) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/TypeReportContentGenerationService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/TypeReportContentGenerationService.java
@@ -11,6 +11,8 @@ import com.devkor.ifive.nadab.domain.typereport.core.dto.TypeReportContentDto;
 import com.devkor.ifive.nadab.domain.typereport.infra.TypeReportLlmClient;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +38,7 @@ public class TypeReportContentGenerationService {
     private final TypeReportLlmClient llmClient;
     private final ObjectMapper objectMapper;
 
-    public TypeReportContentDto generate(
+    public LlmGenerationResult<TypeReportContentDto> generate(
             AnalysisTypeCandidateDto selectedType,
             PatternExtractionResultDto patterns,
             List<EvidenceCardDto> allCards,
@@ -56,19 +58,23 @@ public class TypeReportContentGenerationService {
         String evidenceCardsText = TypeReportInputAssembler.assembleEvidenceCards(representative);
         String emotionStatsText = TypeReportInputAssembler.assembleEmotionStats(emotionStats);
 
-        JsonNode raw = llmClient.generateRaw(selectedTypeText, patternsText, evidenceCardsText, emotionStatsText);
+        LlmGenerationResult<JsonNode> rawResult =
+                llmClient.generateRaw(selectedTypeText, patternsText, evidenceCardsText, emotionStatsText);
+        JsonNode raw = rawResult.content();
+        LlmTokenUsage tokenUsage = rawResult.tokenUsage();
 
         // 1차 파싱/검증
         try {
             TypeReportContentDto dto = toDto(raw);
             validate(dto, expectedAnalysisTypeCode);
-            return dto;
+            return new LlmGenerationResult<>(dto, tokenUsage);
         } catch (AiResponseParseException e) {
             // 리페어 1회
-            JsonNode repaired = llmClient.rewriteOnly(raw);
+            LlmGenerationResult<JsonNode> rewriteResult = llmClient.rewriteOnly(raw);
+            JsonNode repaired = rewriteResult.content();
             TypeReportContentDto dto2 = toDto(repaired);
             validate(dto2, expectedAnalysisTypeCode);
-            return dto2;
+            return new LlmGenerationResult<>(dto2, tokenUsage.plus(rewriteResult.tokenUsage()));
         }
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/TypeSelectionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/core/service/TypeSelectionService.java
@@ -7,6 +7,7 @@ import com.devkor.ifive.nadab.domain.typereport.core.dto.TypeSelectionResultDto;
 import com.devkor.ifive.nadab.domain.typereport.infra.TypeSelectLlmClient;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class TypeSelectionService {
 
     private final TypeSelectLlmClient llmClient;
 
-    public TypeSelectionResultDto select(
+    public LlmGenerationResult<TypeSelectionResultDto> select(
             List<AnalysisTypeCandidateDto> candidates,
             PatternExtractionResultDto patternResult
     ) {
@@ -47,12 +48,12 @@ public class TypeSelectionService {
         String candidatesText = TypeSelectionInputAssembler.assembleCandidates(candidates);
         String patternsText = TypeSelectionInputAssembler.assemblePatterns(patternResult);
 
-        JsonNode raw = llmClient.selectTypeRawJson(candidatesText, patternsText);
+        LlmGenerationResult<JsonNode> rawResult = llmClient.selectTypeRawJson(candidatesText, patternsText);
 
-        TypeSelectionResultDto dto = toDto(raw);
+        TypeSelectionResultDto dto = toDto(rawResult.content());
         validate(dto, candidateCodes, validEvidenceIds);
 
-        return dto;
+        return new LlmGenerationResult<>(dto, rawResult.tokenUsage());
     }
 
     private TypeSelectionResultDto toDto(JsonNode raw) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeEvidenceCardLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeEvidenceCardLlmClient.java
@@ -5,12 +5,16 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.stereotype.Component;
@@ -28,25 +32,27 @@ public class TypeEvidenceCardLlmClient {
 
     private final LlmProvider provider = LlmProvider.OPENAI;
 
-    public List<Map<String, String>> generateRawCardsJsonArray(String entriesText) {
+    public LlmGenerationResult<List<Map<String, String>>> generateRawCardsJsonArray(String entriesText) {
         String prompt = promptLoader.loadPrompt()
                 .replace("{entries}", entriesText);
 
         ChatClient client = llmRouter.route(provider);
 
-        String content;
+        ChatResponse response;
         try {
-            content = client.prompt()
+            response = client.prompt()
                     .user(prompt)
                     .options(OpenAiChatOptions.builder()
                             .model(OpenAiApi.ChatModel.GPT_4_O_MINI)
                             .temperature(0.0)
                             .build())
                     .call()
-                    .content();
+                    .chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_EVIDENCE_CARD_NO_RESPONSE, e);
         }
+        String content = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_EVIDENCE_CARD_NO_RESPONSE);
@@ -54,12 +60,19 @@ public class TypeEvidenceCardLlmClient {
 
         try {
             // JSON 배열 파싱: [{"id":"D1","card":"..."}...]
-            return objectMapper.readValue(content, new TypeReference<>() {});
+            return new LlmGenerationResult<>(objectMapper.readValue(content, new TypeReference<>() {}), tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (Exception e) {
             // 파싱 실패 / LLM 이상 응답
             throw new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypePatternExtractLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypePatternExtractLlmClient.java
@@ -5,12 +5,16 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.stereotype.Component;
@@ -25,7 +29,7 @@ public class TypePatternExtractLlmClient {
 
     private final LlmProvider provider = LlmProvider.OPENAI;
 
-    public JsonNode extractPatternsRawJson(String cardsText) {
+    public LlmGenerationResult<JsonNode> extractPatternsRawJson(String cardsText) {
         String prompt = promptLoader.loadPrompt().replace("{cards}", cardsText);
 
         ChatClient client = llmRouter.route(provider);
@@ -35,28 +39,37 @@ public class TypePatternExtractLlmClient {
                 .temperature(0.0)
                 .build();
 
-        String content;
+        ChatResponse response;
         try {
-            content = client.prompt()
+            response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_PATTERN_EXTRACT_NO_RESPONSE, e);
         }
+        String content = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_PATTERN_EXTRACT_NO_RESPONSE);
         }
 
         try {
-            return objectMapper.readTree(content);
+            return new LlmGenerationResult<>(objectMapper.readTree(content), tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (Exception e) {
             // 파싱 실패 / LLM 이상 응답
             throw new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeReportLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeReportLlmClient.java
@@ -5,8 +5,11 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.devkor.ifive.nadab.global.shared.reportcontent.Mark;
 import com.devkor.ifive.nadab.global.shared.reportcontent.Segment;
 import com.devkor.ifive.nadab.global.shared.reportcontent.StyledText;
@@ -20,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.stereotype.Component;
@@ -56,7 +60,7 @@ public class TypeReportLlmClient {
             "패턴", "분석", "데이터", "기록", "습관", "장점", "단점", "모습", "결국", "보여집니다", "확인됩니다"
     };
 
-    public JsonNode generateRaw(String selectedType, String patterns, String evidenceCards, String emotionStats) {
+    public LlmGenerationResult<JsonNode> generateRaw(String selectedType, String patterns, String evidenceCards, String emotionStats) {
         if (blank(selectedType) || blank(patterns) || blank(evidenceCards) || blank(emotionStats)) {
             throw new AiResponseParseException(ErrorCode.TYPE_REPORT_GENERATE_INPUT_EMPTY);
         }
@@ -75,16 +79,18 @@ public class TypeReportLlmClient {
                 .temperature(0.0)
                 .build();
 
-        String content;
+        ChatResponse response;
         try {
-            content = client.prompt()
+            response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
+        String content = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_NO_RESPONSE);
@@ -95,7 +101,7 @@ public class TypeReportLlmClient {
             if (raw.isObject()) {
                 hydrateTypeAnalysisIfMissing((ObjectNode) raw);
             }
-            return raw;
+            return new LlmGenerationResult<>(raw, tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (Exception e) {
@@ -103,11 +109,11 @@ public class TypeReportLlmClient {
         }
     }
 
-    public JsonNode rewriteOnly(JsonNode raw) {
+    public LlmGenerationResult<JsonNode> rewriteOnly(JsonNode raw) {
         return enforceLength(raw);
     }
 
-    private JsonNode enforceLength(JsonNode raw) {
+    private LlmGenerationResult<JsonNode> enforceLength(JsonNode raw) {
         if (raw == null || raw.isNull() || !raw.isObject()) {
             throw new AiResponseParseException(ErrorCode.TYPE_REPORT_REWRITE_INPUT_SCHEMA_INVALID);
         }
@@ -116,14 +122,14 @@ public class TypeReportLlmClient {
 
         JsonNode personasNode = root.get("personas");
         if (personasNode == null || !personasNode.isArray()) {
-            return root;
+            return new LlmGenerationResult<>(root, LlmTokenUsage.empty());
         }
         validateRichContentsIfPresent(root);
 
         TypeTextContent sourceTypeAnalysisContent = parseTypeTextContentOrFallback(root.get("typeAnalysisContent"), "");
         String typeAnalysis = sourceTypeAnalysisContent.plainText().trim();
         if (blank(typeAnalysis)) {
-            return root;
+            return new LlmGenerationResult<>(root, LlmTokenUsage.empty());
         }
         root.put("typeAnalysis", typeAnalysis);
         ArrayNode personasArr = (ArrayNode) personasNode;
@@ -140,13 +146,17 @@ public class TypeReportLlmClient {
             badP2 = isOutOfRange(getPersonaContent(personasArr.get(1)).length(), MIN_PERSONA_CONTENT, MAX_PERSONA_CONTENT);
         }
 
-        if (!badTA && !badP1 && !badP2) return root;
+        if (!badTA && !badP1 && !badP2) return new LlmGenerationResult<>(root, LlmTokenUsage.empty());
 
         ChatClient rewriteClient = llmRouter.route(REWRITE_PROVIDER);
+        LlmTokenUsage tokenUsage = LlmTokenUsage.empty();
 
         if (badTA) {
             log.debug("[TypeReportRewrite] typeAnalysis invalid. len={}, twoParagraph={}", typeAnalysis.length(), validTwoParagraphs(typeAnalysis));
-            StyledText rewritten = rewriteTypeAnalysis(rewriteClient, sourceTypeAnalysisContent.styledText());
+            LlmGenerationResult<StyledText> rewriteResult =
+                    rewriteTypeAnalysis(rewriteClient, sourceTypeAnalysisContent.styledText());
+            StyledText rewritten = rewriteResult.content();
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
             validateStyledText(rewritten, true);
             TypeTextContent rewrittenContent = new TypeTextContent(rewritten).normalized();
             root.set("typeAnalysisContent", objectMapper.valueToTree(rewrittenContent));
@@ -157,14 +167,18 @@ public class TypeReportLlmClient {
             ObjectNode p0 = (ObjectNode) personasArr.get(0);
             String in = safeText(p0.get("content"));
             log.debug("[TypeReportRewrite] personas[0].content invalid. len={}", in.length());
-            p0.put("content", rewritePersonaContent(rewriteClient, in, 1));
+            LlmGenerationResult<String> rewriteResult = rewritePersonaContent(rewriteClient, in, 1);
+            p0.put("content", rewriteResult.content());
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
         }
 
         if (personasArr.size() >= 2 && badP2 && personasArr.get(1).isObject()) {
             ObjectNode p1 = (ObjectNode) personasArr.get(1);
             String in = safeText(p1.get("content"));
             log.debug("[TypeReportRewrite] personas[1].content invalid. len={}", in.length());
-            p1.put("content", rewritePersonaContent(rewriteClient, in, 2));
+            LlmGenerationResult<String> rewriteResult = rewritePersonaContent(rewriteClient, in, 2);
+            p1.put("content", rewriteResult.content());
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
         }
 
         // ===== rewrite 후 검증(원인별 코드로) =====
@@ -195,7 +209,7 @@ public class TypeReportLlmClient {
             }
         }
 
-        return root;
+        return new LlmGenerationResult<>(root, tokenUsage);
     }
 
     private void validateRichContentsIfPresent(ObjectNode root) {
@@ -273,7 +287,7 @@ public class TypeReportLlmClient {
         }
     }
 
-    private StyledText rewriteTypeAnalysis(ChatClient client, StyledText in) {
+    private LlmGenerationResult<StyledText> rewriteTypeAnalysis(ChatClient client, StyledText in) {
         StyledText inputStyled = in == null ? new StyledText(List.of(new Segment("", List.of()))) : in.normalized();
         String jsonInput;
         try {
@@ -312,12 +326,14 @@ public class TypeReportLlmClient {
                 .temperature(0.0)
                 .build();
 
-        String out;
+        ChatResponse response;
         try {
-            out = client.prompt().user(prompt).options(options).call().content();
+            response = client.prompt().user(prompt).options(options).call().chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.TYPE_REPORT_REWRITE_NO_RESPONSE, e);
         }
+        String out = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (out == null || out.isBlank()) {
             throw new AiServiceUnavailableException(ErrorCode.TYPE_REPORT_REWRITE_NO_RESPONSE);
@@ -328,7 +344,7 @@ public class TypeReportLlmClient {
             if (rewritten == null || rewritten.segments() == null || rewritten.segments().isEmpty()) {
                 throw new AiResponseParseException(ErrorCode.TYPE_REPORT_REWRITE_OUTPUT_EMPTY);
             }
-            return rewritten;
+            return new LlmGenerationResult<>(rewritten, tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (JsonParseException e) {
@@ -369,7 +385,7 @@ public class TypeReportLlmClient {
         }
     }
 
-    private String rewritePersonaContent(ChatClient client, String in, int personaIndex) {
+    private LlmGenerationResult<String> rewritePersonaContent(ChatClient client, String in, int personaIndex) {
         String prompt = """
         아래 'personas[%d].content' 본문은 의미는 유지하되 글자수 규칙을 맞춰야 해요.
         의미는 유지하면서 글자수(공백 포함)를 최소 %d자 ~ 최대 %d자로 맞춰서 다시 써줘요.
@@ -406,12 +422,14 @@ public class TypeReportLlmClient {
                 .temperature(0.0)
                 .build();
 
-        String out;
+        ChatResponse response;
         try {
-            out = client.prompt().user(prompt).options(options).call().content();
+            response = client.prompt().user(prompt).options(options).call().chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.TYPE_REPORT_REWRITE_NO_RESPONSE, e);
         }
+        String out = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (out == null || out.isBlank()) {
             throw new AiServiceUnavailableException(ErrorCode.TYPE_REPORT_REWRITE_NO_RESPONSE);
@@ -421,7 +439,7 @@ public class TypeReportLlmClient {
             JsonNode node = objectMapper.readTree(out);
             String text = safeText(node.get("text")).trim();
             if (blank(text)) throw new AiResponseParseException(ErrorCode.TYPE_REPORT_REWRITE_OUTPUT_EMPTY);
-            return text;
+            return new LlmGenerationResult<>(text, tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (JsonParseException e) {
@@ -457,6 +475,13 @@ public class TypeReportLlmClient {
     private String safeText(JsonNode node) {
         if (node == null || node.isNull() || !node.isTextual()) return "";
         return node.asText();
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 
     private boolean blank(String s) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeSelectLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/typereport/infra/TypeSelectLlmClient.java
@@ -5,12 +5,16 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.stereotype.Component;
@@ -25,7 +29,7 @@ public class TypeSelectLlmClient {
 
     private final LlmProvider provider = LlmProvider.OPENAI;
 
-    public JsonNode selectTypeRawJson(String candidatesText, String patternsText) {
+    public LlmGenerationResult<JsonNode> selectTypeRawJson(String candidatesText, String patternsText) {
         if (candidatesText == null || candidatesText.isBlank() || patternsText == null || patternsText.isBlank()) {
             throw new AiResponseParseException(ErrorCode.TYPE_SELECT_INPUT_EMPTY);
         }
@@ -41,27 +45,36 @@ public class TypeSelectLlmClient {
                 .temperature(0.0)
                 .build();
 
-        String content;
+        ChatResponse response;
         try {
-            content = client.prompt()
+            response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_TYPE_SELECT_NO_RESPONSE, e);
         }
+        String content = extractContent(response);
+        LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_TYPE_SELECT_NO_RESPONSE);
         }
 
         try {
-            return objectMapper.readTree(content);
+            return new LlmGenerationResult<>(objectMapper.readTree(content), tokenUsage);
         } catch (AiResponseParseException e) {
             throw e;
         } catch (Exception e) {
             throw new AiResponseParseException(ErrorCode.TYPE_SELECT_JSON_MISSING_FIELDS);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/weeklyreport/application/listener/WeeklyReportGenerationListener.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/weeklyreport/application/listener/WeeklyReportGenerationListener.java
@@ -10,7 +10,9 @@ import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.WeeklyReportGenerationRequestedEventDto;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.repository.WeeklyQueryRepository;
 import com.devkor.ifive.nadab.domain.weeklyreport.infra.WeeklyReportLlmClient;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.devkor.ifive.nadab.global.shared.reportcontent.AiReportResultDto;
 import com.devkor.ifive.nadab.global.shared.util.WeekRangeCalculator;
 import com.devkor.ifive.nadab.global.shared.util.dto.WeekRangeDto;
@@ -58,7 +60,17 @@ public class WeeklyReportGenerationListener {
         );
         try {
             // 트랜잭션 밖(백그라운드)에서 LLM 호출
-            dto = weeklyReportLlmClient.generate(range.weekStartDate().toString(), range.weekEndDate().toString(), entries);
+            LlmGenerationResult<AiReportResultDto> generationResult =
+                    weeklyReportLlmClient.generate(range.weekStartDate().toString(), range.weekEndDate().toString(), entries);
+            dto = generationResult.content();
+            LlmTokenUsage tokenUsage = generationResult.tokenUsage();
+            reportGenerationLogRecorder.recordTokenUsage(
+                    generationLogId,
+                    tokenUsage.inputTokens(),
+                    tokenUsage.outputTokens(),
+                    tokenUsage.totalTokens(),
+                    tokenUsage.thinkingTokens()
+            );
             reportGenerationLogRecorder.succeed(generationLogId);
         } catch (Exception e) {
             reportGenerationLogRecorder.fail(generationLogId, e);

--- a/src/main/java/com/devkor/ifive/nadab/domain/weeklyreport/infra/WeeklyReportLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/weeklyreport/infra/WeeklyReportLlmClient.java
@@ -5,8 +5,11 @@ import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
 import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
 import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
 import com.devkor.ifive.nadab.global.shared.reportcontent.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.anthropic.api.AnthropicApi;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.openai.OpenAiChatOptions;
@@ -52,7 +56,7 @@ public class WeeklyReportLlmClient {
      * @param weekEndDate   예: 2026-01-07
      * @param entries       WeeklyEntriesAssembler 결과 문자열
      */
-    public AiReportResultDto generate(String weekStartDate, String weekEndDate, String entries) {
+    public LlmGenerationResult<AiReportResultDto> generate(String weekStartDate, String weekEndDate, String entries) {
 
         if (isBlank(entries)) {
             throw new AiResponseParseException(ErrorCode.WEEKLY_REPORT_INPUT_ENTRIES_EMPTY);
@@ -65,11 +69,13 @@ public class WeeklyReportLlmClient {
 
         ChatClient client = llmRouter.route(provider);
 
-        String content = switch (provider) {
+        LlmGenerationResult<String> generationResult = switch (provider) {
             case OPENAI -> callOpenAi(client, prompt);
             case CLAUDE -> callClaude(client, prompt);
             case GEMINI -> callGemini(client, prompt);
         };
+        String content = generationResult.content();
+        LlmTokenUsage tokenUsage = generationResult.tokenUsage();
 
         if (content == null || content.trim().isEmpty()) {
             throw new AiServiceUnavailableException(ErrorCode.AI_NO_RESPONSE);
@@ -108,12 +114,15 @@ public class WeeklyReportLlmClient {
             }
 
             // 길이 맞추기(StyledText 자체 리라이트)
-            AiReportResultDto dto = enforceLength(new AiReportResultDto(reportContent, discovered, improve));
+            LlmGenerationResult<AiReportResultDto> lengthResult =
+                    enforceLength(new AiReportResultDto(reportContent, discovered, improve));
+            AiReportResultDto dto = lengthResult.content();
+            tokenUsage = tokenUsage.plus(lengthResult.tokenUsage());
 
             // 최종 길이 검증
             validateLength(dto);
 
-            return dto;
+            return new LlmGenerationResult<>(dto, tokenUsage);
 
         } catch (AiResponseParseException e) {
             throw e;
@@ -123,7 +132,7 @@ public class WeeklyReportLlmClient {
         }
     }
 
-    private String callOpenAi(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callOpenAi(ChatClient client, String prompt) {
         OpenAiChatOptions options = OpenAiChatOptions.builder()
                 .model(OpenAiApi.ChatModel.GPT_5_MINI)
                 .reasoningEffort("medium")
@@ -131,34 +140,36 @@ public class WeeklyReportLlmClient {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callClaude(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callClaude(ChatClient client, String prompt) {
         AnthropicChatOptions options = AnthropicChatOptions.builder()
                 .model(AnthropicApi.ChatModel.CLAUDE_3_HAIKU)
                 .temperature(0.3)
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private String callGemini(ChatClient client, String prompt) {
+    private LlmGenerationResult<String> callGemini(ChatClient client, String prompt) {
         GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
                 .model(GoogleGenAiChatModel.ChatModel.GEMINI_2_5_FLASH)
                 .responseMimeType("application/json")
@@ -166,17 +177,18 @@ public class WeeklyReportLlmClient {
                 .build();
 
         try {
-            return client.prompt()
+            ChatResponse response = client.prompt()
                     .user(prompt)
                     .options(options)
                     .call()
-                    .content();
+                    .chatResponse();
+            return new LlmGenerationResult<>(extractContent(response), LlmTokenUsageExtractor.extract(response));
         } catch (Exception e) {
             throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
         }
     }
 
-    private AiReportResultDto enforceLength(AiReportResultDto dto) {
+    private LlmGenerationResult<AiReportResultDto> enforceLength(AiReportResultDto dto) {
         ReportContent c = dto.content();
 
         int dLen = dto.discovered().length();
@@ -185,15 +197,24 @@ public class WeeklyReportLlmClient {
         boolean badD = dLen < MIN_DISCOVERED || dLen > MAX_DISCOVERED;
         boolean badI = iLen < MIN_IMPROVE || iLen > MAX_IMPROVE;
 
-        if (!badD && !badI) return dto;
+        if (!badD && !badI) return new LlmGenerationResult<>(dto, LlmTokenUsage.empty());
 
         ChatClient rewriteClient = llmRouter.route(REWRITE_PROVIDER);
 
         StyledText d = c.discovered();
         StyledText i = c.improve();
+        LlmTokenUsage tokenUsage = LlmTokenUsage.empty();
 
-        if (badD) d = rewriteStyled(rewriteClient, d, true);
-        if (badI) i = rewriteStyled(rewriteClient, i, false);
+        if (badD) {
+            LlmGenerationResult<StyledText> rewriteResult = rewriteStyled(rewriteClient, d, true);
+            d = rewriteResult.content();
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
+        }
+        if (badI) {
+            LlmGenerationResult<StyledText> rewriteResult = rewriteStyled(rewriteClient, i, false);
+            i = rewriteResult.content();
+            tokenUsage = tokenUsage.plus(rewriteResult.tokenUsage());
+        }
 
         ReportContent newContent = new ReportContent(c.summary(), d, i);
         String newD = newContent.discovered().plainText();
@@ -206,10 +227,10 @@ public class WeeklyReportLlmClient {
             throw new AiResponseParseException(ErrorCode.WEEKLY_REPORT_REWRITE_FORMAT_INVALID);
         }
 
-        return new AiReportResultDto(newContent, newD, newI);
+        return new LlmGenerationResult<>(new AiReportResultDto(newContent, newD, newI), tokenUsage);
     }
 
-    private StyledText rewriteStyled(ChatClient client, StyledText in, boolean isDiscovered) {
+    private LlmGenerationResult<StyledText> rewriteStyled(ChatClient client, StyledText in, boolean isDiscovered) {
         int min = isDiscovered ? MIN_DISCOVERED : MIN_IMPROVE;
         int max = isDiscovered ? MAX_DISCOVERED : MAX_IMPROVE;
         int maxHl = isDiscovered ? MAX_HL_DISCOVERED : MAX_HL_IMPROVE;
@@ -242,19 +263,21 @@ public class WeeklyReportLlmClient {
                     .temperature(0.0)
                     .build();
 
-            String out;
+            ChatResponse response;
             try {
-                out = client.prompt().user(prompt).options(options).call().content();
+                response = client.prompt().user(prompt).options(options).call().chatResponse();
             } catch (Exception e) {
                 throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_REWRITE_NO_RESPONSE, e);
             }
+            String out = extractContent(response);
+            LlmTokenUsage tokenUsage = LlmTokenUsageExtractor.extract(response);
 
             if (out == null || out.isBlank()) {
                 throw new AiServiceUnavailableException(ErrorCode.AI_REWRITE_NO_RESPONSE);
             }
 
             try {
-                return objectMapper.readValue(out, StyledText.class);
+                return new LlmGenerationResult<>(objectMapper.readValue(out, StyledText.class), tokenUsage);
             } catch (Exception e) {
                 throw new AiResponseParseException(ErrorCode.WEEKLY_REPORT_REWRITE_JSON_MAPPING_FAILED);
             }
@@ -265,6 +288,13 @@ public class WeeklyReportLlmClient {
             // writeValueAsString 실패 (거의 내부 문제)
             throw new AiResponseParseException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
     }
 
     private boolean isBlank(String s) {

--- a/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmGenerationResult.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmGenerationResult.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.global.infra.llm;
+
+public record LlmGenerationResult<T>(
+        T content,
+        LlmTokenUsage tokenUsage
+) {
+
+    public LlmGenerationResult {
+        if (tokenUsage == null) {
+            tokenUsage = LlmTokenUsage.empty();
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsage.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsage.java
@@ -3,11 +3,16 @@ package com.devkor.ifive.nadab.global.infra.llm;
 public record LlmTokenUsage(
         Long inputTokens,
         Long outputTokens,
-        Long totalTokens
+        Long totalTokens,
+        Long thinkingTokens
 ) {
 
+    public LlmTokenUsage(Long inputTokens, Long outputTokens, Long totalTokens) {
+        this(inputTokens, outputTokens, totalTokens, null);
+    }
+
     public static LlmTokenUsage empty() {
-        return new LlmTokenUsage(null, null, null);
+        return new LlmTokenUsage(null, null, null, null);
     }
 
     public LlmTokenUsage plus(LlmTokenUsage other) {
@@ -17,7 +22,8 @@ public record LlmTokenUsage(
         return new LlmTokenUsage(
                 add(inputTokens, other.inputTokens),
                 add(outputTokens, other.outputTokens),
-                add(totalTokens, other.totalTokens)
+                add(totalTokens, other.totalTokens),
+                add(thinkingTokens, other.thinkingTokens)
         );
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsage.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsage.java
@@ -1,0 +1,33 @@
+package com.devkor.ifive.nadab.global.infra.llm;
+
+public record LlmTokenUsage(
+        Long inputTokens,
+        Long outputTokens,
+        Long totalTokens
+) {
+
+    public static LlmTokenUsage empty() {
+        return new LlmTokenUsage(null, null, null);
+    }
+
+    public LlmTokenUsage plus(LlmTokenUsage other) {
+        if (other == null) {
+            return this;
+        }
+        return new LlmTokenUsage(
+                add(inputTokens, other.inputTokens),
+                add(outputTokens, other.outputTokens),
+                add(totalTokens, other.totalTokens)
+        );
+    }
+
+    private Long add(Long left, Long right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+        return left + right;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractor.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractor.java
@@ -1,0 +1,34 @@
+package com.devkor.ifive.nadab.global.infra.llm;
+
+import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+public final class LlmTokenUsageExtractor {
+
+    private LlmTokenUsageExtractor() {
+    }
+
+    public static LlmTokenUsage extract(ChatResponse response) {
+        if (response == null || response.getMetadata() == null) {
+            return LlmTokenUsage.empty();
+        }
+        return extract(response.getMetadata().getUsage());
+    }
+
+    public static LlmTokenUsage extract(Usage usage) {
+        if (usage == null || usage instanceof EmptyUsage) {
+            return LlmTokenUsage.empty();
+        }
+
+        return new LlmTokenUsage(
+                toLong(usage.getPromptTokens()),
+                toLong(usage.getCompletionTokens()),
+                toLong(usage.getTotalTokens())
+        );
+    }
+
+    private static Long toLong(Integer value) {
+        return value == null ? null : value.longValue();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractor.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractor.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.global.infra.llm;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.google.genai.metadata.GoogleGenAiUsage;
 
 public final class LlmTokenUsageExtractor {
 
@@ -24,8 +25,16 @@ public final class LlmTokenUsageExtractor {
         return new LlmTokenUsage(
                 toLong(usage.getPromptTokens()),
                 toLong(usage.getCompletionTokens()),
-                toLong(usage.getTotalTokens())
+                toLong(usage.getTotalTokens()),
+                extractThinkingTokens(usage)
         );
+    }
+
+    private static Long extractThinkingTokens(Usage usage) {
+        if (usage instanceof GoogleGenAiUsage googleUsage) {
+            return toLong(googleUsage.getThoughtsTokenCount());
+        }
+        return null;
     }
 
     private static Long toLong(Integer value) {

--- a/src/main/resources/db/migration/V20260708_1200__IS_add_token_usage_to_report_generation_logs.sql
+++ b/src/main/resources/db/migration/V20260708_1200__IS_add_token_usage_to_report_generation_logs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE report_generation_logs
+    ADD COLUMN input_tokens BIGINT,
+    ADD COLUMN output_tokens BIGINT,
+    ADD COLUMN total_tokens BIGINT;

--- a/src/main/resources/db/migration/V20260708_1500__IS_add_thinking_tokens_to_report_generation_logs.sql
+++ b/src/main/resources/db/migration/V20260708_1500__IS_add_thinking_tokens_to_report_generation_logs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE report_generation_logs
+    ADD COLUMN thinking_tokens BIGINT;

--- a/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
@@ -1,0 +1,194 @@
+package com.devkor.ifive.nadab.domain.dailyreport.application;
+
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.request.DailyReportRequest;
+import com.devkor.ifive.nadab.domain.dailyreport.api.dto.response.CreateDailyReportResponse;
+import com.devkor.ifive.nadab.domain.dailyreport.core.dto.AiDailyReportResultDto;
+import com.devkor.ifive.nadab.domain.dailyreport.core.dto.ConfirmDailyAndRewardDto;
+import com.devkor.ifive.nadab.domain.dailyreport.core.dto.PrepareDailyResultDto;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.AnswerEntry;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.Emotion;
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.EmotionCode;
+import com.devkor.ifive.nadab.domain.dailyreport.infra.DailyReportLlmClient;
+import com.devkor.ifive.nadab.domain.question.core.entity.DailyQuestion;
+import com.devkor.ifive.nadab.domain.question.core.entity.UserDailyQuestion;
+import com.devkor.ifive.nadab.domain.question.core.repository.DailyQuestionRepository;
+import com.devkor.ifive.nadab.domain.question.core.repository.UserDailyQuestionRepository;
+import com.devkor.ifive.nadab.domain.reportlog.application.ReportGenerationLogRecorder;
+import com.devkor.ifive.nadab.domain.reportlog.core.entity.ReportGenerationStep;
+import com.devkor.ifive.nadab.domain.reportlog.core.entity.ReportGenerationType;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.domain.user.core.service.ProfileImageService;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyReportServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    DailyQuestionRepository dailyQuestionRepository;
+
+    @Mock
+    UserDailyQuestionRepository userDailyQuestionRepository;
+
+    @Mock
+    DailyReportTxService dailyReportTxService;
+
+    @Mock
+    ProfileImageService profileImageService;
+
+    @Mock
+    DailyReportLlmClient dailyReportLlmClient;
+
+    @Mock
+    ReportGenerationLogRecorder reportGenerationLogRecorder;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    ProfileImageUrlBuilder profileImageUrlBuilder;
+
+    DailyReportService dailyReportService;
+
+    @BeforeEach
+    void setUp() {
+        dailyReportService = new DailyReportService(
+                userRepository,
+                dailyQuestionRepository,
+                userDailyQuestionRepository,
+                dailyReportTxService,
+                profileImageService,
+                dailyReportLlmClient,
+                reportGenerationLogRecorder,
+                eventPublisher,
+                profileImageUrlBuilder
+        );
+        ReflectionTestUtils.setField(dailyReportService, "env", "test");
+    }
+
+    @Test
+    void generate_daily_report_records_token_usage_before_succeeding_generation_log() {
+        // given
+        Long userId = 1L;
+        Long reportId = 100L;
+        Long generationLogId = 10L;
+        User user = user(userId);
+        DailyQuestion question = dailyQuestion(20L);
+        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", LocalDate.now(), null);
+        AiDailyReportResultDto aiResult = new AiDailyReportResultDto("message", "ACHIEVEMENT");
+        Emotion emotion = emotion(EmotionCode.ACHIEVEMENT);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(dailyQuestionRepository.findByIdWithInterest(20L)).thenReturn(Optional.of(question));
+        when(userDailyQuestionRepository.findByUserIdAndDate(eq(userId), any(LocalDate.class)))
+                .thenReturn(Optional.of(UserDailyQuestion.create(user, LocalDate.now(), question)));
+        when(dailyReportTxService.prepareDaily(user, question, "answer", false, null))
+                .thenReturn(new PrepareDailyResultDto(answerEntry, reportId, userId));
+        when(reportGenerationLogRecorder.start(
+                userId,
+                ReportGenerationType.DAILY,
+                reportId,
+                ReportGenerationStep.DAILY_GENERATE,
+                LlmProvider.OPENAI,
+                "GPT_4_O_MINI"
+        )).thenReturn(generationLogId);
+        when(dailyReportLlmClient.generate("question", answerEntry))
+                .thenReturn(new LlmGenerationResult<>(aiResult, new LlmTokenUsage(100L, 50L, 150L)));
+        when(dailyReportTxService.confirmDailyAndReward(
+                any(PrepareDailyResultDto.class),
+                eq(aiResult),
+                eq(null)
+        )).thenReturn(new ConfirmDailyAndRewardDto(emotion, 110L));
+
+        // when
+        CreateDailyReportResponse response = dailyReportService.generateDailyReport(
+                userId,
+                new DailyReportRequest(20L, "answer", null, null)
+        );
+
+        // then
+        assertThat(response.reportId()).isEqualTo(reportId);
+        assertThat(response.content()).isEqualTo("message");
+        assertThat(response.balanceAfter()).isEqualTo(110L);
+
+        InOrder inOrder = inOrder(reportGenerationLogRecorder);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, 100L, 50L, 150L);
+        inOrder.verify(reportGenerationLogRecorder).succeed(generationLogId);
+    }
+
+    @Test
+    void generate_daily_report_records_null_token_usage_when_usage_is_empty() {
+        // given
+        Long userId = 1L;
+        Long reportId = 100L;
+        Long generationLogId = 10L;
+        User user = user(userId);
+        DailyQuestion question = dailyQuestion(20L);
+        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", LocalDate.now(), null);
+        AiDailyReportResultDto aiResult = new AiDailyReportResultDto("message", "ACHIEVEMENT");
+        Emotion emotion = emotion(EmotionCode.ACHIEVEMENT);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(dailyQuestionRepository.findByIdWithInterest(20L)).thenReturn(Optional.of(question));
+        when(userDailyQuestionRepository.findByUserIdAndDate(eq(userId), any(LocalDate.class)))
+                .thenReturn(Optional.of(UserDailyQuestion.create(user, LocalDate.now(), question)));
+        when(dailyReportTxService.prepareDaily(user, question, "answer", false, null))
+                .thenReturn(new PrepareDailyResultDto(answerEntry, reportId, userId));
+        when(reportGenerationLogRecorder.start(any(), any(), any(), any(), any(), any()))
+                .thenReturn(generationLogId);
+        when(dailyReportLlmClient.generate("question", answerEntry))
+                .thenReturn(new LlmGenerationResult<>(aiResult, LlmTokenUsage.empty()));
+        when(dailyReportTxService.confirmDailyAndReward(any(), eq(aiResult), eq(null)))
+                .thenReturn(new ConfirmDailyAndRewardDto(emotion, 110L));
+
+        // when
+        dailyReportService.generateDailyReport(userId, new DailyReportRequest(20L, "answer", null, null));
+
+        // then
+        verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, null, null, null);
+    }
+
+    private User user(Long id) {
+        User user = User.createUser("test@test.com", "hashed_password");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private DailyQuestion dailyQuestion(Long id) {
+        DailyQuestion question = mock(DailyQuestion.class);
+        when(question.getId()).thenReturn(id);
+        when(question.getQuestionText()).thenReturn("question");
+        return question;
+    }
+
+    private Emotion emotion(EmotionCode code) {
+        Emotion emotion = mock(Emotion.class);
+        when(emotion.getCode()).thenReturn(code);
+        return emotion;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
@@ -137,7 +137,7 @@ class DailyReportServiceTest {
         assertThat(response.balanceAfter()).isEqualTo(110L);
 
         InOrder inOrder = inOrder(reportGenerationLogRecorder);
-        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, 100L, 50L, 150L);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, 100L, 50L, 150L, null);
         inOrder.verify(reportGenerationLogRecorder).succeed(generationLogId);
     }
 
@@ -170,7 +170,7 @@ class DailyReportServiceTest {
         dailyReportService.generateDailyReport(userId, new DailyReportRequest(20L, "answer", null, null));
 
         // then
-        verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, null, null, null);
+        verify(reportGenerationLogRecorder).recordTokenUsage(generationLogId, null, null, null, null);
     }
 
     private User user(Long id) {

--- a/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClientTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/infra/DailyReportLlmClientTest.java
@@ -1,0 +1,107 @@
+package com.devkor.ifive.nadab.domain.dailyreport.infra;
+
+import com.devkor.ifive.nadab.domain.dailyreport.core.entity.AnswerEntry;
+import com.devkor.ifive.nadab.domain.question.core.entity.DailyQuestion;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.global.core.prompt.daily.DailyReportPromptLoader;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyReportLlmClientTest {
+
+    @Mock
+    DailyReportPromptLoader dailyReportPromptLoader;
+
+    @Mock
+    LlmRouter llmRouter;
+
+    @Mock
+    ProfileImageUrlBuilder profileImageUrlBuilder;
+
+    @Mock
+    ChatClient chatClient;
+
+    @Mock
+    ChatClient.ChatClientRequestSpec requestSpec;
+
+    @Mock
+    ChatClient.CallResponseSpec callResponseSpec;
+
+    @Test
+    void generate_returns_content_with_token_usage() {
+        // given
+        DailyReportLlmClient client = new DailyReportLlmClient(
+                dailyReportPromptLoader,
+                new ObjectMapper(),
+                llmRouter,
+                profileImageUrlBuilder
+        );
+        AnswerEntry answerEntry = AnswerEntry.create(
+                User.createUser("test@test.com", "hashed_password"),
+                dailyQuestion(1L),
+                "answer",
+                LocalDate.now(),
+                null
+        );
+
+        when(dailyReportPromptLoader.loadPrompt()).thenReturn("question={question}, answer={answer}");
+        when(dailyReportPromptLoader.loadWithImagePrompt()).thenReturn("image question={question}, answer={answer}");
+        when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.messages(any(Message[].class))).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse(
+                "{\"message\":\"good\",\"emotion\":\"ACHIEVEMENT\"}",
+                new DefaultUsage(100, 50, 150)
+        ));
+
+        // when
+        LlmGenerationResult<?> result = client.generate("question", answerEntry);
+
+        // then
+        assertThat(result.content()).isEqualTo(new com.devkor.ifive.nadab.domain.dailyreport.core.dto.AiDailyReportResultDto(
+                "good",
+                "ACHIEVEMENT"
+        ));
+        assertThat(result.tokenUsage().inputTokens()).isEqualTo(100L);
+        assertThat(result.tokenUsage().outputTokens()).isEqualTo(50L);
+        assertThat(result.tokenUsage().totalTokens()).isEqualTo(150L);
+    }
+
+    private ChatResponse chatResponse(String content, DefaultUsage usage) {
+        return new ChatResponse(
+                List.of(new Generation(new AssistantMessage(content))),
+                ChatResponseMetadata.builder()
+                        .usage(usage)
+                        .build()
+        );
+    }
+
+    private DailyQuestion dailyQuestion(Long id) {
+        return mock(DailyQuestion.class);
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2Test.java
@@ -24,6 +24,7 @@ import com.devkor.ifive.nadab.global.shared.reportcontent.StyledText;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +35,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -103,7 +105,9 @@ class MonthlyReportGenerationListenerV2Test {
         assertThat(context.dominantKeyword()).isEqualTo("성장");
         assertThat(context.stylePreset()).isEqualTo(MonthlyImageStylePreset.INK_WASH);
         assertThat(context.colorPalette()).isEqualTo(MonthlyImageColorPalette.OCEAN_LIGHT);
-        verify(reportGenerationLogRecorder).recordTokenUsage(200L, 100L, 50L, 150L, 30L);
+        InOrder inOrder = inOrder(reportGenerationLogRecorder);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(200L, 100L, 50L, 150L, 30L);
+        inOrder.verify(reportGenerationLogRecorder).succeed(200L);
         verify(monthlyReportTxServiceV2).confirmMonthly(10L, 100L, "monthly/1/10.webp");
     }
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/listener/MonthlyReportGenerationListenerV2Test.java
@@ -18,6 +18,8 @@ import com.devkor.ifive.nadab.domain.monthlyreport.infra.MonthlyReportImageStora
 import com.devkor.ifive.nadab.domain.monthlyreport.infra.MonthlyReportLlmClientV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.infra.OpenAiImageClient;
 import com.devkor.ifive.nadab.domain.reportlog.application.ReportGenerationLogRecorder;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import com.devkor.ifive.nadab.global.shared.reportcontent.StyledText;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,8 +78,10 @@ class MonthlyReportGenerationListenerV2Test {
         when(monthlyWeeklySummariesService.buildWeeklySummaries(anyLong(), any())).thenReturn("");
         when(monthlySocialSummaryService.buildSocialSummary(anyLong(), any()))
                 .thenReturn(MonthlySocialSummaryContent.empty(1));
+        when(reportGenerationLogRecorder.start(anyLong(), any(), anyLong(), any(), any(), any()))
+                .thenReturn(200L, 201L, 202L, 203L);
         when(monthlyReportLlmClientV2.generate(any(), any(), any(), any(), any(), any()))
-                .thenReturn(result);
+                .thenReturn(new LlmGenerationResult<>(result, new LlmTokenUsage(100L, 50L, 150L, 30L)));
         when(monthlyImagePresetAssignmentService.getOrAssignVisualPreset(1L, 10L))
                 .thenReturn(new MonthlyImageVisualPreset(
                         MonthlyImageStylePreset.INK_WASH,
@@ -99,6 +103,7 @@ class MonthlyReportGenerationListenerV2Test {
         assertThat(context.dominantKeyword()).isEqualTo("성장");
         assertThat(context.stylePreset()).isEqualTo(MonthlyImageStylePreset.INK_WASH);
         assertThat(context.colorPalette()).isEqualTo(MonthlyImageColorPalette.OCEAN_LIGHT);
+        verify(reportGenerationLogRecorder).recordTokenUsage(200L, 100L, 50L, 150L, 30L);
         verify(monthlyReportTxServiceV2).confirmMonthly(10L, 100L, "monthly/1/10.webp");
     }
 
@@ -123,8 +128,10 @@ class MonthlyReportGenerationListenerV2Test {
         when(monthlyWeeklySummariesService.buildWeeklySummaries(anyLong(), any())).thenReturn("");
         when(monthlySocialSummaryService.buildSocialSummary(anyLong(), any()))
                 .thenReturn(MonthlySocialSummaryContent.empty(1));
+        when(reportGenerationLogRecorder.start(anyLong(), any(), anyLong(), any(), any(), any()))
+                .thenReturn(200L, 201L);
         when(monthlyReportLlmClientV2.generate(any(), any(), any(), any(), any(), any()))
-                .thenReturn(new AiMonthlyReportResultDto(content, null));
+                .thenReturn(new LlmGenerationResult<>(new AiMonthlyReportResultDto(content, null), LlmTokenUsage.empty()));
         when(monthlyImagePresetAssignmentService.getOrAssignVisualPreset(1L, 10L))
                 .thenThrow(new IllegalStateException("preset assignment failed"));
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/reportlog/ReportGenerationLogRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/reportlog/ReportGenerationLogRepositoryTest.java
@@ -86,7 +86,7 @@ class ReportGenerationLogRepositoryTest extends PostgresIntegrationTestSupport {
         // given
         User user = new UserBuilder(em).build();
         ReportGenerationLog log = startLog(user, ReportGenerationType.DAILY, 101L, ReportGenerationStep.DAILY_GENERATE);
-        log.recordTokenUsage(100L, 50L, 150L);
+        log.recordTokenUsage(100L, 50L, 150L, 30L);
         ReportGenerationLog saved = reportGenerationLogRepository.save(log);
 
         em.flush();
@@ -99,6 +99,7 @@ class ReportGenerationLogRepositoryTest extends PostgresIntegrationTestSupport {
         assertThat(found.getInputTokens()).isEqualTo(100L);
         assertThat(found.getOutputTokens()).isEqualTo(50L);
         assertThat(found.getTotalTokens()).isEqualTo(150L);
+        assertThat(found.getThinkingTokens()).isEqualTo(30L);
     }
 
     private ReportGenerationLog startLog(

--- a/src/test/java/com/devkor/ifive/nadab/domain/reportlog/ReportGenerationLogRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/reportlog/ReportGenerationLogRepositoryTest.java
@@ -81,6 +81,26 @@ class ReportGenerationLogRepositoryTest extends PostgresIntegrationTestSupport {
                 .containsOnly(ReportGenerationLogStatus.FAILED);
     }
 
+    @Test
+    void save_token_usage() {
+        // given
+        User user = new UserBuilder(em).build();
+        ReportGenerationLog log = startLog(user, ReportGenerationType.DAILY, 101L, ReportGenerationStep.DAILY_GENERATE);
+        log.recordTokenUsage(100L, 50L, 150L);
+        ReportGenerationLog saved = reportGenerationLogRepository.save(log);
+
+        em.flush();
+        em.clear();
+
+        // when
+        ReportGenerationLog found = reportGenerationLogRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getInputTokens()).isEqualTo(100L);
+        assertThat(found.getOutputTokens()).isEqualTo(50L);
+        assertThat(found.getTotalTokens()).isEqualTo(150L);
+    }
+
     private ReportGenerationLog startLog(
             User user,
             ReportGenerationType reportType,

--- a/src/test/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogServiceTest.java
@@ -82,6 +82,36 @@ class ReportGenerationLogServiceTest {
     }
 
     @Test
+    void record_token_usage_updates_token_fields() {
+        // given
+        ReportGenerationLog log = startLog();
+        when(reportGenerationLogRepository.findById(1L)).thenReturn(Optional.of(log));
+
+        // when
+        reportGenerationLogService.recordTokenUsage(1L, 100L, 50L, 150L);
+
+        // then
+        assertThat(log.getInputTokens()).isEqualTo(100L);
+        assertThat(log.getOutputTokens()).isEqualTo(50L);
+        assertThat(log.getTotalTokens()).isEqualTo(150L);
+    }
+
+    @Test
+    void record_token_usage_allows_null_values() {
+        // given
+        ReportGenerationLog log = startLog();
+        when(reportGenerationLogRepository.findById(1L)).thenReturn(Optional.of(log));
+
+        // when
+        reportGenerationLogService.recordTokenUsage(1L, null, null, null);
+
+        // then
+        assertThat(log.getInputTokens()).isNull();
+        assertThat(log.getOutputTokens()).isNull();
+        assertThat(log.getTotalTokens()).isNull();
+    }
+
+    @Test
     void fail_marks_log_failed_with_external_status() {
         // given
         ReportGenerationLog log = startLog();

--- a/src/test/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/reportlog/application/ReportGenerationLogServiceTest.java
@@ -88,12 +88,13 @@ class ReportGenerationLogServiceTest {
         when(reportGenerationLogRepository.findById(1L)).thenReturn(Optional.of(log));
 
         // when
-        reportGenerationLogService.recordTokenUsage(1L, 100L, 50L, 150L);
+        reportGenerationLogService.recordTokenUsage(1L, 100L, 50L, 150L, 30L);
 
         // then
         assertThat(log.getInputTokens()).isEqualTo(100L);
         assertThat(log.getOutputTokens()).isEqualTo(50L);
         assertThat(log.getTotalTokens()).isEqualTo(150L);
+        assertThat(log.getThinkingTokens()).isEqualTo(30L);
     }
 
     @Test
@@ -103,12 +104,13 @@ class ReportGenerationLogServiceTest {
         when(reportGenerationLogRepository.findById(1L)).thenReturn(Optional.of(log));
 
         // when
-        reportGenerationLogService.recordTokenUsage(1L, null, null, null);
+        reportGenerationLogService.recordTokenUsage(1L, null, null, null, null);
 
         // then
         assertThat(log.getInputTokens()).isNull();
         assertThat(log.getOutputTokens()).isNull();
         assertThat(log.getTotalTokens()).isNull();
+        assertThat(log.getThinkingTokens()).isNull();
     }
 
     @Test

--- a/src/test/java/com/devkor/ifive/nadab/domain/typereport/application/listener/TypeReportGenerationListenerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/typereport/application/listener/TypeReportGenerationListenerTest.java
@@ -1,0 +1,174 @@
+package com.devkor.ifive.nadab.domain.typereport.application.listener;
+
+import com.devkor.ifive.nadab.domain.reportlog.application.ReportGenerationLogRecorder;
+import com.devkor.ifive.nadab.domain.typereport.application.TypeReportTxService;
+import com.devkor.ifive.nadab.domain.typereport.core.content.TypeContentFactory;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.AnalysisTypeCandidateDto;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.EvidenceCardDto;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.PatternExtractionResultDto;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.TypeReportContentDto;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.TypeReportGenerationRequestedEventDto;
+import com.devkor.ifive.nadab.domain.typereport.core.dto.TypeSelectionResultDto;
+import com.devkor.ifive.nadab.domain.typereport.core.entity.TypeReport;
+import com.devkor.ifive.nadab.domain.typereport.core.repository.AnalysisTypeRepository;
+import com.devkor.ifive.nadab.domain.typereport.core.repository.TypeDailyEntryQueryRepository;
+import com.devkor.ifive.nadab.domain.typereport.core.repository.TypeReportRepository;
+import com.devkor.ifive.nadab.domain.typereport.core.service.EvidenceCardGenerationService;
+import com.devkor.ifive.nadab.domain.typereport.core.service.PatternExtractionService;
+import com.devkor.ifive.nadab.domain.typereport.core.service.TypeReportContentGenerationService;
+import com.devkor.ifive.nadab.domain.typereport.core.service.TypeSelectionService;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TypeReportGenerationListenerTest {
+
+    @Mock
+    TypeReportTxService typeReportTxService;
+
+    @Mock
+    TypeReportRepository typeReportRepository;
+
+    @Mock
+    TypeDailyEntryQueryRepository typeDailyEntryQueryRepository;
+
+    @Mock
+    AnalysisTypeRepository analysisTypeRepository;
+
+    @Mock
+    EvidenceCardGenerationService evidenceCardGenerationService;
+
+    @Mock
+    PatternExtractionService patternExtractionService;
+
+    @Mock
+    TypeSelectionService typeSelectionService;
+
+    @Mock
+    TypeReportContentGenerationService typeReportContentGenerationService;
+
+    @Mock
+    ReportGenerationLogRecorder reportGenerationLogRecorder;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    TypeReportGenerationListener listener;
+
+    @Test
+    void handle_records_token_usage_for_each_llm_step_before_succeeding_logs() {
+        // given
+        TypeReportGenerationRequestedEventDto event =
+                new TypeReportGenerationRequestedEventDto(10L, 1L, 100L, null);
+        TypeReport report = mock(TypeReport.class);
+        DailyEntryDto entry = dailyEntry();
+        EvidenceCardDto card = new EvidenceCardDto("D1", LocalDate.of(2026, 1, 1), "card");
+        PatternExtractionResultDto patterns = new PatternExtractionResultDto(
+                List.of(new PatternExtractionResultDto.PatternDto("pattern", List.of("D1"), "note"))
+        );
+        AnalysisTypeCandidateDto selectedType = new AnalysisTypeCandidateDto(
+                "TYPE_A", "name", "description", "#a", "#b", "#c"
+        );
+        TypeSelectionResultDto selection = new TypeSelectionResultDto(
+                "TYPE_A",
+                90,
+                List.of(new TypeSelectionResultDto.BecauseDto("pattern", List.of("D1")))
+        );
+        TypeReportContentDto content = typeReportContent();
+
+        when(typeReportRepository.findById(10L)).thenReturn(Optional.of(report));
+        when(report.getInterestCode()).thenReturn(InterestCode.ROUTINE);
+        when(typeDailyEntryQueryRepository.findRecentDailyEntriesByInterest(eq(1L), eq(InterestCode.ROUTINE), any()))
+                .thenReturn(List.of(entry));
+        when(typeDailyEntryQueryRepository.countCompletedEmotionStatsByInterest(anyLong(), eq(InterestCode.ROUTINE), any()))
+                .thenReturn(List.of());
+        when(reportGenerationLogRecorder.start(anyLong(), any(), anyLong(), any(), any(), any()))
+                .thenReturn(200L, 201L, 202L, 203L, 204L);
+        when(evidenceCardGenerationService.generate(List.of(entry)))
+                .thenReturn(new LlmGenerationResult<>(List.of(card), new LlmTokenUsage(10L, 5L, 15L, null)));
+        when(patternExtractionService.extract(List.of(card)))
+                .thenReturn(new LlmGenerationResult<>(patterns, new LlmTokenUsage(20L, 6L, 26L, null)));
+        when(analysisTypeRepository.findCandidatesByInterestCode(InterestCode.ROUTINE))
+                .thenReturn(List.of(selectedType));
+        when(typeSelectionService.select(List.of(selectedType), patterns))
+                .thenReturn(new LlmGenerationResult<>(selection, new LlmTokenUsage(30L, 7L, 37L, null)));
+        when(typeReportContentGenerationService.generate(selectedType, patterns, List.of(card), TypeContentFactory.emptyEmotionStats().normalized(), "TYPE_A"))
+                .thenReturn(new LlmGenerationResult<>(content, new LlmTokenUsage(40L, 8L, 80L, 32L)));
+
+        // when
+        listener.handle(event);
+
+        // then
+        InOrder inOrder = inOrder(reportGenerationLogRecorder);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(200L, 10L, 5L, 15L, null);
+        inOrder.verify(reportGenerationLogRecorder).succeed(200L);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(201L, 20L, 6L, 26L, null);
+        inOrder.verify(reportGenerationLogRecorder).succeed(201L);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(202L, 30L, 7L, 37L, null);
+        inOrder.verify(reportGenerationLogRecorder).succeed(202L);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(203L, 40L, 8L, 80L, 32L);
+        inOrder.verify(reportGenerationLogRecorder).succeed(203L);
+        inOrder.verify(reportGenerationLogRecorder).succeed(204L);
+
+        verify(typeReportTxService).confirmType(
+                10L,
+                100L,
+                null,
+                "TYPE_A",
+                content.typeAnalysis(),
+                content.typeAnalysisContent(),
+                content.emotionSummaryContent(),
+                TypeContentFactory.emptyEmotionStats().normalized(),
+                "persona1",
+                "content1",
+                "persona2",
+                "content2"
+        );
+        verify(eventPublisher).publishEvent(any(Object.class));
+    }
+
+    private DailyEntryDto dailyEntry() {
+        return new DailyEntryDto(
+                LocalDate.of(2026, 1, 1),
+                "question",
+                "answer",
+                "daily report",
+                null
+        );
+    }
+
+    private TypeReportContentDto typeReportContent() {
+        return new TypeReportContentDto(
+                "TYPE_A",
+                "type analysis",
+                TypeContentFactory.fromPlainText("type analysis").normalized(),
+                TypeContentFactory.emptyText().normalized(),
+                List.of(
+                        new TypeReportContentDto.PersonaDto("persona1", "content1"),
+                        new TypeReportContentDto.PersonaDto("persona2", "content2")
+                )
+        );
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/weeklyreport/application/listener/WeeklyReportGenerationListenerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/weeklyreport/application/listener/WeeklyReportGenerationListenerTest.java
@@ -1,0 +1,94 @@
+package com.devkor.ifive.nadab.domain.weeklyreport.application.listener;
+
+import com.devkor.ifive.nadab.domain.reportlog.application.ReportGenerationLogRecorder;
+import com.devkor.ifive.nadab.domain.weeklyreport.application.WeeklyReportTxService;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.DailyEntryDto;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.dto.WeeklyReportGenerationRequestedEventDto;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.repository.WeeklyQueryRepository;
+import com.devkor.ifive.nadab.domain.weeklyreport.infra.WeeklyReportLlmClient;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.shared.reportcontent.AiReportResultDto;
+import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContent;
+import com.devkor.ifive.nadab.global.shared.reportcontent.Segment;
+import com.devkor.ifive.nadab.global.shared.reportcontent.StyledText;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyReportGenerationListenerTest {
+
+    @Mock
+    WeeklyQueryRepository weeklyQueryRepository;
+
+    @Mock
+    WeeklyReportLlmClient weeklyReportLlmClient;
+
+    @Mock
+    WeeklyReportTxService weeklyReportTxService;
+
+    @Mock
+    ReportGenerationLogRecorder reportGenerationLogRecorder;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    WeeklyReportGenerationListener listener;
+
+    @Test
+    void handle_records_token_usage_before_generation_log_succeeds() {
+        WeeklyReportGenerationRequestedEventDto event =
+                new WeeklyReportGenerationRequestedEventDto(10L, 1L, 100L);
+        AiReportResultDto aiResult = aiResult();
+
+        when(weeklyQueryRepository.findWeeklyInputs(anyLong(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(List.of(dailyEntry()));
+        when(reportGenerationLogRecorder.start(anyLong(), any(), anyLong(), any(), any(), any()))
+                .thenReturn(200L, 201L);
+        when(weeklyReportLlmClient.generate(anyString(), anyString(), anyString()))
+                .thenReturn(new LlmGenerationResult<>(aiResult, new LlmTokenUsage(100L, 50L, 150L, 30L)));
+
+        listener.handle(event);
+
+        InOrder inOrder = inOrder(reportGenerationLogRecorder);
+        inOrder.verify(reportGenerationLogRecorder).recordTokenUsage(200L, 100L, 50L, 150L, 30L);
+        inOrder.verify(reportGenerationLogRecorder).succeed(200L);
+        verify(weeklyReportTxService).confirmWeekly(10L, 100L, aiResult.content());
+        verify(eventPublisher).publishEvent(any(Object.class));
+    }
+
+    private DailyEntryDto dailyEntry() {
+        return new DailyEntryDto(
+                LocalDate.of(2026, 1, 1),
+                "question",
+                "answer",
+                "message",
+                null
+        );
+    }
+
+    private AiReportResultDto aiResult() {
+        ReportContent content = new ReportContent(
+                "steady growth",
+                new StyledText(List.of(new Segment("a".repeat(150), List.of()))),
+                new StyledText(List.of(new Segment("b".repeat(80), List.of())))
+        );
+        return new AiReportResultDto(content, content.discovered().plainText(), content.improve().plainText());
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/weeklyreport/infra/WeeklyReportLlmClientTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/weeklyreport/infra/WeeklyReportLlmClientTest.java
@@ -1,0 +1,141 @@
+package com.devkor.ifive.nadab.domain.weeklyreport.infra;
+
+import com.devkor.ifive.nadab.global.core.prompt.weekly.WeeklyReportPromptLoader;
+import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.shared.reportcontent.AiReportResultDto;
+import com.devkor.ifive.nadab.global.shared.reportcontent.LlmResultDto;
+import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContent;
+import com.devkor.ifive.nadab.global.shared.reportcontent.Segment;
+import com.devkor.ifive.nadab.global.shared.reportcontent.StyledText;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyReportLlmClientTest {
+
+    @Mock
+    WeeklyReportPromptLoader weeklyReportPromptLoader;
+
+    @Mock
+    LlmRouter llmRouter;
+
+    @Mock
+    ChatClient chatClient;
+
+    @Mock
+    ChatClient.ChatClientRequestSpec requestSpec;
+
+    @Mock
+    ChatClient.CallResponseSpec callResponseSpec;
+
+    @Test
+    void generate_returns_content_with_token_usage() throws Exception {
+        WeeklyReportLlmClient client = new WeeklyReportLlmClient(
+                weeklyReportPromptLoader,
+                new ObjectMapper(),
+                llmRouter
+        );
+
+        when(weeklyReportPromptLoader.loadPrompt())
+                .thenReturn("start={weekStartDate}, end={weekEndDate}, entries={entries}");
+        when(llmRouter.route(LlmProvider.GEMINI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.user(anyString())).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse(
+                reportJson("steady growth", "a".repeat(150), "b".repeat(80)),
+                new DefaultUsage(100, 50, 150)
+        ));
+
+        LlmGenerationResult<AiReportResultDto> result =
+                client.generate("2026-01-01", "2026-01-07", "entries");
+
+        assertThat(result.content().content().summary()).isEqualTo("steady growth");
+        assertThat(result.content().discovered()).hasSize(150);
+        assertThat(result.content().improve()).hasSize(80);
+        assertThat(result.tokenUsage().inputTokens()).isEqualTo(100L);
+        assertThat(result.tokenUsage().outputTokens()).isEqualTo(50L);
+        assertThat(result.tokenUsage().totalTokens()).isEqualTo(150L);
+    }
+
+    @Test
+    void generate_adds_rewrite_token_usage() throws Exception {
+        WeeklyReportLlmClient client = new WeeklyReportLlmClient(
+                weeklyReportPromptLoader,
+                new ObjectMapper(),
+                llmRouter
+        );
+
+        when(weeklyReportPromptLoader.loadPrompt())
+                .thenReturn("start={weekStartDate}, end={weekEndDate}, entries={entries}");
+        when(llmRouter.route(LlmProvider.GEMINI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.user(anyString())).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(
+                chatResponse(
+                        reportJson("steady growth", "a".repeat(20), "b".repeat(80)),
+                        new DefaultUsage(100, 50, 150)
+                ),
+                chatResponse(
+                        styledTextJson("c".repeat(150)),
+                        new DefaultUsage(20, 10, 30)
+                )
+        );
+
+        LlmGenerationResult<AiReportResultDto> result =
+                client.generate("2026-01-01", "2026-01-07", "entries");
+
+        assertThat(result.content().discovered()).hasSize(150);
+        assertThat(result.tokenUsage().inputTokens()).isEqualTo(120L);
+        assertThat(result.tokenUsage().outputTokens()).isEqualTo(60L);
+        assertThat(result.tokenUsage().totalTokens()).isEqualTo(180L);
+    }
+
+    private ChatResponse chatResponse(String content, DefaultUsage usage) {
+        return new ChatResponse(
+                List.of(new Generation(new AssistantMessage(content))),
+                ChatResponseMetadata.builder()
+                        .usage(usage)
+                        .build()
+        );
+    }
+
+    private String reportJson(String summary, String discovered, String improve) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(new LlmResultDto(
+                summary,
+                new StyledText(List.of(new Segment(discovered, List.of()))),
+                new StyledText(List.of(new Segment(improve, List.of())))
+        ));
+    }
+
+    private String styledTextJson(String text) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(new ReportContent(
+                "",
+                new StyledText(List.of(new Segment(text, List.of()))),
+                null
+        ).discovered());
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractorTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractorTest.java
@@ -6,6 +6,7 @@ import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.google.genai.metadata.GoogleGenAiUsage;
 
 import java.util.List;
 
@@ -30,6 +31,35 @@ class LlmTokenUsageExtractorTest {
         assertThat(usage.inputTokens()).isEqualTo(100L);
         assertThat(usage.outputTokens()).isEqualTo(50L);
         assertThat(usage.totalTokens()).isEqualTo(150L);
+        assertThat(usage.thinkingTokens()).isNull();
+    }
+
+    @Test
+    void extract_maps_google_genai_thinking_tokens() {
+        // given
+        GoogleGenAiUsage googleUsage = new GoogleGenAiUsage(
+                3163,
+                369,
+                6710,
+                3178,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        // when
+        LlmTokenUsage usage = LlmTokenUsageExtractor.extract(googleUsage);
+
+        // then
+        assertThat(usage.inputTokens()).isEqualTo(3163L);
+        assertThat(usage.outputTokens()).isEqualTo(369L);
+        assertThat(usage.totalTokens()).isEqualTo(6710L);
+        assertThat(usage.thinkingTokens()).isEqualTo(3178L);
     }
 
     @Test
@@ -41,6 +71,8 @@ class LlmTokenUsageExtractorTest {
         assertThat(usage.inputTokens()).isNull();
         assertThat(usage.outputTokens()).isNull();
         assertThat(usage.totalTokens()).isNull();
+        assertThat(usage.thinkingTokens()).isNull();
+        assertThat(usage.thinkingTokens()).isNull();
     }
 
     @Test
@@ -86,18 +118,20 @@ class LlmTokenUsageExtractorTest {
         assertThat(usage.inputTokens()).isNull();
         assertThat(usage.outputTokens()).isEqualTo(50L);
         assertThat(usage.totalTokens()).isNull();
+        assertThat(usage.thinkingTokens()).isNull();
     }
 
     @Test
     void token_usage_plus_sums_existing_values_and_preserves_missing_values() {
         // when
-        LlmTokenUsage usage = new LlmTokenUsage(100L, null, 150L)
-                .plus(new LlmTokenUsage(30L, 20L, null));
+        LlmTokenUsage usage = new LlmTokenUsage(100L, null, 150L, 10L)
+                .plus(new LlmTokenUsage(30L, 20L, null, 5L));
 
         // then
         assertThat(usage.inputTokens()).isEqualTo(130L);
         assertThat(usage.outputTokens()).isEqualTo(20L);
         assertThat(usage.totalTokens()).isEqualTo(150L);
+        assertThat(usage.thinkingTokens()).isEqualTo(15L);
     }
 
     @Test
@@ -110,5 +144,6 @@ class LlmTokenUsageExtractorTest {
         assertThat(result.tokenUsage().inputTokens()).isNull();
         assertThat(result.tokenUsage().outputTokens()).isNull();
         assertThat(result.tokenUsage().totalTokens()).isNull();
+        assertThat(result.tokenUsage().thinkingTokens()).isNull();
     }
 }

--- a/src/test/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractorTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/global/infra/llm/LlmTokenUsageExtractorTest.java
@@ -1,0 +1,114 @@
+package com.devkor.ifive.nadab.global.infra.llm;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmTokenUsageExtractorTest {
+
+    @Test
+    void extract_maps_prompt_completion_total_tokens() {
+        // given
+        ChatResponse response = new ChatResponse(
+                List.of(),
+                ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(100, 50, 150))
+                        .build()
+        );
+
+        // when
+        LlmTokenUsage usage = LlmTokenUsageExtractor.extract(response);
+
+        // then
+        assertThat(usage.inputTokens()).isEqualTo(100L);
+        assertThat(usage.outputTokens()).isEqualTo(50L);
+        assertThat(usage.totalTokens()).isEqualTo(150L);
+    }
+
+    @Test
+    void extract_returns_empty_usage_when_response_is_null() {
+        // when
+        LlmTokenUsage usage = LlmTokenUsageExtractor.extract((ChatResponse) null);
+
+        // then
+        assertThat(usage.inputTokens()).isNull();
+        assertThat(usage.outputTokens()).isNull();
+        assertThat(usage.totalTokens()).isNull();
+    }
+
+    @Test
+    void extract_returns_empty_usage_for_empty_usage_metadata() {
+        // when
+        LlmTokenUsage usage = LlmTokenUsageExtractor.extract(new EmptyUsage());
+
+        // then
+        assertThat(usage.inputTokens()).isNull();
+        assertThat(usage.outputTokens()).isNull();
+        assertThat(usage.totalTokens()).isNull();
+    }
+
+    @Test
+    void extract_preserves_partially_missing_usage_values() {
+        // given
+        Usage partialUsage = new Usage() {
+            @Override
+            public Integer getPromptTokens() {
+                return null;
+            }
+
+            @Override
+            public Integer getCompletionTokens() {
+                return 50;
+            }
+
+            @Override
+            public Integer getTotalTokens() {
+                return null;
+            }
+
+            @Override
+            public Object getNativeUsage() {
+                return null;
+            }
+        };
+
+        // when
+        LlmTokenUsage usage = LlmTokenUsageExtractor.extract(partialUsage);
+
+        // then
+        assertThat(usage.inputTokens()).isNull();
+        assertThat(usage.outputTokens()).isEqualTo(50L);
+        assertThat(usage.totalTokens()).isNull();
+    }
+
+    @Test
+    void token_usage_plus_sums_existing_values_and_preserves_missing_values() {
+        // when
+        LlmTokenUsage usage = new LlmTokenUsage(100L, null, 150L)
+                .plus(new LlmTokenUsage(30L, 20L, null));
+
+        // then
+        assertThat(usage.inputTokens()).isEqualTo(130L);
+        assertThat(usage.outputTokens()).isEqualTo(20L);
+        assertThat(usage.totalTokens()).isEqualTo(150L);
+    }
+
+    @Test
+    void generation_result_defaults_null_token_usage_to_empty() {
+        // when
+        LlmGenerationResult<String> result = new LlmGenerationResult<>("content", null);
+
+        // then
+        assertThat(result.content()).isEqualTo("content");
+        assertThat(result.tokenUsage().inputTokens()).isNull();
+        assertThat(result.tokenUsage().outputTokens()).isNull();
+        assertThat(result.tokenUsage().totalTokens()).isNull();
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

리포트 생성 로그에서 LLM 토큰 사용량을 추적할 수 있도록 `report_generation_logs`에 토큰 관련 컬럼을 추가하고,
일간·주간·월간·유형 리포트 생성 흐름에 Spring AI `ChatResponse` 기반 usage 기록을 연결했습니다.

### 주요 변경 사항

- `report_generation_logs`에 `input_tokens`, `output_tokens`, `total_tokens`, `thinking_tokens` 컬럼 추가
- Spring AI `ChatResponse`에서 공통 토큰 사용량을 추출하는 `LlmTokenUsage`, `LlmGenerationResult`, `LlmTokenUsageExtractor` 추가
- Gemini `thoughtsTokenCount`를 `thinking_tokens`로 분리 저장
- 일간·주간·월간·유형 리포트 LLM 생성 단계에 토큰 사용량 기록 연결
- rewrite 등 추가 LLM 호출이 발생하는 경우 토큰 사용량 합산 처리
- 리포트 생성 로그 저장소, 서비스, listener 단위 테스트 보강

### 검증

- `compileJava`
- 관련 report log/service/listener/LLM client 테스트 실행
- `git diff --check`

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.