### PR TITLE
feat(report): 이전 리포트 목록 조회에 페이지네이션 응답 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
@@ -1,6 +1,6 @@
 package com.devkor.ifive.nadab.domain.monthlyreport.api;
 
-import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.AllReportItemResponseV2;
+import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.AllReportListResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MyMonthlyReportLookupResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportStartResponse;
@@ -12,6 +12,7 @@ import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
 import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,7 +24,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @Tag(name = "월간 리포트 API V2", description = "월간 리포트 생성 및 조회 관련 API V2")
 @RestController
@@ -110,7 +110,7 @@ public class MonthlyReportControllerV2 {
                     @ApiResponse(
                             responseCode = "200",
                             description = "전체 리포트 목록 조회 성공",
-                            content = @Content(schema = @Schema(implementation = AllReportItemResponseV2.class), mediaType = "application/json")
+                            content = @Content(schema = @Schema(implementation = AllReportListResponseV2.class), mediaType = "application/json")
                     ),
                     @ApiResponse(
                             responseCode = "401",
@@ -124,11 +124,16 @@ public class MonthlyReportControllerV2 {
                     )
             }
     )
-    public ResponseEntity<ApiResponseDto<List<AllReportItemResponseV2>>> getAllReports(
+    public ResponseEntity<ApiResponseDto<AllReportListResponseV2>> getAllReports(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestParam(defaultValue = "ALL") ReportListTypeV2 type
+            @Parameter(description = "리포트 목록 타입: ALL | MONTHLY | WEEKLY")
+            @RequestParam(defaultValue = "ALL") ReportListTypeV2 type,
+            @Parameter(description = "페이지 번호(1부터 시작)")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 크기(기본 7, 최대 50)")
+            @RequestParam(defaultValue = "7") int size
     ) {
-        List<AllReportItemResponseV2> response = monthlyReportQueryServiceV2.getAllReports(principal.getId(), type);
+        AllReportListResponseV2 response = monthlyReportQueryServiceV2.getAllReports(principal.getId(), type, page, size);
         return ApiResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
@@ -92,25 +92,42 @@ public class MonthlyReportControllerV2 {
     @Operation(
             summary = "이전 리포트 목록 조회",
             description = """
-                    주간/월간 이전 리포트를 통합 조회합니다.
+                    주간/월간 이전 리포트를 통합 조회합니다. 응답은 페이지네이션 메타데이터를 포함한 객체입니다.
                     
                     type: ALL | MONTHLY | WEEKLY
+                    - ALL: 월간 리포트와 주간 리포트를 모두 조회합니다.
+                    - MONTHLY: 월간 리포트만 조회합니다.
+                    - WEEKLY: 주간 리포트만 조회합니다.
+
+                    페이지네이션:
+                    - page는 1부터 시작합니다. 기본값은 1입니다.
+                    - size 기본값은 7이고, 최대 50까지 요청할 수 있습니다.
+                    - data.items에는 현재 페이지의 리포트 목록이 들어갑니다.
+                    - data.totalCount, data.totalPages, data.hasPrevious, data.hasNext로 페이지 UI를 구성할 수 있습니다.
+                    - 조회 결과가 없으면 items는 빈 배열, totalCount와 totalPages는 0입니다.
                     
                     정렬 순서:
-                    1) 년-월 내림차순
-                    2) 동일 월에서는 월간 먼저, 그 다음 주간(주차 내림차순)
+                    1) 최신 연도/월 우선
+                    2) 같은 월에서는 월간 리포트가 먼저 노출됩니다.
+                    3) 주간 리포트는 주차가 큰 순서로 노출됩니다.
+                    4) 같은 조건에서는 version 내림차순, id 내림차순으로 정렬됩니다.
                     
-                    version 규칙:
-                    - weekly: 값과 상관없이 GET /api/v1/weekly-report/{id} 로 조회
-                    - monthly_reports - 1인 경우 : GET /api/v1/monthly-report/{id}로 조회 (기존의 레거시 버전)
-                    - monthly_reports - 2인 경우 : GET /api/v2/monthly-report/{id}로 조회 (새로운 V2 버전)
+                    상세 조회 라우팅:
+                    - type = WEEKLY: GET /api/v1/weekly-report/{id}
+                    - type = MONTHLY, version = 1: GET /api/v1/monthly-report/{id}
+                    - type = MONTHLY, version = 2: GET /api/v2/monthly-report/{id}
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "전체 리포트 목록 조회 성공",
+                            description = "이전 리포트 목록 페이지 조회 성공",
                             content = @Content(schema = @Schema(implementation = AllReportListResponseV2.class), mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "- ErrorCode: VALIDATION_FAILED - page는 1 이상, size는 1 이상 50 이하로 요청해야 함",
+                            content = @Content
                     ),
                     @ApiResponse(
                             responseCode = "401",
@@ -126,11 +143,11 @@ public class MonthlyReportControllerV2 {
     )
     public ResponseEntity<ApiResponseDto<AllReportListResponseV2>> getAllReports(
             @AuthenticationPrincipal UserPrincipal principal,
-            @Parameter(description = "리포트 목록 타입: ALL | MONTHLY | WEEKLY")
+            @Parameter(description = "리포트 목록 타입: ALL | MONTHLY | WEEKLY", example = "ALL")
             @RequestParam(defaultValue = "ALL") ReportListTypeV2 type,
-            @Parameter(description = "페이지 번호(1부터 시작)")
+            @Parameter(description = "페이지 번호(1부터 시작)", example = "1")
             @RequestParam(defaultValue = "1") int page,
-            @Parameter(description = "페이지 크기(기본 7, 최대 50)")
+            @Parameter(description = "페이지 크기(기본 7, 최대 50)", example = "7")
             @RequestParam(defaultValue = "7") int size
     ) {
         AllReportListResponseV2 response = monthlyReportQueryServiceV2.getAllReports(principal.getId(), type, page, size);

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportListResponseV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportListResponseV2.java
@@ -4,21 +4,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "전체 리포트 목록 페이지 응답")
+@Schema(description = "이전 리포트 목록 페이지 응답")
 public record AllReportListResponseV2(
-        @Schema(description = "현재 페이지의 리포트 목록")
+        @Schema(description = "현재 페이지의 리포트 목록. 각 item의 type/version/id로 상세 조회 API를 선택합니다.")
         List<AllReportItemResponseV2> items,
-        @Schema(description = "전체 리포트 개수", example = "43")
+        @Schema(description = "조회 조건에 맞는 전체 리포트 개수", example = "43")
         int totalCount,
         @Schema(description = "현재 페이지 번호(1부터 시작)", example = "1")
         int currentPage,
-        @Schema(description = "페이지 크기", example = "7")
+        @Schema(description = "요청한 페이지 크기", example = "7")
         int pageSize,
-        @Schema(description = "전체 페이지 수", example = "7")
+        @Schema(description = "전체 페이지 수. 조회 결과가 없으면 0입니다.", example = "7")
         int totalPages,
-        @Schema(description = "이전 페이지 존재 여부", example = "false")
+        @Schema(description = "이전 페이지 존재 여부. 이전 버튼 활성화에 사용할 수 있습니다.", example = "false")
         boolean hasPrevious,
-        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        @Schema(description = "다음 페이지 존재 여부. 다음 버튼 활성화에 사용할 수 있습니다.", example = "true")
         boolean hasNext
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportListResponseV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportListResponseV2.java
@@ -1,0 +1,24 @@
+package com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "전체 리포트 목록 페이지 응답")
+public record AllReportListResponseV2(
+        @Schema(description = "현재 페이지의 리포트 목록")
+        List<AllReportItemResponseV2> items,
+        @Schema(description = "전체 리포트 개수", example = "43")
+        int totalCount,
+        @Schema(description = "현재 페이지 번호(1부터 시작)", example = "1")
+        int currentPage,
+        @Schema(description = "페이지 크기", example = "7")
+        int pageSize,
+        @Schema(description = "전체 페이지 수", example = "7")
+        int totalPages,
+        @Schema(description = "이전 페이지 존재 여부", example = "false")
+        boolean hasPrevious,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
@@ -1,6 +1,7 @@
 package com.devkor.ifive.nadab.domain.monthlyreport.application;
 
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.AllReportItemResponseV2;
+import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.AllReportListResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportLocatorResponse;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MyMonthlyReportLookupResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportResponseV2;
@@ -23,6 +24,7 @@ import com.devkor.ifive.nadab.domain.weeklyreport.core.entity.WeeklyReport;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.entity.WeeklyReportStatus;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.repository.WeeklyReportRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ForbiddenException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import com.devkor.ifive.nadab.global.shared.util.MonthRangeCalculator;
@@ -49,7 +51,9 @@ public class MonthlyReportQueryServiceV2 {
     private final ProfileImageUrlBuilder profileImageUrlBuilder;
     private final MonthlyReportLocatorResolver monthlyReportLocatorResolver;
 
-    public List<AllReportItemResponseV2> getAllReports(Long userId, ReportListTypeV2 type) {
+    public AllReportListResponseV2 getAllReports(Long userId, ReportListTypeV2 type, int page, int size) {
+        validatePageRequest(page, size);
+
         if (!userRepository.existsById(userId)) {
             throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
         }
@@ -114,9 +118,24 @@ public class MonthlyReportQueryServiceV2 {
                         .thenComparing(Comparator.comparingLong(ReportListRow::id).reversed())
         );
 
-        return rows.stream()
+        int totalCount = rows.size();
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        int fromIndex = Math.min((page - 1) * size, totalCount);
+        int toIndex = Math.min(fromIndex + size, totalCount);
+
+        List<AllReportItemResponseV2> items = rows.subList(fromIndex, toIndex).stream()
                 .map(r -> new AllReportItemResponseV2(r.id(), r.type(), r.period(), r.summary(), r.version()))
                 .toList();
+
+        return new AllReportListResponseV2(
+                items,
+                totalCount,
+                page,
+                size,
+                totalPages,
+                page > 1 && totalPages > 0,
+                page < totalPages
+        );
     }
 
     public MyMonthlyReportLookupResponseV2 getMyMonthlyReport(Long userId) {
@@ -202,6 +221,12 @@ public class MonthlyReportQueryServiceV2 {
                 profileImageUrl,
                 item.topRank()
         );
+    }
+
+    private void validatePageRequest(int page, int size) {
+        if (page < 1 || size < 1 || size > 50) {
+            throw new BadRequestException(ErrorCode.VALIDATION_FAILED);
+        }
     }
 
     private record ReportListRow(

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
@@ -1,10 +1,13 @@
 package com.devkor.ifive.nadab.domain.monthlyreport.application;
 
+import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.AllReportItemResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportResponseV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.MonthlyReportLocatorResponse;
+import com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response.ReportListTypeV2;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.content.MonthlyEmotionComparisonContent;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.content.MonthlySocialRankingItem;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.content.MonthlySocialSummaryContent;
+import com.devkor.ifive.nadab.domain.monthlyreport.core.entity.MonthlyReport;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.entity.MonthlyReportComparisonType;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.entity.MonthlyReportStatus;
 import com.devkor.ifive.nadab.domain.monthlyreport.core.entity.MonthlyReportV2;
@@ -15,7 +18,10 @@ import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.entity.WeeklyReport;
+import com.devkor.ifive.nadab.domain.weeklyreport.core.entity.WeeklyReportStatus;
 import com.devkor.ifive.nadab.domain.weeklyreport.core.repository.WeeklyReportRepository;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.shared.util.MonthRangeCalculator;
 import com.devkor.ifive.nadab.global.shared.util.dto.MonthRangeDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +36,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +69,124 @@ class MonthlyReportQueryServiceV2Test {
                 profileImageUrlBuilder,
                 monthlyReportLocatorResolver
         );
+    }
+
+    @Test
+    void getAllReports_returns_first_page_with_page_metadata() {
+        List<MonthlyReport> monthlyV1Reports = List.of(
+                monthlyV1(101L, LocalDate.of(2026, 1, 1), "monthly-v1-jan"),
+                monthlyV1(102L, LocalDate.of(2025, 12, 1), "monthly-v1-dec")
+        );
+        List<MonthlyReportV2> monthlyV2Reports = List.of(
+                monthlyV2(201L, LocalDate.of(2026, 1, 1), "monthly-v2-jan"),
+                monthlyV2(202L, LocalDate.of(2025, 11, 1), "monthly-v2-nov")
+        );
+        List<WeeklyReport> weeklyReports = List.of(
+                weekly(301L, LocalDate.of(2026, 1, 19), "weekly-jan-4"),
+                weekly(302L, LocalDate.of(2026, 1, 12), "weekly-jan-3")
+        );
+
+        when(userRepository.existsById(1L)).thenReturn(true);
+        when(monthlyReportRepository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV1Reports);
+        when(monthlyReportV2Repository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV2Reports);
+        when(weeklyReportRepository.findAllByUserIdAndStatus(1L, WeeklyReportStatus.COMPLETED))
+                .thenReturn(weeklyReports);
+
+        var response = service.getAllReports(1L, ReportListTypeV2.ALL, 1, 3);
+
+        assertThat(response.totalCount()).isEqualTo(6);
+        assertThat(response.currentPage()).isEqualTo(1);
+        assertThat(response.pageSize()).isEqualTo(3);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.hasPrevious()).isFalse();
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.items())
+                .extracting(AllReportItemResponseV2::id)
+                .containsExactly(201L, 101L, 301L);
+    }
+
+    @Test
+    void getAllReports_returns_last_page_metadata() {
+        List<MonthlyReport> monthlyV1Reports = List.of(
+                monthlyV1(101L, LocalDate.of(2026, 1, 1), "monthly-v1-jan"),
+                monthlyV1(102L, LocalDate.of(2025, 12, 1), "monthly-v1-dec")
+        );
+        List<MonthlyReportV2> monthlyV2Reports = List.of(
+                monthlyV2(201L, LocalDate.of(2026, 1, 1), "monthly-v2-jan")
+        );
+        List<WeeklyReport> weeklyReports = List.of(
+                weekly(301L, LocalDate.of(2026, 1, 19), "weekly-jan-4")
+        );
+
+        when(userRepository.existsById(1L)).thenReturn(true);
+        when(monthlyReportRepository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV1Reports);
+        when(monthlyReportV2Repository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV2Reports);
+        when(weeklyReportRepository.findAllByUserIdAndStatus(1L, WeeklyReportStatus.COMPLETED))
+                .thenReturn(weeklyReports);
+
+        var response = service.getAllReports(1L, ReportListTypeV2.ALL, 2, 3);
+
+        assertThat(response.totalCount()).isEqualTo(4);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.hasPrevious()).isTrue();
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.items())
+                .extracting(AllReportItemResponseV2::id)
+                .containsExactly(102L);
+    }
+
+    @Test
+    void getAllReports_filters_monthly_reports_only() {
+        List<MonthlyReport> monthlyV1Reports = List.of(
+                monthlyV1(101L, LocalDate.of(2026, 1, 1), "monthly-v1-jan")
+        );
+        List<MonthlyReportV2> monthlyV2Reports = List.of(
+                monthlyV2(201L, LocalDate.of(2026, 2, 1), "monthly-v2-feb")
+        );
+
+        when(userRepository.existsById(1L)).thenReturn(true);
+        when(monthlyReportRepository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV1Reports);
+        when(monthlyReportV2Repository.findAllByUserIdAndStatus(1L, MonthlyReportStatus.COMPLETED))
+                .thenReturn(monthlyV2Reports);
+
+        var response = service.getAllReports(1L, ReportListTypeV2.MONTHLY, 1, 10);
+
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.totalPages()).isEqualTo(1);
+        assertThat(response.items())
+                .extracting(AllReportItemResponseV2::id, AllReportItemResponseV2::type, AllReportItemResponseV2::version)
+                .containsExactly(
+                        tuple(201L, "MONTHLY", 2),
+                        tuple(101L, "MONTHLY", 1)
+                );
+    }
+
+    @Test
+    void getAllReports_returns_empty_page_when_no_reports() {
+        when(userRepository.existsById(1L)).thenReturn(true);
+        when(weeklyReportRepository.findAllByUserIdAndStatus(1L, WeeklyReportStatus.COMPLETED))
+                .thenReturn(List.of());
+
+        var response = service.getAllReports(1L, ReportListTypeV2.WEEKLY, 1, 7);
+
+        assertThat(response.items()).isEmpty();
+        assertThat(response.totalCount()).isZero();
+        assertThat(response.totalPages()).isZero();
+        assertThat(response.hasPrevious()).isFalse();
+        assertThat(response.hasNext()).isFalse();
+    }
+
+    @Test
+    void getAllReports_rejects_invalid_page_request() {
+        assertThatThrownBy(() -> service.getAllReports(1L, ReportListTypeV2.ALL, 0, 7))
+                .isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.getAllReports(1L, ReportListTypeV2.ALL, 1, 51))
+                .isInstanceOf(BadRequestException.class);
     }
 
     @Test
@@ -189,5 +315,29 @@ class MonthlyReportQueryServiceV2Test {
         assertThat(response.socialSummary().month()).isEqualTo(5);
         assertThat(response.socialSummary().likeRanking()).isEmpty();
         assertThat(response.socialSummary().commentRanking()).isEmpty();
+    }
+
+    private MonthlyReport monthlyV1(Long id, LocalDate monthStartDate, String summary) {
+        MonthlyReport report = mock(MonthlyReport.class);
+        when(report.getId()).thenReturn(id);
+        when(report.getMonthStartDate()).thenReturn(monthStartDate);
+        when(report.getSummary()).thenReturn(summary);
+        return report;
+    }
+
+    private MonthlyReportV2 monthlyV2(Long id, LocalDate monthStartDate, String summary) {
+        MonthlyReportV2 report = mock(MonthlyReportV2.class);
+        when(report.getId()).thenReturn(id);
+        when(report.getMonthStartDate()).thenReturn(monthStartDate);
+        when(report.getSummary()).thenReturn(summary);
+        return report;
+    }
+
+    private WeeklyReport weekly(Long id, LocalDate weekStartDate, String summary) {
+        WeeklyReport report = mock(WeeklyReport.class);
+        when(report.getId()).thenReturn(id);
+        when(report.getWeekStartDate()).thenReturn(weekStartDate);
+        when(report.getSummary()).thenReturn(summary);
+        return report;
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- `GET /api/v2/monthly-report/all` API에 페이지네이션 응답을 추가했습니다.
- 기존 월간 V1, 월간 V2, 주간 리포트 통합 정렬 규칙은 유지하면서 `page`, `size` 기반으로 목록을 잘라 반환하도록 변경했습니다.

### 주요 변경사항
- 기존 `List<AllReportItemResponseV2>` 응답을 `AllReportListResponseV2` 페이지 객체 응답으로 변경
- 응답에 `items`, `totalCount`, `currentPage`, `pageSize`, `totalPages`, `hasPrevious`, `hasNext` 추가
- `page` 기본값 1, `size` 기본값 7, `size` 최대값 50 적용
- 잘못된 페이지 요청은 `VALIDATION_FAILED`로 처리
- OpenAPI 문서에 페이지 파라미터와 페이지 응답 DTO 반영
- `MonthlyReportQueryServiceV2Test`에 첫 페이지, 마지막 페이지, MONTHLY 필터, 빈 결과, 잘못된 page/size 검증 추가

### 검증
- `.\gradlew.bat compileJava`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.monthlyreport.application.MonthlyReportQueryServiceV2Test"`
- `git diff --check`

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.