### PR TITLE
feat(report): 이전 리포트 목록 조회 응답에 생성 시각 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportItemResponseV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportItemResponseV2.java
@@ -2,6 +2,8 @@ package com.devkor.ifive.nadab.domain.monthlyreport.api.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.OffsetDateTime;
+
 @Schema(description = "전체 리포트 목록 아이템")
 public record AllReportItemResponseV2(
         @Schema(description = "리포트 ID")
@@ -13,6 +15,8 @@ public record AllReportItemResponseV2(
         @Schema(description = "요약")
         String summary,
         @Schema(description = "리포트 버전", example = "2")
-        int version
+        int version,
+        @Schema(description = "리포트 생성 시각 ISO 8601 timestamp", example = "2026-01-31T10:30:00+09:00")
+        OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -72,7 +73,8 @@ public class MonthlyReportQueryServiceV2 {
                         99,
                         month.getMonthValue() + "월",
                         report.getSummary(),
-                        1
+                        1,
+                        report.getCreatedAt()
                 ));
             }
 
@@ -87,7 +89,8 @@ public class MonthlyReportQueryServiceV2 {
                         99,
                         month.getMonthValue() + "월",
                         report.getSummary(),
-                        2
+                        2,
+                        report.getCreatedAt()
                 ));
             }
         }
@@ -105,7 +108,8 @@ public class MonthlyReportQueryServiceV2 {
                         weekOfMonth,
                         weekStart.getMonthValue() + "월 " + weekOfMonth + "주차",
                         report.getSummary(),
-                        1
+                        1,
+                        report.getCreatedAt()
                 ));
             }
         }
@@ -124,7 +128,7 @@ public class MonthlyReportQueryServiceV2 {
         int toIndex = Math.min(fromIndex + size, totalCount);
 
         List<AllReportItemResponseV2> items = rows.subList(fromIndex, toIndex).stream()
-                .map(r -> new AllReportItemResponseV2(r.id(), r.type(), r.period(), r.summary(), r.version()))
+                .map(r -> new AllReportItemResponseV2(r.id(), r.type(), r.period(), r.summary(), r.version(), r.createdAt()))
                 .toList();
 
         return new AllReportListResponseV2(
@@ -237,7 +241,8 @@ public class MonthlyReportQueryServiceV2 {
             int weekOrder,
             String period,
             String summary,
-            int version
+            int version,
+            OffsetDateTime createdAt
     ) {
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/entity/MonthlyReport.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/entity/MonthlyReport.java
@@ -1,6 +1,7 @@
 package com.devkor.ifive.nadab.domain.monthlyreport.core.entity;
 
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
 import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContent;
 import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContentFactory;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -23,7 +24,7 @@ import java.time.OffsetDateTime;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MonthlyReport {
+public class MonthlyReport extends CreatableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -105,6 +107,13 @@ class MonthlyReportQueryServiceV2Test {
         assertThat(response.items())
                 .extracting(AllReportItemResponseV2::id)
                 .containsExactly(201L, 101L, 301L);
+        assertThat(response.items())
+                .extracting(AllReportItemResponseV2::createdAt)
+                .containsExactly(
+                        OffsetDateTime.parse("2026-01-01T10:00:00+09:00"),
+                        OffsetDateTime.parse("2026-01-01T09:00:00+09:00"),
+                        OffsetDateTime.parse("2026-01-19T09:00:00+09:00")
+                );
     }
 
     @Test
@@ -322,6 +331,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getMonthStartDate()).thenReturn(monthStartDate);
         when(report.getSummary()).thenReturn(summary);
+        when(report.getCreatedAt()).thenReturn(monthStartDate.atTime(9, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 
@@ -330,6 +340,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getMonthStartDate()).thenReturn(monthStartDate);
         when(report.getSummary()).thenReturn(summary);
+        when(report.getCreatedAt()).thenReturn(monthStartDate.atTime(10, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 
@@ -338,6 +349,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getWeekStartDate()).thenReturn(weekStartDate);
         when(report.getSummary()).thenReturn(summary);
+        when(report.getCreatedAt()).thenReturn(weekStartDate.atTime(9, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `GET /api/v2/monthly-report/all` 응답의 각 `items[]` 항목에 `createdAt` 추가
- 이전 리포트 목록 화면에서 리포트별 상대 시간 표시가 가능하도록 API 응답 계약 확장

### 주요 변경사항
- `AllReportItemResponseV2`에 `createdAt: OffsetDateTime` 필드 추가
- 월간 V1, 월간 V2, 주간 리포트 모두 저장된 생성 시각을 목록 응답에 매핑
- `monthly_reports` 테이블에 이미 존재하던 `created_at` 컬럼을 V1 `MonthlyReport` 엔티티에서 `CreatableEntity` 상속으로 노출
- 목록 응답의 `createdAt` 매핑을 검증하는 서비스 테스트 보강

### 검증
- `.\gradlew.bat compileJava`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.monthlyreport.application.MonthlyReportQueryServiceV2Test"`
- `git diff --check`

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.