### PR TITLE
feat(ai): Ask Chat 히스토리 저장/조회 및 RAG 기반 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
@@ -1,0 +1,99 @@
+package com.devkor.ifive.nadab.domain.askchat.api;
+
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHistoryDetailResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHistoryListResponse;
+import com.devkor.ifive.nadab.domain.askchat.application.AskChatHistoryQueryService;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
+import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Ask Chat API", description = "물어보기 채팅 히스토리 API")
+@RestController
+@RequestMapping("${api_prefix}/ask-chat")
+@RequiredArgsConstructor
+public class AskChatHistoryController {
+
+    private final AskChatHistoryQueryService askChatHistoryQueryService;
+
+    @GetMapping("/histories")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 히스토리 목록 조회",
+            description = """
+                    사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.
+                    page는 1부터 시작하며, size는 최대 50까지 요청할 수 있습니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "히스토리 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatHistoryListResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "- ErrorCode: VALIDATION_FAILED - page는 1 이상, size는 1 이상 50 이하로 요청해야 함",
+                            content = @Content
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatHistoryListResponse>> getHistories(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        AskChatHistoryListResponse response = askChatHistoryQueryService.getHistories(
+                principal.getId(),
+                page,
+                size
+        );
+        return ApiResponseEntity.ok(response);
+    }
+
+    @GetMapping("/histories/{sessionId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 히스토리 상세 조회",
+            description = "선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "히스토리 상세 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatHistoryDetailResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "- ErrorCode: ASK_CHAT_SESSION_NOT_FOUND - 채팅 세션을 찾을 수 없음",
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatHistoryDetailResponse>> getHistoryDetail(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long sessionId
+    ) {
+        AskChatHistoryDetailResponse response = askChatHistoryQueryService.getHistoryDetail(
+                principal.getId(),
+                sessionId
+        );
+        return ApiResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryDetailResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryDetailResponse.java
@@ -1,0 +1,29 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Schema(description = "Ask Chat 히스토리 상세 응답")
+public record AskChatHistoryDetailResponse(
+        @Schema(description = "채팅 세션 ID", example = "1")
+        Long sessionId,
+
+        @Schema(description = "채팅 세션 상태", example = "ENDED")
+        AskChatSessionStatus status,
+
+        @Schema(description = "성공적으로 답변된 대화 횟수", example = "5")
+        int answeredTurnCount,
+
+        @Schema(description = "채팅 시작 시각")
+        OffsetDateTime createdAt,
+
+        @Schema(description = "채팅 종료 시각")
+        OffsetDateTime endedAt,
+
+        @Schema(description = "시간순 메시지 목록")
+        List<AskChatMessageResponse> messages
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryItemResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryItemResponse.java
@@ -1,0 +1,25 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "Ask Chat 히스토리 목록 항목")
+public record AskChatHistoryItemResponse(
+        @Schema(description = "채팅 세션 ID", example = "1")
+        Long sessionId,
+
+        @Schema(description = "히스토리 카드 제목으로 사용할 첫 사용자 질문", example = "나는 어떤 사람이야?")
+        String title,
+
+        @Schema(description = "채팅 세션 상태", example = "ACTIVE")
+        AskChatSessionStatus status,
+
+        @Schema(description = "성공적으로 답변된 대화 횟수", example = "3")
+        int answeredTurnCount,
+
+        @Schema(description = "채팅 시작 시각")
+        OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryListResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryListResponse.java
@@ -1,0 +1,30 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Ask Chat 히스토리 목록 응답")
+public record AskChatHistoryListResponse(
+        @Schema(description = "히스토리 목록")
+        List<AskChatHistoryItemResponse> histories,
+
+        @Schema(description = "전체 히스토리 수", example = "12")
+        long totalCount,
+
+        @Schema(description = "현재 페이지 번호(1부터 시작)", example = "1")
+        int currentPage,
+
+        @Schema(description = "페이지 크기", example = "20")
+        int pageSize,
+
+        @Schema(description = "전체 페이지 수", example = "1")
+        int totalPages,
+
+        @Schema(description = "이전 페이지 존재 여부", example = "false")
+        boolean hasPrevious,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "false")
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatMessageResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatMessageResponse.java
@@ -1,0 +1,37 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "Ask Chat 메시지 응답")
+public record AskChatMessageResponse(
+        @Schema(description = "메시지 ID", example = "10")
+        Long id,
+
+        @Schema(description = "메시지 역할", example = "USER")
+        AskChatMessageRole role,
+
+        @Schema(description = "메시지 상태", example = "COMPLETED")
+        AskChatMessageStatus status,
+
+        @Schema(description = "메시지 내용", example = "나는 어떤 사람이야?")
+        String content,
+
+        @Schema(description = "메시지 생성 시각")
+        OffsetDateTime createdAt
+) {
+
+    public static AskChatMessageResponse from(AskChatMessage message) {
+        return new AskChatMessageResponse(
+                message.getId(),
+                message.getRole(),
+                message.getStatus(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryService.java
@@ -1,0 +1,99 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHistoryDetailResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHistoryItemResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHistoryListResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatMessageResponse;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AskChatHistoryQueryService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final AskChatSessionRepository askChatSessionRepository;
+    private final AskChatMessageRepository askChatMessageRepository;
+
+    public AskChatHistoryListResponse getHistories(Long userId, int page, int size) {
+        validatePageRequest(page, size);
+
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        List<AskChatSession> sessions = askChatSessionRepository.findAllByUserIdOrderByCreatedAtDesc(
+                userId,
+                pageRequest
+        );
+        long totalCount = askChatSessionRepository.countByUserId(userId);
+        int totalPages = totalCount == 0 ? 0 : (int) Math.ceil((double) totalCount / size);
+
+        List<AskChatHistoryItemResponse> histories = sessions.stream()
+                .map(this::toHistoryItem)
+                .toList();
+
+        return new AskChatHistoryListResponse(
+                histories,
+                totalCount,
+                page,
+                size,
+                totalPages,
+                page > 1 && totalPages > 0,
+                totalPages > 0 && page < totalPages
+        );
+    }
+
+    public AskChatHistoryDetailResponse getHistoryDetail(Long userId, Long sessionId) {
+        AskChatSession session = askChatSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ASK_CHAT_SESSION_NOT_FOUND));
+
+        List<AskChatMessageResponse> messages = askChatMessageRepository.findAllBySessionIdOrderByCreatedAtAsc(sessionId)
+                .stream()
+                .map(AskChatMessageResponse::from)
+                .toList();
+
+        return new AskChatHistoryDetailResponse(
+                session.getId(),
+                session.getStatus(),
+                session.getAnsweredTurnCount(),
+                session.getCreatedAt(),
+                session.getEndedAt(),
+                messages
+        );
+    }
+
+    private AskChatHistoryItemResponse toHistoryItem(AskChatSession session) {
+        String title = askChatMessageRepository.findFirstBySessionIdAndRoleOrderByCreatedAtAsc(
+                        session.getId(),
+                        AskChatMessageRole.USER
+                )
+                .map(AskChatMessage::getContent)
+                .orElse("");
+
+        return new AskChatHistoryItemResponse(
+                session.getId(),
+                title,
+                session.getStatus(),
+                session.getAnsweredTurnCount(),
+                session.getCreatedAt()
+        );
+    }
+
+    private void validatePageRequest(int page, int size) {
+        if (page < 1 || size < 1 || size > MAX_PAGE_SIZE) {
+            throw new BadRequestException(ErrorCode.VALIDATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatRagIndexingService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatRagIndexingService.java
@@ -1,0 +1,97 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagVectorRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatEmbeddingClient;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AskChatRagIndexingService {
+
+    private static final int ERROR_CODE_MAX_LENGTH = 128;
+
+    private final AskChatMessageRepository messageRepository;
+    private final AskChatRagDocumentRepository ragDocumentRepository;
+    private final AskChatRagVectorRepository ragVectorRepository;
+    private final AskChatEmbeddingClient embeddingClient;
+
+    @Transactional
+    public void indexAssistantMessage(Long messageId, InterestCode interestCode) {
+        AskChatMessage message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ASK_CHAT_MESSAGE_NOT_FOUND));
+
+        if (!isIndexableAssistantMessage(message)) {
+            return;
+        }
+
+        int embeddingVersion = embeddingClient.version();
+        if (ragDocumentRepository.existsBySourceTypeAndSourceIdAndEmbeddingVersion(
+                AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE,
+                message.getId(),
+                embeddingVersion
+        )) {
+            return;
+        }
+
+        AskChatRagDocument document = ragDocumentRepository.save(AskChatRagDocument.createPending(
+                message.getSession().getUser(),
+                AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE,
+                message.getId(),
+                interestCode,
+                message.getContent(),
+                metadata(message),
+                embeddingClient.model(),
+                embeddingVersion
+        ));
+
+        try {
+            List<Double> embedding = embeddingClient.embed(message.getContent());
+            ragVectorRepository.updateEmbedding(document.getId(), embedding);
+        } catch (RuntimeException e) {
+            ragVectorRepository.markEmbeddingFailed(document.getId(), truncate(e.getClass().getSimpleName()));
+        }
+    }
+
+    private boolean isIndexableAssistantMessage(AskChatMessage message) {
+        return message.getRole() == AskChatMessageRole.ASSISTANT
+                && message.getStatus() == AskChatMessageStatus.COMPLETED;
+    }
+
+    private Map<String, Object> metadata(AskChatMessage message) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("sessionId", message.getSession().getId());
+        metadata.put("messageId", message.getId());
+        metadata.put("role", message.getRole().name());
+        metadata.put("status", message.getStatus().name());
+        if (message.getLlmProvider() != null) {
+            metadata.put("llmProvider", message.getLlmProvider().name());
+        }
+        if (message.getLlmModel() != null) {
+            metadata.put("llmModel", message.getLlmModel());
+        }
+        return metadata;
+    }
+
+    private String truncate(String value) {
+        if (value.length() <= ERROR_CODE_MAX_LENGTH) {
+            return value;
+        }
+        return value.substring(0, ERROR_CODE_MAX_LENGTH);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatRagSearchResultDto.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatRagSearchResultDto.java
@@ -1,0 +1,14 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+
+public record AskChatRagSearchResultDto(
+        Long documentId,
+        AskChatRagDocumentSourceType sourceType,
+        Long sourceId,
+        InterestCode interestCode,
+        String content,
+        double distance
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessage.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessage.java
@@ -1,0 +1,121 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ask_chat_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AskChatMessage extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "session_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ask_chat_messages_session")
+    )
+    private AskChatSession session;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 16)
+    private AskChatMessageRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private AskChatMessageStatus status;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "llm_provider", length = 32)
+    private LlmProvider llmProvider;
+
+    @Column(name = "llm_model", length = 128)
+    private String llmModel;
+
+    @Column(name = "input_tokens")
+    private Long inputTokens;
+
+    @Column(name = "output_tokens")
+    private Long outputTokens;
+
+    @Column(name = "total_tokens")
+    private Long totalTokens;
+
+    @Column(name = "thinking_tokens")
+    private Long thinkingTokens;
+
+    @Column(name = "error_code", length = 128)
+    private String errorCode;
+
+    public static AskChatMessage createUserMessage(AskChatSession session, String content) {
+        AskChatMessage message = create(session, AskChatMessageRole.USER, content);
+        message.status = AskChatMessageStatus.COMPLETED;
+        return message;
+    }
+
+    public static AskChatMessage createAssistantMessage(
+            AskChatSession session,
+            String content,
+            LlmProvider llmProvider,
+            String llmModel,
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens,
+            Long thinkingTokens
+    ) {
+        AskChatMessage message = create(session, AskChatMessageRole.ASSISTANT, content);
+        message.status = AskChatMessageStatus.COMPLETED;
+        message.llmProvider = llmProvider;
+        message.llmModel = llmModel;
+        message.inputTokens = inputTokens;
+        message.outputTokens = outputTokens;
+        message.totalTokens = totalTokens;
+        message.thinkingTokens = thinkingTokens;
+        return message;
+    }
+
+    public static AskChatMessage createFailedAssistantMessage(
+            AskChatSession session,
+            String content,
+            LlmProvider llmProvider,
+            String llmModel,
+            String errorCode
+    ) {
+        AskChatMessage message = create(session, AskChatMessageRole.ASSISTANT, content);
+        message.status = AskChatMessageStatus.FAILED;
+        message.llmProvider = llmProvider;
+        message.llmModel = llmModel;
+        message.errorCode = errorCode;
+        return message;
+    }
+
+    private static AskChatMessage create(AskChatSession session, AskChatMessageRole role, String content) {
+        AskChatMessage message = new AskChatMessage();
+        message.session = session;
+        message.role = role;
+        message.content = content;
+        return message;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageRole.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageRole.java
@@ -1,0 +1,6 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+public enum AskChatMessageRole {
+    USER,
+    ASSISTANT
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageStatus.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageStatus.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+public enum AskChatMessageStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagDocument.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagDocument.java
@@ -1,0 +1,121 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.AuditableEntity;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@Entity
+@Table(
+        name = "ask_chat_rag_documents",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_ask_chat_rag_documents_source_version",
+                        columnNames = {"source_type", "source_id", "embedding_version"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AskChatRagDocument extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ask_chat_rag_documents_user")
+    )
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 32)
+    private AskChatRagDocumentSourceType sourceType;
+
+    @Column(name = "source_id", nullable = false)
+    private Long sourceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interest_code", length = 32)
+    private InterestCode interestCode;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Type(JsonType.class)
+    @Column(name = "metadata", nullable = false, columnDefinition = "jsonb")
+    private Map<String, Object> metadata;
+
+    @Column(name = "embedding_model", nullable = false, length = 128)
+    private String embeddingModel;
+
+    @Column(name = "embedding_version", nullable = false)
+    private int embeddingVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "embedding_status", nullable = false, length = 16)
+    private AskChatRagEmbeddingStatus embeddingStatus;
+
+    @Column(name = "error_code", length = 128)
+    private String errorCode;
+
+    @Column(name = "embedded_at")
+    private OffsetDateTime embeddedAt;
+
+    public static AskChatRagDocument createPending(
+            User user,
+            AskChatRagDocumentSourceType sourceType,
+            Long sourceId,
+            InterestCode interestCode,
+            String content,
+            Map<String, Object> metadata,
+            String embeddingModel,
+            int embeddingVersion
+    ) {
+        AskChatRagDocument document = new AskChatRagDocument();
+        document.user = user;
+        document.sourceType = sourceType;
+        document.sourceId = sourceId;
+        document.interestCode = interestCode;
+        document.content = content;
+        document.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        document.embeddingModel = embeddingModel;
+        document.embeddingVersion = embeddingVersion;
+        document.embeddingStatus = AskChatRagEmbeddingStatus.PENDING;
+        return document;
+    }
+
+    public void markCompleted() {
+        this.embeddingStatus = AskChatRagEmbeddingStatus.COMPLETED;
+        this.errorCode = null;
+        this.embeddedAt = OffsetDateTime.now();
+    }
+
+    public void markFailed(String errorCode) {
+        this.embeddingStatus = AskChatRagEmbeddingStatus.FAILED;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagDocumentSourceType.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagDocumentSourceType.java
@@ -1,0 +1,6 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+public enum AskChatRagDocumentSourceType {
+    ANSWER_ENTRY,
+    ASK_CHAT_MESSAGE
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagEmbeddingStatus.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatRagEmbeddingStatus.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+public enum AskChatRagEmbeddingStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatSession.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatSession.java
@@ -1,0 +1,70 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.shared.entity.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ask_chat_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AskChatSession extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ask_chat_sessions_user")
+    )
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private AskChatSessionStatus status;
+
+    @Column(name = "answered_turn_count", nullable = false)
+    private int answeredTurnCount;
+
+    @Column(name = "ended_at")
+    private OffsetDateTime endedAt;
+
+    public static AskChatSession start(User user) {
+        AskChatSession session = new AskChatSession();
+        session.user = user;
+        session.status = AskChatSessionStatus.ACTIVE;
+        session.answeredTurnCount = 0;
+        return session;
+    }
+
+    public void incrementAnsweredTurnCount() {
+        this.answeredTurnCount++;
+    }
+
+    public void end() {
+        if (this.status == AskChatSessionStatus.ENDED) {
+            return;
+        }
+        this.status = AskChatSessionStatus.ENDED;
+        this.endedAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatSessionStatus.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatSessionStatus.java
@@ -1,0 +1,6 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+public enum AskChatSessionStatus {
+    ACTIVE,
+    ENDED
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/properties/AskChatRagProperties.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/properties/AskChatRagProperties.java
@@ -1,0 +1,32 @@
+package com.devkor.ifive.nadab.domain.askchat.core.properties;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "ask-chat.rag")
+public class AskChatRagProperties {
+
+    @NotBlank
+    private String embeddingModel = "text-embedding-3-small";
+
+    @Min(1)
+    private int embeddingDimensions = 1536;
+
+    @Min(1)
+    private int embeddingVersion = 1;
+
+    @Min(1)
+    private int embeddingBatchSize = 20;
+
+    @Min(1)
+    private int retrievalLimit = 5;
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
@@ -1,0 +1,28 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AskChatMessageRepository extends JpaRepository<AskChatMessage, Long> {
+
+    List<AskChatMessage> findAllBySessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    List<AskChatMessage> findAllBySessionIdOrderByCreatedAtDesc(Long sessionId, Pageable pageable);
+
+    Optional<AskChatMessage> findFirstBySessionIdAndRoleOrderByCreatedAtDesc(
+            Long sessionId,
+            AskChatMessageRole role
+    );
+
+    long countBySessionIdAndRoleAndStatus(
+            Long sessionId,
+            AskChatMessageRole role,
+            AskChatMessageStatus status
+    );
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
@@ -20,6 +20,11 @@ public interface AskChatMessageRepository extends JpaRepository<AskChatMessage, 
             AskChatMessageRole role
     );
 
+    Optional<AskChatMessage> findFirstBySessionIdAndRoleOrderByCreatedAtAsc(
+            Long sessionId,
+            AskChatMessageRole role
+    );
+
     long countBySessionIdAndRoleAndStatus(
             Long sessionId,
             AskChatMessageRole role,

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagDocumentRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagDocumentRepository.java
@@ -1,0 +1,30 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagEmbeddingStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AskChatRagDocumentRepository extends JpaRepository<AskChatRagDocument, Long> {
+
+    Optional<AskChatRagDocument> findBySourceTypeAndSourceIdAndEmbeddingVersion(
+            AskChatRagDocumentSourceType sourceType,
+            Long sourceId,
+            int embeddingVersion
+    );
+
+    boolean existsBySourceTypeAndSourceIdAndEmbeddingVersion(
+            AskChatRagDocumentSourceType sourceType,
+            Long sourceId,
+            int embeddingVersion
+    );
+
+    List<AskChatRagDocument> findAllByEmbeddingStatusOrderByCreatedAtAsc(
+            AskChatRagEmbeddingStatus embeddingStatus,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagVectorRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagVectorRepository.java
@@ -1,0 +1,100 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatRagSearchResultDto;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.StringJoiner;
+
+@Repository
+@RequiredArgsConstructor
+public class AskChatRagVectorRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public int updateEmbedding(Long documentId, List<Double> embedding) {
+        String sql = """
+                UPDATE ask_chat_rag_documents
+                   SET embedding = CAST(:embedding AS vector),
+                       embedding_status = 'COMPLETED',
+                       error_code = NULL,
+                       embedded_at = CURRENT_TIMESTAMP,
+                       updated_at = CURRENT_TIMESTAMP
+                 WHERE id = :documentId
+                """;
+
+        return jdbcTemplate.update(sql, new MapSqlParameterSource()
+                .addValue("documentId", documentId)
+                .addValue("embedding", formatVector(embedding)));
+    }
+
+    public int markEmbeddingFailed(Long documentId, String errorCode) {
+        String sql = """
+                UPDATE ask_chat_rag_documents
+                   SET embedding_status = 'FAILED',
+                       error_code = :errorCode,
+                       updated_at = CURRENT_TIMESTAMP
+                 WHERE id = :documentId
+                """;
+
+        return jdbcTemplate.update(sql, new MapSqlParameterSource()
+                .addValue("documentId", documentId)
+                .addValue("errorCode", errorCode));
+    }
+
+    public List<AskChatRagSearchResultDto> search(
+            Long userId,
+            InterestCode interestCode,
+            List<Double> queryEmbedding,
+            int limit
+    ) {
+        String sql = """
+                SELECT id,
+                       source_type,
+                       source_id,
+                       interest_code,
+                       content,
+                       embedding <=> CAST(:queryEmbedding AS vector) AS distance
+                  FROM ask_chat_rag_documents
+                 WHERE user_id = :userId
+                   AND embedding_status = 'COMPLETED'
+                   AND embedding IS NOT NULL
+                   AND (:interestCode IS NULL OR interest_code = :interestCode)
+                 ORDER BY embedding <=> CAST(:queryEmbedding AS vector)
+                 LIMIT :limit
+                """;
+
+        return jdbcTemplate.query(sql, new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("interestCode", interestCode == null ? null : interestCode.name())
+                .addValue("queryEmbedding", formatVector(queryEmbedding))
+                .addValue("limit", limit), this::mapSearchResult);
+    }
+
+    private AskChatRagSearchResultDto mapSearchResult(ResultSet rs, int rowNum) throws SQLException {
+        String interestCode = rs.getString("interest_code");
+        return new AskChatRagSearchResultDto(
+                rs.getLong("id"),
+                AskChatRagDocumentSourceType.valueOf(rs.getString("source_type")),
+                rs.getLong("source_id"),
+                interestCode == null ? null : InterestCode.valueOf(interestCode),
+                rs.getString("content"),
+                rs.getDouble("distance")
+        );
+    }
+
+    private String formatVector(List<Double> embedding) {
+        StringJoiner joiner = new StringJoiner(",", "[", "]");
+        for (Double value : embedding) {
+            joiner.add(Double.toString(value));
+        }
+        return joiner.toString();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
@@ -18,4 +18,6 @@ public interface AskChatSessionRepository extends JpaRepository<AskChatSession, 
     );
 
     List<AskChatSession> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
@@ -1,0 +1,21 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AskChatSessionRepository extends JpaRepository<AskChatSession, Long> {
+
+    Optional<AskChatSession> findByIdAndUserId(Long id, Long userId);
+
+    Optional<AskChatSession> findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+            Long userId,
+            AskChatSessionStatus status
+    );
+
+    List<AskChatSession> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatEmbeddingClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatEmbeddingClient.java
@@ -1,0 +1,54 @@
+package com.devkor.ifive.nadab.domain.askchat.infra;
+
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatRagProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AskChatEmbeddingClient {
+
+    private final OpenAiEmbeddingModel embeddingModel;
+    private final AskChatRagProperties properties;
+
+    public List<Double> embed(String content) {
+        return toDoubleList(embeddingModel.embed(content));
+    }
+
+    public List<List<Double>> embedAll(List<String> contents) {
+        return contents.stream()
+                .map(this::embed)
+                .toList();
+    }
+
+    public String model() {
+        return properties.getEmbeddingModel();
+    }
+
+    public int version() {
+        return properties.getEmbeddingVersion();
+    }
+
+    public int dimensions() {
+        return properties.getEmbeddingDimensions();
+    }
+
+    public int batchSize() {
+        return properties.getEmbeddingBatchSize();
+    }
+
+    public int retrievalLimit() {
+        return properties.getRetrievalLimit();
+    }
+
+    private List<Double> toDoubleList(float[] embedding) {
+        Double[] values = new Double[embedding.length];
+        for (int i = 0; i < embedding.length; i++) {
+            values[i] = (double) embedding[i];
+        }
+        return List.of(values);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -231,6 +231,7 @@ public enum ErrorCode {
     // ==================== ASK_CHAT (물어보기) ====================
     // 404 Not Found
     ASK_CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다"),
+    ASK_CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지를 찾을 수 없습니다"),
 
     // ==================== PROMPT (프롬프트) ====================
     // 400 Bad Request

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -228,6 +228,10 @@ public enum ErrorCode {
     // 404 Not Found
     SEARCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "검색어를 찾을 수 없습니다"),
 
+    // ==================== ASK_CHAT (물어보기) ====================
+    // 404 Not Found
+    ASK_CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다"),
+
     // ==================== PROMPT (프롬프트) ====================
     // 400 Bad Request
     PROMPT_DAILY_FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "일간 리포트 프롬프트 파일이 존재하지 않습니다"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,10 @@ spring:
         options:
           model: gpt-4o-mini
           temperature: 0.0
+      embedding:
+        options:
+          model: text-embedding-3-small
+          dimensions: 1536
     anthropic:
       api-key: ${ANTHROPIC_API_KEY}
       chat:
@@ -90,6 +94,14 @@ admin:
     cookie-name: admin_auth
 
 api_prefix: /api/v1
+
+ask-chat:
+  rag:
+    embedding-model: text-embedding-3-small
+    embedding-dimensions: 1536
+    embedding-version: 1
+    embedding-batch-size: 20
+    retrieval-limit: 5
 
 firebase:
   admin:

--- a/src/main/resources/db/migration/V20260713_1200__IS_create_ask_chat_tables.sql
+++ b/src/main/resources/db/migration/V20260713_1200__IS_create_ask_chat_tables.sql
@@ -1,0 +1,37 @@
+CREATE TABLE ask_chat_sessions (
+    id                  BIGSERIAL    PRIMARY KEY,
+    user_id             BIGINT       NOT NULL,
+    status              VARCHAR(16)  NOT NULL,
+    answered_turn_count INTEGER      NOT NULL DEFAULT 0,
+    ended_at            TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_ask_chat_sessions_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE ask_chat_messages (
+    id              BIGSERIAL    PRIMARY KEY,
+    session_id      BIGINT       NOT NULL,
+    role            VARCHAR(16)  NOT NULL,
+    status          VARCHAR(16)  NOT NULL,
+    content         TEXT         NOT NULL,
+    llm_provider    VARCHAR(32),
+    llm_model       VARCHAR(128),
+    input_tokens    BIGINT,
+    output_tokens   BIGINT,
+    total_tokens    BIGINT,
+    thinking_tokens BIGINT,
+    error_code      VARCHAR(128),
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_ask_chat_messages_session
+        FOREIGN KEY (session_id) REFERENCES ask_chat_sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ask_chat_sessions_user_status_created
+    ON ask_chat_sessions(user_id, status, created_at DESC);
+
+CREATE INDEX idx_ask_chat_messages_session_created
+    ON ask_chat_messages(session_id, created_at);

--- a/src/main/resources/db/migration/V20260713_1300__IS_create_ask_chat_rag_documents.sql
+++ b/src/main/resources/db/migration/V20260713_1300__IS_create_ask_chat_rag_documents.sql
@@ -1,0 +1,38 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE ask_chat_rag_documents (
+    id                BIGSERIAL    PRIMARY KEY,
+    user_id           BIGINT       NOT NULL,
+    source_type       VARCHAR(32)  NOT NULL,
+    source_id         BIGINT       NOT NULL,
+    interest_code     VARCHAR(32),
+    content           TEXT         NOT NULL,
+    metadata          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    embedding         VECTOR(1536),
+    embedding_model   VARCHAR(128) NOT NULL,
+    embedding_version INTEGER      NOT NULL,
+    embedding_status  VARCHAR(16)  NOT NULL DEFAULT 'PENDING',
+    error_code        VARCHAR(128),
+    embedded_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_ask_chat_rag_documents_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT uq_ask_chat_rag_documents_source_version
+        UNIQUE (source_type, source_id, embedding_version)
+);
+
+CREATE INDEX idx_ask_chat_rag_documents_user_status_created
+    ON ask_chat_rag_documents(user_id, embedding_status, created_at DESC);
+
+CREATE INDEX idx_ask_chat_rag_documents_user_interest_created
+    ON ask_chat_rag_documents(user_id, interest_code, created_at DESC);
+
+CREATE INDEX idx_ask_chat_rag_documents_source
+    ON ask_chat_rag_documents(source_type, source_id);
+
+CREATE INDEX idx_ask_chat_rag_documents_embedding_hnsw
+    ON ask_chat_rag_documents
+    USING hnsw (embedding vector_cosine_ops)
+    WHERE embedding IS NOT NULL;

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryServiceTest.java
@@ -1,0 +1,191 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatHistoryQueryServiceTest {
+
+    @Mock
+    private AskChatSessionRepository askChatSessionRepository;
+
+    @Mock
+    private AskChatMessageRepository askChatMessageRepository;
+
+    private AskChatHistoryQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AskChatHistoryQueryService(
+                askChatSessionRepository,
+                askChatMessageRepository
+        );
+    }
+
+    @Test
+    void getHistories_returns_page_metadata_and_first_user_message_title() {
+        OffsetDateTime activeCreatedAt = OffsetDateTime.of(2026, 7, 13, 10, 0, 0, 0, ZoneOffset.ofHours(9));
+        OffsetDateTime endedCreatedAt = OffsetDateTime.of(2026, 7, 12, 10, 0, 0, 0, ZoneOffset.ofHours(9));
+        AskChatSession active = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                2,
+                activeCreatedAt,
+                null
+        );
+        AskChatSession ended = session(
+                9L,
+                AskChatSessionStatus.ENDED,
+                15,
+                endedCreatedAt,
+                OffsetDateTime.of(2026, 7, 12, 10, 20, 0, 0, ZoneOffset.ofHours(9))
+        );
+        when(askChatSessionRepository.findAllByUserIdOrderByCreatedAtDesc(1L, PageRequest.of(0, 2)))
+                .thenReturn(List.of(active, ended));
+        when(askChatSessionRepository.countByUserId(1L)).thenReturn(3L);
+        AskChatMessage activeTitleMessage = message(
+                100L,
+                AskChatMessageRole.USER,
+                "나는 어떤 사람이야?",
+                activeCreatedAt
+        );
+        AskChatMessage endedTitleMessage = message(
+                90L,
+                AskChatMessageRole.USER,
+                "내 장점은 뭐야?",
+                endedCreatedAt
+        );
+        when(askChatMessageRepository.findFirstBySessionIdAndRoleOrderByCreatedAtAsc(10L, AskChatMessageRole.USER))
+                .thenReturn(Optional.of(activeTitleMessage));
+        when(askChatMessageRepository.findFirstBySessionIdAndRoleOrderByCreatedAtAsc(9L, AskChatMessageRole.USER))
+                .thenReturn(Optional.of(endedTitleMessage));
+
+        var response = service.getHistories(1L, 1, 2);
+
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(response.currentPage()).isEqualTo(1);
+        assertThat(response.pageSize()).isEqualTo(2);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.hasPrevious()).isFalse();
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.histories())
+                .extracting("sessionId", "title", "status", "answeredTurnCount")
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(10L, "나는 어떤 사람이야?", AskChatSessionStatus.ACTIVE, 2),
+                        org.assertj.core.groups.Tuple.tuple(9L, "내 장점은 뭐야?", AskChatSessionStatus.ENDED, 15)
+                );
+    }
+
+    @Test
+    void getHistories_rejects_invalid_page_request() {
+        assertThatThrownBy(() -> service.getHistories(1L, 0, 20))
+                .isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.getHistories(1L, 1, 0))
+                .isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.getHistories(1L, 1, 51))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void getHistoryDetail_returns_session_messages_in_created_order() {
+        AskChatSession session = session(
+                10L,
+                AskChatSessionStatus.ENDED,
+                1,
+                OffsetDateTime.of(2026, 7, 13, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                OffsetDateTime.of(2026, 7, 13, 10, 2, 0, 0, ZoneOffset.ofHours(9))
+        );
+        AskChatMessage userMessage = message(
+                100L,
+                AskChatMessageRole.USER,
+                "나는 어떤 사람이야?",
+                OffsetDateTime.of(2026, 7, 13, 10, 0, 0, 0, ZoneOffset.ofHours(9))
+        );
+        AskChatMessage assistantMessage = message(
+                101L,
+                AskChatMessageRole.ASSISTANT,
+                "따뜻함을 자주 발견하는 사람이에요.",
+                OffsetDateTime.of(2026, 7, 13, 10, 1, 0, 0, ZoneOffset.ofHours(9))
+        );
+        when(askChatSessionRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(session));
+        when(askChatMessageRepository.findAllBySessionIdOrderByCreatedAtAsc(10L))
+                .thenReturn(List.of(userMessage, assistantMessage));
+
+        var response = service.getHistoryDetail(1L, 10L);
+
+        assertThat(response.sessionId()).isEqualTo(10L);
+        assertThat(response.status()).isEqualTo(AskChatSessionStatus.ENDED);
+        assertThat(response.answeredTurnCount()).isEqualTo(1);
+        assertThat(response.messages())
+                .extracting("id", "role", "content")
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(100L, AskChatMessageRole.USER, "나는 어떤 사람이야?"),
+                        org.assertj.core.groups.Tuple.tuple(101L, AskChatMessageRole.ASSISTANT, "따뜻함을 자주 발견하는 사람이에요.")
+                );
+    }
+
+    @Test
+    void getHistoryDetail_rejects_missing_or_other_user_session() {
+        when(askChatSessionRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getHistoryDetail(1L, 10L))
+                .isInstanceOfSatisfying(NotFoundException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ASK_CHAT_SESSION_NOT_FOUND));
+    }
+
+    private AskChatSession session(
+            Long id,
+            AskChatSessionStatus status,
+            int answeredTurnCount,
+            OffsetDateTime createdAt,
+            OffsetDateTime endedAt
+    ) {
+        AskChatSession session = mock(AskChatSession.class);
+        lenient().when(session.getId()).thenReturn(id);
+        lenient().when(session.getStatus()).thenReturn(status);
+        lenient().when(session.getAnsweredTurnCount()).thenReturn(answeredTurnCount);
+        lenient().when(session.getCreatedAt()).thenReturn(createdAt);
+        lenient().when(session.getEndedAt()).thenReturn(endedAt);
+        return session;
+    }
+
+    private AskChatMessage message(
+            Long id,
+            AskChatMessageRole role,
+            String content,
+            OffsetDateTime createdAt
+    ) {
+        AskChatMessage message = mock(AskChatMessage.class);
+        lenient().when(message.getId()).thenReturn(id);
+        lenient().when(message.getRole()).thenReturn(role);
+        lenient().when(message.getStatus()).thenReturn(AskChatMessageStatus.COMPLETED);
+        lenient().when(message.getContent()).thenReturn(content);
+        lenient().when(message.getCreatedAt()).thenReturn(createdAt);
+        return message;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatRagIndexingServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatRagIndexingServiceTest.java
@@ -1,0 +1,176 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagVectorRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatEmbeddingClient;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatRagIndexingServiceTest {
+
+    @Mock
+    private AskChatMessageRepository messageRepository;
+
+    @Mock
+    private AskChatRagDocumentRepository ragDocumentRepository;
+
+    @Mock
+    private AskChatRagVectorRepository ragVectorRepository;
+
+    @Mock
+    private AskChatEmbeddingClient embeddingClient;
+
+    private AskChatRagIndexingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AskChatRagIndexingService(
+                messageRepository,
+                ragDocumentRepository,
+                ragVectorRepository,
+                embeddingClient
+        );
+    }
+
+    @Test
+    void indexAssistantMessage_saves_rag_document_and_embedding_for_completed_assistant_message() {
+        AskChatMessage message = message(10L, AskChatMessageRole.ASSISTANT, AskChatMessageStatus.COMPLETED);
+        AskChatRagDocument savedDocument = mock(AskChatRagDocument.class);
+        when(savedDocument.getId()).thenReturn(100L);
+        when(messageRepository.findById(10L)).thenReturn(Optional.of(message));
+        when(embeddingClient.version()).thenReturn(1);
+        when(embeddingClient.model()).thenReturn("text-embedding-3-small");
+        when(ragDocumentRepository.existsBySourceTypeAndSourceIdAndEmbeddingVersion(
+                AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE,
+                10L,
+                1
+        )).thenReturn(false);
+        when(ragDocumentRepository.save(any(AskChatRagDocument.class))).thenReturn(savedDocument);
+        when(embeddingClient.embed("assistant answer")).thenReturn(List.of(0.1, 0.2, 0.3));
+
+        service.indexAssistantMessage(10L, InterestCode.RELATIONSHIP);
+
+        ArgumentCaptor<AskChatRagDocument> captor = ArgumentCaptor.forClass(AskChatRagDocument.class);
+        verify(ragDocumentRepository).save(captor.capture());
+        AskChatRagDocument document = captor.getValue();
+        assertThat(document.getSourceType()).isEqualTo(AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE);
+        assertThat(document.getSourceId()).isEqualTo(10L);
+        assertThat(document.getInterestCode()).isEqualTo(InterestCode.RELATIONSHIP);
+        assertThat(document.getContent()).isEqualTo("assistant answer");
+        assertThat(document.getEmbeddingModel()).isEqualTo("text-embedding-3-small");
+        assertThat(document.getEmbeddingVersion()).isEqualTo(1);
+        assertThat(document.getMetadata())
+                .containsEntry("sessionId", 20L)
+                .containsEntry("messageId", 10L)
+                .containsEntry("role", "ASSISTANT")
+                .containsEntry("status", "COMPLETED")
+                .containsEntry("llmProvider", "OPENAI")
+                .containsEntry("llmModel", "gpt-4o-mini");
+        verify(ragVectorRepository).updateEmbedding(100L, List.of(0.1, 0.2, 0.3));
+    }
+
+    @Test
+    void indexAssistantMessage_skips_non_completed_assistant_message() {
+        AskChatMessage message = message(10L, AskChatMessageRole.USER, AskChatMessageStatus.COMPLETED);
+        when(messageRepository.findById(10L)).thenReturn(Optional.of(message));
+
+        service.indexAssistantMessage(10L, InterestCode.RELATIONSHIP);
+
+        verifyNoInteractions(ragDocumentRepository, ragVectorRepository, embeddingClient);
+    }
+
+    @Test
+    void indexAssistantMessage_skips_duplicate_document_version() {
+        AskChatMessage message = message(10L, AskChatMessageRole.ASSISTANT, AskChatMessageStatus.COMPLETED);
+        when(messageRepository.findById(10L)).thenReturn(Optional.of(message));
+        when(embeddingClient.version()).thenReturn(1);
+        when(ragDocumentRepository.existsBySourceTypeAndSourceIdAndEmbeddingVersion(
+                AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE,
+                10L,
+                1
+        )).thenReturn(true);
+
+        service.indexAssistantMessage(10L, InterestCode.RELATIONSHIP);
+
+        verify(ragDocumentRepository, never()).save(any());
+        verifyNoInteractions(ragVectorRepository);
+    }
+
+    @Test
+    void indexAssistantMessage_marks_document_failed_when_embedding_fails() {
+        AskChatMessage message = message(10L, AskChatMessageRole.ASSISTANT, AskChatMessageStatus.COMPLETED);
+        AskChatRagDocument savedDocument = mock(AskChatRagDocument.class);
+        when(savedDocument.getId()).thenReturn(100L);
+        when(messageRepository.findById(10L)).thenReturn(Optional.of(message));
+        when(embeddingClient.version()).thenReturn(1);
+        when(embeddingClient.model()).thenReturn("text-embedding-3-small");
+        when(ragDocumentRepository.existsBySourceTypeAndSourceIdAndEmbeddingVersion(
+                AskChatRagDocumentSourceType.ASK_CHAT_MESSAGE,
+                10L,
+                1
+        )).thenReturn(false);
+        when(ragDocumentRepository.save(any(AskChatRagDocument.class))).thenReturn(savedDocument);
+        when(embeddingClient.embed("assistant answer")).thenThrow(new IllegalStateException("embedding failed"));
+
+        service.indexAssistantMessage(10L, InterestCode.RELATIONSHIP);
+
+        verify(ragVectorRepository).markEmbeddingFailed(100L, "IllegalStateException");
+        verify(ragVectorRepository, never()).updateEmbedding(any(), any());
+    }
+
+    @Test
+    void indexAssistantMessage_rejects_missing_message() {
+        when(messageRepository.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.indexAssistantMessage(10L, InterestCode.RELATIONSHIP))
+                .isInstanceOfSatisfying(NotFoundException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ASK_CHAT_MESSAGE_NOT_FOUND));
+    }
+
+    private AskChatMessage message(Long id, AskChatMessageRole role, AskChatMessageStatus status) {
+        User user = mock(User.class);
+        AskChatSession session = mock(AskChatSession.class);
+        lenient().when(session.getId()).thenReturn(20L);
+        lenient().when(session.getUser()).thenReturn(user);
+
+        AskChatMessage message = mock(AskChatMessage.class);
+        lenient().when(message.getId()).thenReturn(id);
+        lenient().when(message.getSession()).thenReturn(session);
+        lenient().when(message.getRole()).thenReturn(role);
+        lenient().when(message.getStatus()).thenReturn(status);
+        lenient().when(message.getContent()).thenReturn("assistant answer");
+        lenient().when(message.getLlmProvider()).thenReturn(LlmProvider.OPENAI);
+        lenient().when(message.getLlmModel()).thenReturn("gpt-4o-mini");
+        return message;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatEmbeddingClientTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatEmbeddingClientTest.java
@@ -1,0 +1,56 @@
+package com.devkor.ifive.nadab.domain.askchat.infra;
+
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatRagProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatEmbeddingClientTest {
+
+    @Mock
+    OpenAiEmbeddingModel embeddingModel;
+
+    @Test
+    void embed_converts_float_embedding_to_double_list() {
+        AskChatEmbeddingClient client = new AskChatEmbeddingClient(embeddingModel, properties());
+        when(embeddingModel.embed("Who am I?")).thenReturn(new float[]{0.1f, -0.2f, 0.3f});
+
+        List<Double> result = client.embed("Who am I?");
+
+        assertThat(result).containsExactly(
+                (double) 0.1f,
+                (double) -0.2f,
+                (double) 0.3f
+        );
+    }
+
+    @Test
+    void exposes_rag_embedding_options() {
+        AskChatRagProperties properties = properties();
+        AskChatEmbeddingClient client = new AskChatEmbeddingClient(embeddingModel, properties);
+
+        assertThat(client.model()).isEqualTo("text-embedding-3-small");
+        assertThat(client.version()).isEqualTo(1);
+        assertThat(client.dimensions()).isEqualTo(1536);
+        assertThat(client.batchSize()).isEqualTo(20);
+        assertThat(client.retrievalLimit()).isEqualTo(5);
+    }
+
+    private AskChatRagProperties properties() {
+        AskChatRagProperties properties = new AskChatRagProperties();
+        properties.setEmbeddingModel("text-embedding-3-small");
+        properties.setEmbeddingDimensions(1536);
+        properties.setEmbeddingVersion(1);
+        properties.setEmbeddingBatchSize(20);
+        properties.setRetrievalLimit(5);
+        return properties;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/infra/db/PostgresTestContainer.java
+++ b/src/test/java/com/devkor/ifive/nadab/infra/db/PostgresTestContainer.java
@@ -12,7 +12,8 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class PostgresTestContainer {
 
-    private static final DockerImageName IMAGE = DockerImageName.parse("postgres:16-alpine");
+    private static final DockerImageName IMAGE = DockerImageName.parse("pgvector/pgvector:pg16")
+            .asCompatibleSubstituteFor("postgres");
 
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(IMAGE);
 


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 물어보기 기능을 위한 채팅 세션/메시지 저장 기반을 추가했습니다.
- 히스토리 목록/상세 조회 API를 추가했습니다.
- Ask Chat 답변을 RAG 문서로 저장하고 pgvector embedding 검색에 활용할 수 있는 기반을 추가했습니다.

### 주요 변경사항
- `ask_chat_sessions`, `ask_chat_messages` 테이블 및 JPA 엔티티 추가
- Ask Chat 히스토리 조회 API 추가
  - `GET /ask-chat/histories`
  - `GET /ask-chat/histories/{sessionId}`
- `ask_chat_rag_documents` 테이블 추가
  - `pgvector` extension 활성화
  - `VECTOR(1536)` embedding 컬럼
  - HNSW cosine index
  - source/version unique constraint
- RAG 문서 저장소 및 vector 검색 repository 추가
- Spring AI OpenAI embedding 설정 및 embedding client 추가
- 완료된 assistant 메시지를 RAG 문서로 색인하는 indexing service 추가
- 히스토리 조회, embedding client, RAG indexing service 단위 테스트 추가

### 검증
- `git diff --check`
- `./gradlew.bat --no-daemon compileJava`
- `./gradlew.bat --no-daemon test --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatHistoryQueryServiceTest"`
- `./gradlew.bat --no-daemon test --tests "com.devkor.ifive.nadab.domain.askchat.infra.AskChatEmbeddingClientTest"`
- `./gradlew.bat --no-daemon test --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatRagIndexingServiceTest"`

### 참고 / 리스크
- 실제 채팅 전송/답변 생성 API와 RAG retrieval 연결은 후속 PR 범위입니다.
- DB migration에서 `pgvector` extension을 사용하므로 배포 DB에 extension 생성 권한/지원 여부 확인이 필요합니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.