### PR TITLE
fix(report): 이전 리포트 목록 기준 시각을 분석 완료 시각으로 보정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportItemResponseV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/AllReportItemResponseV2.java
@@ -16,7 +16,7 @@ public record AllReportItemResponseV2(
         String summary,
         @Schema(description = "리포트 버전", example = "2")
         int version,
-        @Schema(description = "리포트 생성 시각 ISO 8601 timestamp", example = "2026-01-31T10:30:00+09:00")
+        @Schema(description = "목록 표시 기준 시각(리포트 분석 완료 시각) ISO 8601 timestamp", example = "2026-01-31T10:30:00+09:00")
         OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
@@ -74,7 +74,7 @@ public class MonthlyReportQueryServiceV2 {
                         month.getMonthValue() + "월",
                         report.getSummary(),
                         1,
-                        report.getCreatedAt()
+                        report.getAnalyzedAt()
                 ));
             }
 
@@ -90,7 +90,7 @@ public class MonthlyReportQueryServiceV2 {
                         month.getMonthValue() + "월",
                         report.getSummary(),
                         2,
-                        report.getCreatedAt()
+                        report.getAnalyzedAt()
                 ));
             }
         }
@@ -109,7 +109,7 @@ public class MonthlyReportQueryServiceV2 {
                         weekStart.getMonthValue() + "월 " + weekOfMonth + "주차",
                         report.getSummary(),
                         1,
-                        report.getCreatedAt()
+                        report.getAnalyzedAt()
                 ));
             }
         }

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/entity/MonthlyReport.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/entity/MonthlyReport.java
@@ -1,7 +1,6 @@
 package com.devkor.ifive.nadab.domain.monthlyreport.core.entity;
 
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
-import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
 import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContent;
 import com.devkor.ifive.nadab.global.shared.reportcontent.ReportContentFactory;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -24,7 +23,7 @@ import java.time.OffsetDateTime;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MonthlyReport extends CreatableEntity {
+public class MonthlyReport {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
@@ -110,9 +110,9 @@ class MonthlyReportQueryServiceV2Test {
         assertThat(response.items())
                 .extracting(AllReportItemResponseV2::createdAt)
                 .containsExactly(
-                        OffsetDateTime.parse("2026-01-01T10:00:00+09:00"),
-                        OffsetDateTime.parse("2026-01-01T09:00:00+09:00"),
-                        OffsetDateTime.parse("2026-01-19T09:00:00+09:00")
+                        OffsetDateTime.parse("2026-01-01T12:00:00+09:00"),
+                        OffsetDateTime.parse("2026-01-01T11:00:00+09:00"),
+                        OffsetDateTime.parse("2026-01-19T11:00:00+09:00")
                 );
     }
 
@@ -331,7 +331,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getMonthStartDate()).thenReturn(monthStartDate);
         when(report.getSummary()).thenReturn(summary);
-        when(report.getCreatedAt()).thenReturn(monthStartDate.atTime(9, 0).atOffset(ZoneOffset.ofHours(9)));
+        when(report.getAnalyzedAt()).thenReturn(monthStartDate.atTime(11, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 
@@ -340,7 +340,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getMonthStartDate()).thenReturn(monthStartDate);
         when(report.getSummary()).thenReturn(summary);
-        when(report.getCreatedAt()).thenReturn(monthStartDate.atTime(10, 0).atOffset(ZoneOffset.ofHours(9)));
+        when(report.getAnalyzedAt()).thenReturn(monthStartDate.atTime(12, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 
@@ -349,7 +349,7 @@ class MonthlyReportQueryServiceV2Test {
         when(report.getId()).thenReturn(id);
         when(report.getWeekStartDate()).thenReturn(weekStartDate);
         when(report.getSummary()).thenReturn(summary);
-        when(report.getCreatedAt()).thenReturn(weekStartDate.atTime(9, 0).atOffset(ZoneOffset.ofHours(9)));
+        when(report.getAnalyzedAt()).thenReturn(weekStartDate.atTime(11, 0).atOffset(ZoneOffset.ofHours(9)));
         return report;
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `GET /api/v2/monthly-report/all` 응답의 `createdAt` 필드 값을 `created_at`이 아닌 `analyzedAt` 기준으로 보정
- 실패 레코드 재사용 시 최초 생성 시각이 목록의 상대 시간 기준으로 노출되는 문제를 방지

### 주요 변경사항
- 월간 V1, 월간 V2, 주간 리포트 목록 row 생성 시 `getAnalyzedAt()` 값을 `createdAt` 응답 필드에 매핑
- `createdAt` 필드의 OpenAPI 설명을 “목록 표시 기준 시각(리포트 분석 완료 시각)”으로 수정
- V1 `MonthlyReport`에 추가됐던 불필요한 `CreatableEntity` 상속 제거
- 서비스 테스트에서 `createdAt` 응답값이 `analyzedAt` 기반인지 검증하도록 수정

### 검증
- `.\gradlew.bat compileJava`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.monthlyreport.application.MonthlyReportQueryServiceV2Test"`
- `git diff --check`

### 참고 / 리스크
- 응답 필드명은 클라이언트 계약을 유지하기 위해 `createdAt` 그대로 사용
- 실제 값의 의미는 리포트 row 생성 시각이 아니라 분석 완료 시각

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.