### PR TITLE
feat(ai): Ask Chat 세션과 히스토리 API 추가

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
@@ -36,6 +36,7 @@ public class AskChatHistoryController {
             summary = "물어보기 히스토리 목록 조회",
             description = """
                     사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.
+                    USER 메시지가 1개 이상 저장된 세션만 히스토리로 노출하며, 세션만 생성되고 질문이 없는 대화는 목록에 포함하지 않습니다.
                     page는 1부터 시작하며, size는 최대 50까지 요청할 수 있습니다.
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
@@ -70,7 +71,7 @@ public class AskChatHistoryController {
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 히스토리 상세 조회",
-            description = "선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다.",
+            description = "선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다. 과거 대화 상세 화면은 readOnly=true로 반환하며 새 질문 입력은 제공하지 않습니다.",
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
@@ -35,9 +35,10 @@ public class AskChatHistoryController {
     @Operation(
             summary = "물어보기 히스토리 목록 조회",
             description = """
-                    사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.
+                    ask_history_01 화면에서 사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.
                     USER 메시지가 1개 이상 저장된 세션만 히스토리로 노출하며, 세션만 생성되고 질문이 없는 대화는 목록에 포함하지 않습니다.
                     page는 1부터 시작하며, size는 최대 50까지 요청할 수 있습니다.
+                    응답의 empty는 현재 페이지의 목록이 비어 있는지 나타내며, 각 항목의 createdDate는 히스토리 카드 날짜 표시용입니다.
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
@@ -71,7 +72,11 @@ public class AskChatHistoryController {
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 히스토리 상세 조회",
-            description = "선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다. 과거 대화 상세 화면은 readOnly=true로 반환하며 새 질문 입력은 제공하지 않습니다.",
+            description = """
+                    ask_history_02 화면에서 선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다.
+                    본인의 세션만 조회할 수 있으며, 다른 사용자의 세션이거나 존재하지 않는 세션이면 ASK_CHAT_SESSION_NOT_FOUND를 반환합니다.
+                    과거 대화 상세 화면은 읽기 전용이므로 readOnly=true를 반환하며, 새 질문 입력 UI는 제공하지 않습니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
@@ -39,8 +39,12 @@ public class AskChatSessionController {
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 홈 진입",
-            description = "사용자의 활성 물어보기 채팅 세션을 조회합니다. </br>" +
-                    "활성 세션이 없으면 응답의 activeSession 필드를 null로 반환합니다.",
+            description = """
+                    ask_home_01 화면 진입 시 호출합니다.
+                    홈 진입만으로 새 채팅 세션을 생성하지 않고, 이어갈 수 있는 ACTIVE 세션이 있는지만 조회합니다.
+                    ACTIVE 세션이 있으면 activeSession에 세션 정보를 담아 반환하고, 없으면 activeSession만 null로 반환합니다.
+                    maxTurnCount와 remainingTurnCount는 홈 화면의 잔여 대화 횟수 표시용 값입니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(
@@ -63,7 +67,11 @@ public class AskChatSessionController {
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 세션 시작",
-            description = "사용자의 활성 물어보기 채팅 세션을 반환하고, 활성 세션이 없으면 새 세션을 생성합니다.",
+            description = """
+                    명시적으로 물어보기 채팅 세션을 준비할 때 호출합니다.
+                    이미 ACTIVE 세션이 있으면 같은 세션을 반환하고, ACTIVE 세션이 없으면 새 세션을 생성합니다.
+                    이 API는 질문 메시지를 저장하지 않으며, 실제 질문 저장은 POST /ask-chat/messages에서 수행합니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(
@@ -86,8 +94,13 @@ public class AskChatSessionController {
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 질문 전송",
-            description = "사용자 질문을 현재 활성 세션에 저장합니다. 활성 세션이 없으면 새 세션을 생성한 뒤 USER 메시지만 저장하며, 아직 AI 답변은 생성하지 않습니다. </br>" +
-                    "세션의 성공 답변 수가 15회에 도달한 경우 메시지를 저장하지 않고 ASK_CHAT_TURN_LIMIT_EXCEEDED 오류를 반환합니다.",
+            description = """
+                    ask_home_01 또는 ask_chat_01 화면에서 사용자가 질문을 보낼 때 호출합니다.
+                    ACTIVE 세션이 있으면 해당 세션에 USER 메시지를 저장하고, ACTIVE 세션이 없으면 새 세션을 생성한 뒤 USER 메시지를 저장합니다.
+                    이 PR 단계에서는 AI 답변을 생성하지 않으므로 ASSISTANT 메시지, followUpQuestions, RAG 근거 문서는 반환하지 않습니다.
+                    질문 내용은 앞뒤 공백 제거 후 1자 이상 200자 이하만 허용합니다.
+                    answeredTurnCount가 15 이상인 세션에서는 메시지를 저장하지 않고 ASK_CHAT_TURN_LIMIT_EXCEEDED를 반환합니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
@@ -1,0 +1,78 @@
+package com.devkor.ifive.nadab.domain.askchat.api;
+
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
+import com.devkor.ifive.nadab.domain.askchat.application.AskChatSessionService;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
+import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
+import com.devkor.ifive.nadab.global.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Ask Chat API", description = "물어보기 채팅 세션 API")
+@RestController
+@RequestMapping("${api_prefix}/ask-chat")
+@RequiredArgsConstructor
+public class AskChatSessionController {
+
+    private final AskChatSessionService askChatSessionService;
+
+    @GetMapping("/home")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 홈 진입",
+            description = "사용자의 활성 물어보기 채팅 세션을 조회합니다. </br>" +
+                    "활성 세션이 없으면 응답의 activeSession 필드를 null로 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "물어보기 홈 진입 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatHomeResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatHomeResponse>> enterHome(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AskChatHomeResponse response = askChatSessionService.getHome(principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/sessions")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 세션 시작",
+            description = "사용자의 활성 물어보기 채팅 세션을 반환하고, 활성 세션이 없으면 새 세션을 생성합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "물어보기 세션 준비 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatSessionResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatSessionResponse>> startSession(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AskChatSessionResponse response = askChatSessionService.startSession(principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
@@ -1,7 +1,10 @@
 package com.devkor.ifive.nadab.domain.askchat.api;
 
+import com.devkor.ifive.nadab.domain.askchat.api.dto.request.AskChatQuestionRequest;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
+import com.devkor.ifive.nadab.domain.askchat.application.AskChatMessageCommandService;
 import com.devkor.ifive.nadab.domain.askchat.application.AskChatSessionService;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseDto;
 import com.devkor.ifive.nadab.global.core.response.ApiResponseEntity;
@@ -12,10 +15,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AskChatSessionController {
 
     private final AskChatSessionService askChatSessionService;
+    private final AskChatMessageCommandService askChatMessageCommandService;
 
     @GetMapping("/home")
     @PreAuthorize("isAuthenticated()")
@@ -73,6 +79,43 @@ public class AskChatSessionController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         AskChatSessionResponse response = askChatSessionService.startSession(principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+
+    @PostMapping("/messages")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 질문 전송",
+            description = "사용자 질문을 현재 활성 세션에 저장합니다. 활성 세션이 없으면 새 세션을 생성한 뒤 USER 메시지만 저장하며, 아직 AI 답변은 생성하지 않습니다. </br>" +
+                    "세션의 성공 답변 수가 15회에 도달한 경우 메시지를 저장하지 않고 ASK_CHAT_TURN_LIMIT_EXCEEDED 오류를 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "질문 저장 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatQuestionSendResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "- ErrorCode: VALIDATION_FAILED - 질문은 공백 제외 1자 이상 200자 이하로 요청해야 함",
+                            content = @Content
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "- ErrorCode: ASK_CHAT_TURN_LIMIT_EXCEEDED - 세션당 대화 횟수 제한 초과",
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatQuestionSendResponse>> sendQuestion(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody AskChatQuestionRequest request
+    ) {
+        AskChatQuestionSendResponse response = askChatMessageCommandService.sendQuestion(
+                principal.getId(),
+                request.content()
+        );
         return ApiResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/request/AskChatQuestionRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/request/AskChatQuestionRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "물어보기 질문 전송 요청")
 public record AskChatQuestionRequest(
-        @Schema(description = "사용자 질문 내용. 공백 제외 1자 이상 200자 이하로 입력해야 합니다.", example = "나는 어떤 사람이야?")
+        @Schema(description = "사용자 질문 내용. 앞뒤 공백 제거 후 1자 이상 200자 이하로 입력해야 합니다.", example = "나는 어떤 사람이야?")
         @NotBlank
         @Size(max = 200)
         String content

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/request/AskChatQuestionRequest.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/request/AskChatQuestionRequest.java
@@ -1,0 +1,14 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "물어보기 질문 전송 요청")
+public record AskChatQuestionRequest(
+        @Schema(description = "사용자 질문 내용. 공백 제외 1자 이상 200자 이하로 입력해야 합니다.", example = "나는 어떤 사람이야?")
+        @NotBlank
+        @Size(max = 200)
+        String content
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryDetailResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryDetailResponse.java
@@ -17,6 +17,9 @@ public record AskChatHistoryDetailResponse(
         @Schema(description = "성공적으로 답변된 대화 횟수", example = "5")
         int answeredTurnCount,
 
+        @Schema(description = "과거 대화 상세 화면은 읽기 전용인지 여부", example = "true")
+        boolean readOnly,
+
         @Schema(description = "채팅 시작 시각")
         OffsetDateTime createdAt,
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryItemResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryItemResponse.java
@@ -3,6 +3,7 @@ package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 @Schema(description = "Ask Chat 히스토리 목록 항목")
@@ -12,6 +13,9 @@ public record AskChatHistoryItemResponse(
 
         @Schema(description = "히스토리 카드 제목으로 사용할 첫 사용자 질문", example = "나는 어떤 사람이야?")
         String title,
+
+        @Schema(description = "히스토리 카드에 표시할 작성일", example = "2026-06-20")
+        LocalDate createdDate,
 
         @Schema(description = "채팅 세션 상태", example = "ACTIVE")
         AskChatSessionStatus status,

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryListResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHistoryListResponse.java
@@ -9,6 +9,9 @@ public record AskChatHistoryListResponse(
         @Schema(description = "히스토리 목록")
         List<AskChatHistoryItemResponse> histories,
 
+        @Schema(description = "히스토리가 비어 있는지 여부", example = "false")
+        boolean empty,
+
         @Schema(description = "전체 히스토리 수", example = "12")
         long totalCount,
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHomeResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatHomeResponse.java
@@ -1,0 +1,34 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Optional;
+
+@Schema(description = "물어보기 홈 응답")
+public record AskChatHomeResponse(
+        @Schema(description = "세션당 최대 대화 횟수", example = "15")
+        int maxTurnCount,
+
+        @Schema(description = "홈 화면에 표시할 잔여 대화 횟수. 활성 세션이 없으면 세션당 최대 대화 횟수와 같습니다.", example = "12")
+        int remainingTurnCount,
+
+        @Schema(description = "현재 이어갈 수 있는 활성 채팅 세션입니다. 활성 세션이 없으면 이 필드만 null입니다.", nullable = true)
+        AskChatSessionResponse activeSession
+) {
+
+    public static AskChatHomeResponse from(Optional<AskChatSession> session, int maxTurnCount) {
+        AskChatSessionResponse activeSession = session
+                .map(value -> AskChatSessionResponse.from(value, maxTurnCount))
+                .orElse(null);
+        int remainingTurnCount = activeSession == null
+                ? maxTurnCount
+                : activeSession.remainingTurnCount();
+
+        return new AskChatHomeResponse(
+                maxTurnCount,
+                remainingTurnCount,
+                activeSession
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물어보기 질문 전송 응답")
+public record AskChatQuestionSendResponse(
+        @Schema(description = "질문이 저장된 채팅 세션")
+        AskChatSessionResponse session,
+
+        @Schema(description = "저장된 사용자 질문 메시지")
+        AskChatMessageResponse userMessage
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatSessionResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatSessionResponse.java
@@ -1,0 +1,46 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "물어보기 채팅 세션 응답")
+public record AskChatSessionResponse(
+        @Schema(description = "채팅 세션 ID", example = "1")
+        Long sessionId,
+
+        @Schema(description = "채팅 세션 상태", example = "ACTIVE")
+        AskChatSessionStatus status,
+
+        @Schema(description = "성공적으로 답변받은 턴 수", example = "3")
+        int answeredTurnCount,
+
+        @Schema(description = "세션당 최대 대화 횟수", example = "15")
+        int maxTurnCount,
+
+        @Schema(description = "현재 세션의 잔여 대화 횟수", example = "12")
+        int remainingTurnCount,
+
+        @Schema(description = "채팅 세션 생성 시각")
+        OffsetDateTime createdAt,
+
+        @Schema(description = "채팅 세션 종료 시각")
+        OffsetDateTime endedAt
+) {
+
+    public static AskChatSessionResponse from(AskChatSession session, int maxTurnCount) {
+        int remainingTurnCount = Math.max(0, maxTurnCount - session.getAnsweredTurnCount());
+
+        return new AskChatSessionResponse(
+                session.getId(),
+                session.getStatus(),
+                session.getAnsweredTurnCount(),
+                maxTurnCount,
+                remainingTurnCount,
+                session.getCreatedAt(),
+                session.getEndedAt()
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryService.java
@@ -33,11 +33,15 @@ public class AskChatHistoryQueryService {
         validatePageRequest(page, size);
 
         PageRequest pageRequest = PageRequest.of(page - 1, size);
-        List<AskChatSession> sessions = askChatSessionRepository.findAllByUserIdOrderByCreatedAtDesc(
+        List<AskChatSession> sessions = askChatSessionRepository.findHistoriesByUserIdAndMessageRole(
                 userId,
+                AskChatMessageRole.USER,
                 pageRequest
         );
-        long totalCount = askChatSessionRepository.countByUserId(userId);
+        long totalCount = askChatSessionRepository.countHistoriesByUserIdAndMessageRole(
+                userId,
+                AskChatMessageRole.USER
+        );
         int totalPages = totalCount == 0 ? 0 : (int) Math.ceil((double) totalCount / size);
 
         List<AskChatHistoryItemResponse> histories = sessions.stream()
@@ -46,6 +50,7 @@ public class AskChatHistoryQueryService {
 
         return new AskChatHistoryListResponse(
                 histories,
+                histories.isEmpty(),
                 totalCount,
                 page,
                 size,
@@ -68,6 +73,7 @@ public class AskChatHistoryQueryService {
                 session.getId(),
                 session.getStatus(),
                 session.getAnsweredTurnCount(),
+                true,
                 session.getCreatedAt(),
                 session.getEndedAt(),
                 messages
@@ -85,6 +91,7 @@ public class AskChatHistoryQueryService {
         return new AskChatHistoryItemResponse(
                 session.getId(),
                 title,
+                session.getCreatedAt().toLocalDate(),
                 session.getStatus(),
                 session.getAnsweredTurnCount(),
                 session.getCreatedAt()

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -11,6 +11,7 @@ import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepos
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -21,17 +22,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AskChatMessageCommandService {
 
+    private static final int MAX_QUESTION_LENGTH = 200;
+
     private final AskChatSessionRepository askChatSessionRepository;
     private final AskChatMessageRepository askChatMessageRepository;
     private final UserRepository userRepository;
 
     @Transactional
     public AskChatQuestionSendResponse sendQuestion(Long userId, String content) {
+        String normalizedContent = normalizeQuestionContent(content);
         AskChatSession session = getOrCreateActiveSession(userId);
         validateTurnLimit(session);
 
         AskChatMessage userMessage = askChatMessageRepository.save(
-                AskChatMessage.createUserMessage(session, content.trim())
+                AskChatMessage.createUserMessage(session, normalizedContent)
         );
 
         return new AskChatQuestionSendResponse(
@@ -59,5 +63,18 @@ public class AskChatMessageCommandService {
         if (session.getAnsweredTurnCount() >= AskChatSessionService.MAX_TURN_COUNT) {
             throw new ConflictException(ErrorCode.ASK_CHAT_TURN_LIMIT_EXCEEDED);
         }
+    }
+
+    private String normalizeQuestionContent(String content) {
+        if (content == null) {
+            throw new BadRequestException(ErrorCode.VALIDATION_FAILED);
+        }
+
+        String normalizedContent = content.trim();
+        if (normalizedContent.isBlank() || normalizedContent.length() > MAX_QUESTION_LENGTH) {
+            throw new BadRequestException(ErrorCode.VALIDATION_FAILED);
+        }
+
+        return normalizedContent;
     }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -1,0 +1,63 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatMessageResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AskChatMessageCommandService {
+
+    private final AskChatSessionRepository askChatSessionRepository;
+    private final AskChatMessageRepository askChatMessageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AskChatQuestionSendResponse sendQuestion(Long userId, String content) {
+        AskChatSession session = getOrCreateActiveSession(userId);
+        validateTurnLimit(session);
+
+        AskChatMessage userMessage = askChatMessageRepository.save(
+                AskChatMessage.createUserMessage(session, content.trim())
+        );
+
+        return new AskChatQuestionSendResponse(
+                AskChatSessionResponse.from(session, AskChatSessionService.MAX_TURN_COUNT),
+                AskChatMessageResponse.from(userMessage)
+        );
+    }
+
+    private AskChatSession getOrCreateActiveSession(Long userId) {
+        return askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                        userId,
+                        AskChatSessionStatus.ACTIVE
+                )
+                .orElseGet(() -> createSession(userId));
+    }
+
+    private AskChatSession createSession(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        return askChatSessionRepository.save(AskChatSession.start(user));
+    }
+
+    private void validateTurnLimit(AskChatSession session) {
+        if (session.getAnsweredTurnCount() >= AskChatSessionService.MAX_TURN_COUNT) {
+            throw new ConflictException(ErrorCode.ASK_CHAT_TURN_LIMIT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
@@ -1,0 +1,54 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AskChatSessionService {
+
+    public static final int MAX_TURN_COUNT = 15;
+
+    private final AskChatSessionRepository askChatSessionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public AskChatHomeResponse getHome(Long userId) {
+        Optional<AskChatSession> activeSession = askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                userId,
+                AskChatSessionStatus.ACTIVE
+        );
+
+        return AskChatHomeResponse.from(activeSession, MAX_TURN_COUNT);
+    }
+
+    @Transactional
+    public AskChatSessionResponse startSession(Long userId) {
+        AskChatSession session = askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                        userId,
+                        AskChatSessionStatus.ACTIVE
+                )
+                .orElseGet(() -> createSession(userId));
+
+        return AskChatSessionResponse.from(session, MAX_TURN_COUNT);
+    }
+
+    private AskChatSession createSession(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        return askChatSessionRepository.save(AskChatSession.start(user));
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepository.java
@@ -1,9 +1,12 @@
 package com.devkor.ifive.nadab.domain.askchat.core.repository;
 
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +23,38 @@ public interface AskChatSessionRepository extends JpaRepository<AskChatSession, 
     List<AskChatSession> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     long countByUserId(Long userId);
+
+    @Query("""
+        select s
+        from AskChatSession s
+        where s.user.id = :userId
+          and exists (
+              select 1
+              from AskChatMessage m
+              where m.session = s
+                and m.role = :role
+          )
+        order by s.createdAt desc
+        """)
+    List<AskChatSession> findHistoriesByUserIdAndMessageRole(
+            @Param("userId") Long userId,
+            @Param("role") AskChatMessageRole role,
+            Pageable pageable
+    );
+
+    @Query("""
+        select count(s)
+        from AskChatSession s
+        where s.user.id = :userId
+          and exists (
+              select 1
+              from AskChatMessage m
+              where m.session = s
+                and m.role = :role
+          )
+        """)
+    long countHistoriesByUserIdAndMessageRole(
+            @Param("userId") Long userId,
+            @Param("role") AskChatMessageRole role
+    );
 }

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -229,6 +229,9 @@ public enum ErrorCode {
     SEARCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "검색어를 찾을 수 없습니다"),
 
     // ==================== ASK_CHAT (물어보기) ====================
+    // 409 Conflict
+    ASK_CHAT_TURN_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "세션당 대화 횟수를 모두 사용했습니다"),
+
     // 404 Not Found
     ASK_CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다"),
     ASK_CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지를 찾을 수 없습니다"),

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatHistoryQueryServiceTest.java
@@ -65,9 +65,14 @@ class AskChatHistoryQueryServiceTest {
                 endedCreatedAt,
                 OffsetDateTime.of(2026, 7, 12, 10, 20, 0, 0, ZoneOffset.ofHours(9))
         );
-        when(askChatSessionRepository.findAllByUserIdOrderByCreatedAtDesc(1L, PageRequest.of(0, 2)))
+        when(askChatSessionRepository.findHistoriesByUserIdAndMessageRole(
+                1L,
+                AskChatMessageRole.USER,
+                PageRequest.of(0, 2)
+        ))
                 .thenReturn(List.of(active, ended));
-        when(askChatSessionRepository.countByUserId(1L)).thenReturn(3L);
+        when(askChatSessionRepository.countHistoriesByUserIdAndMessageRole(1L, AskChatMessageRole.USER))
+                .thenReturn(3L);
         AskChatMessage activeTitleMessage = message(
                 100L,
                 AskChatMessageRole.USER,
@@ -91,14 +96,47 @@ class AskChatHistoryQueryServiceTest {
         assertThat(response.currentPage()).isEqualTo(1);
         assertThat(response.pageSize()).isEqualTo(2);
         assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.empty()).isFalse();
         assertThat(response.hasPrevious()).isFalse();
         assertThat(response.hasNext()).isTrue();
         assertThat(response.histories())
-                .extracting("sessionId", "title", "status", "answeredTurnCount")
+                .extracting("sessionId", "title", "createdDate", "status", "answeredTurnCount")
                 .containsExactly(
-                        org.assertj.core.groups.Tuple.tuple(10L, "나는 어떤 사람이야?", AskChatSessionStatus.ACTIVE, 2),
-                        org.assertj.core.groups.Tuple.tuple(9L, "내 장점은 뭐야?", AskChatSessionStatus.ENDED, 15)
+                        org.assertj.core.groups.Tuple.tuple(
+                                10L,
+                                "나는 어떤 사람이야?",
+                                activeCreatedAt.toLocalDate(),
+                                AskChatSessionStatus.ACTIVE,
+                                2
+                        ),
+                        org.assertj.core.groups.Tuple.tuple(
+                                9L,
+                                "내 장점은 뭐야?",
+                                endedCreatedAt.toLocalDate(),
+                                AskChatSessionStatus.ENDED,
+                                15
+                        )
                 );
+    }
+
+    @Test
+    void getHistories_returns_empty_response_when_no_user_message_session_exists() {
+        when(askChatSessionRepository.findHistoriesByUserIdAndMessageRole(
+                1L,
+                AskChatMessageRole.USER,
+                PageRequest.of(0, 20)
+        )).thenReturn(List.of());
+        when(askChatSessionRepository.countHistoriesByUserIdAndMessageRole(1L, AskChatMessageRole.USER))
+                .thenReturn(0L);
+
+        var response = service.getHistories(1L, 1, 20);
+
+        assertThat(response.histories()).isEmpty();
+        assertThat(response.empty()).isTrue();
+        assertThat(response.totalCount()).isZero();
+        assertThat(response.totalPages()).isZero();
+        assertThat(response.hasPrevious()).isFalse();
+        assertThat(response.hasNext()).isFalse();
     }
 
     @Test
@@ -141,6 +179,7 @@ class AskChatHistoryQueryServiceTest {
         assertThat(response.sessionId()).isEqualTo(10L);
         assertThat(response.status()).isEqualTo(AskChatSessionStatus.ENDED);
         assertThat(response.answeredTurnCount()).isEqualTo(1);
+        assertThat(response.readOnly()).isTrue();
         assertThat(response.messages())
                 .extracting("id", "role", "content")
                 .containsExactly(

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -1,0 +1,168 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.ConflictException;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatMessageCommandServiceTest {
+
+    @Mock
+    private AskChatSessionRepository askChatSessionRepository;
+
+    @Mock
+    private AskChatMessageRepository askChatMessageRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private AskChatMessageCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AskChatMessageCommandService(
+                askChatSessionRepository,
+                askChatMessageRepository,
+                userRepository
+        );
+    }
+
+    @Test
+    void sendQuestion_saves_user_message_to_active_session() {
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                2,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+        when(askChatMessageRepository.save(any(AskChatMessage.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.sendQuestion(1L, "  나는 어떤 사람이야?  ");
+
+        assertThat(response.session().sessionId()).isEqualTo(10L);
+        assertThat(response.session().remainingTurnCount()).isEqualTo(13);
+        assertThat(response.userMessage().role()).isEqualTo(AskChatMessageRole.USER);
+        assertThat(response.userMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
+        assertThat(response.userMessage().content()).isEqualTo("나는 어떤 사람이야?");
+
+        ArgumentCaptor<AskChatMessage> messageCaptor = ArgumentCaptor.forClass(AskChatMessage.class);
+        verify(askChatMessageRepository).save(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getSession()).isEqualTo(activeSession);
+        assertThat(messageCaptor.getValue().getContent()).isEqualTo("나는 어떤 사람이야?");
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void sendQuestion_creates_session_when_active_session_does_not_exist() {
+        User user = mock(User.class);
+        AskChatSession savedSession = session(
+                11L,
+                AskChatSessionStatus.ACTIVE,
+                0,
+                OffsetDateTime.of(2026, 7, 14, 10, 5, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(askChatSessionRepository.save(any(AskChatSession.class))).thenReturn(savedSession);
+        when(askChatMessageRepository.save(any(AskChatMessage.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.sendQuestion(1L, "궁금한 내용을 적어봐요");
+
+        assertThat(response.session().sessionId()).isEqualTo(11L);
+        assertThat(response.session().remainingTurnCount()).isEqualTo(15);
+        assertThat(response.userMessage().content()).isEqualTo("궁금한 내용을 적어봐요");
+
+        ArgumentCaptor<AskChatSession> sessionCaptor = ArgumentCaptor.forClass(AskChatSession.class);
+        verify(askChatSessionRepository).save(sessionCaptor.capture());
+        assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(AskChatSessionStatus.ACTIVE);
+    }
+
+    @Test
+    void sendQuestion_rejects_when_turn_limit_is_exceeded() {
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                AskChatSessionService.MAX_TURN_COUNT,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+
+        assertThatThrownBy(() -> service.sendQuestion(1L, "더 물어볼래"))
+                .isInstanceOfSatisfying(ConflictException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ASK_CHAT_TURN_LIMIT_EXCEEDED));
+        verify(askChatMessageRepository, never()).save(any());
+    }
+
+    @Test
+    void sendQuestion_rejects_missing_user_when_creating_session() {
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.sendQuestion(1L, "나는 어떤 사람이야?"))
+                .isInstanceOfSatisfying(NotFoundException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+        verify(askChatMessageRepository, never()).save(any());
+    }
+
+    private AskChatSession session(
+            Long id,
+            AskChatSessionStatus status,
+            int answeredTurnCount,
+            OffsetDateTime createdAt,
+            OffsetDateTime endedAt
+    ) {
+        AskChatSession session = mock(AskChatSession.class);
+        lenient().when(session.getId()).thenReturn(id);
+        lenient().when(session.getStatus()).thenReturn(status);
+        lenient().when(session.getAnsweredTurnCount()).thenReturn(answeredTurnCount);
+        lenient().when(session.getCreatedAt()).thenReturn(createdAt);
+        lenient().when(session.getEndedAt()).thenReturn(endedAt);
+        return session;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -10,6 +10,7 @@ import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepos
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -133,6 +134,19 @@ class AskChatMessageCommandServiceTest {
         assertThatThrownBy(() -> service.sendQuestion(1L, "더 물어볼래"))
                 .isInstanceOfSatisfying(ConflictException.class, ex ->
                         assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ASK_CHAT_TURN_LIMIT_EXCEEDED));
+        verify(askChatMessageRepository, never()).save(any());
+    }
+
+    @Test
+    void sendQuestion_rejects_blank_or_too_long_content_before_session_lookup() {
+        assertThatThrownBy(() -> service.sendQuestion(1L, "   "))
+                .isInstanceOfSatisfying(BadRequestException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.VALIDATION_FAILED));
+        assertThatThrownBy(() -> service.sendQuestion(1L, "가".repeat(201)))
+                .isInstanceOfSatisfying(BadRequestException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.VALIDATION_FAILED));
+
+        verify(askChatSessionRepository, never()).findFirstByUserIdAndStatusOrderByCreatedAtDesc(any(), any());
         verify(askChatMessageRepository, never()).save(any());
     }
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
@@ -1,0 +1,175 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatSessionServiceTest {
+
+    @Mock
+    private AskChatSessionRepository askChatSessionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private AskChatSessionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AskChatSessionService(
+                askChatSessionRepository,
+                userRepository
+        );
+    }
+
+    @Test
+    void getHome_returns_active_session_when_exists() {
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                4,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+
+        var response = service.getHome(1L);
+
+        assertThat(response.maxTurnCount()).isEqualTo(AskChatSessionService.MAX_TURN_COUNT);
+        assertThat(response.remainingTurnCount()).isEqualTo(11);
+        assertThat(response.activeSession()).isNotNull();
+        assertThat(response.activeSession().sessionId()).isEqualTo(10L);
+        assertThat(response.activeSession().status()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(response.activeSession().answeredTurnCount()).isEqualTo(4);
+        verify(userRepository, never()).findById(any());
+        verify(askChatSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void getHome_does_not_create_session_when_active_session_does_not_exist() {
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+
+        var response = service.getHome(1L);
+
+        assertThat(response.maxTurnCount()).isEqualTo(AskChatSessionService.MAX_TURN_COUNT);
+        assertThat(response.remainingTurnCount()).isEqualTo(15);
+        assertThat(response.activeSession()).isNull();
+        verify(userRepository, never()).findById(any());
+        verify(askChatSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void startSession_returns_active_session_when_exists() {
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                4,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+
+        var response = service.startSession(1L);
+
+        assertThat(response.sessionId()).isEqualTo(10L);
+        assertThat(response.status()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(response.answeredTurnCount()).isEqualTo(4);
+        assertThat(response.maxTurnCount()).isEqualTo(AskChatSessionService.MAX_TURN_COUNT);
+        assertThat(response.remainingTurnCount()).isEqualTo(11);
+        verify(userRepository, never()).findById(any());
+        verify(askChatSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void startSession_creates_session_when_active_session_does_not_exist() {
+        User user = mock(User.class);
+        AskChatSession savedSession = session(
+                11L,
+                AskChatSessionStatus.ACTIVE,
+                0,
+                OffsetDateTime.of(2026, 7, 14, 10, 5, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(askChatSessionRepository.save(any(AskChatSession.class))).thenReturn(savedSession);
+
+        var response = service.startSession(1L);
+
+        assertThat(response.sessionId()).isEqualTo(11L);
+        assertThat(response.status()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(response.answeredTurnCount()).isZero();
+        assertThat(response.remainingTurnCount()).isEqualTo(15);
+
+        ArgumentCaptor<AskChatSession> sessionCaptor = ArgumentCaptor.forClass(AskChatSession.class);
+        verify(askChatSessionRepository).save(sessionCaptor.capture());
+        assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(sessionCaptor.getValue().getAnsweredTurnCount()).isZero();
+    }
+
+    @Test
+    void startSession_rejects_missing_user_when_creating_session() {
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.startSession(1L))
+                .isInstanceOfSatisfying(NotFoundException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+        verify(askChatSessionRepository, never()).save(any());
+    }
+
+    private AskChatSession session(
+            Long id,
+            AskChatSessionStatus status,
+            int answeredTurnCount,
+            OffsetDateTime createdAt,
+            OffsetDateTime endedAt
+    ) {
+        AskChatSession session = mock(AskChatSession.class);
+        lenient().when(session.getId()).thenReturn(id);
+        lenient().when(session.getStatus()).thenReturn(status);
+        lenient().when(session.getAnsweredTurnCount()).thenReturn(answeredTurnCount);
+        lenient().when(session.getCreatedAt()).thenReturn(createdAt);
+        lenient().when(session.getEndedAt()).thenReturn(endedAt);
+        return session;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.infra.db.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AskChatSessionRepositoryTest extends PostgresIntegrationTestSupport {
+
+    @Autowired
+    private AskChatSessionRepository askChatSessionRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findHistoriesByUserIdAndMessageRole_returns_only_sessions_with_user_message() {
+        User user = persistUser("history-user@test.com");
+        AskChatSession emptySession = persistSession(user);
+        AskChatSession assistantOnlySession = persistSession(user);
+        persistMessage(AskChatMessage.createFailedAssistantMessage(
+                assistantOnlySession,
+                "답변 생성에 실패했습니다.",
+                null,
+                null,
+                "TEST_ERROR"
+        ));
+        AskChatSession firstHistory = persistSession(user);
+        persistMessage(AskChatMessage.createUserMessage(firstHistory, "나는 어떤 사람이야?"));
+        AskChatSession secondHistory = persistSession(user);
+        persistMessage(AskChatMessage.createUserMessage(secondHistory, "내 장점은 뭐야?"));
+        em.flush();
+        em.clear();
+
+        List<AskChatSession> histories = askChatSessionRepository.findHistoriesByUserIdAndMessageRole(
+                user.getId(),
+                AskChatMessageRole.USER,
+                PageRequest.of(0, 10)
+        );
+        long totalCount = askChatSessionRepository.countHistoriesByUserIdAndMessageRole(
+                user.getId(),
+                AskChatMessageRole.USER
+        );
+
+        assertThat(histories)
+                .extracting(AskChatSession::getId)
+                .containsExactly(secondHistory.getId(), firstHistory.getId());
+        assertThat(histories)
+                .extracting(AskChatSession::getId)
+                .doesNotContain(emptySession.getId(), assistantOnlySession.getId());
+        assertThat(totalCount).isEqualTo(2);
+    }
+
+    private User persistUser(String email) {
+        User user = User.createUser(email, "hashed");
+        user.updateNickname(email.substring(0, email.indexOf('@')));
+        return em.persistAndFlush(user);
+    }
+
+    private AskChatSession persistSession(User user) {
+        AskChatSession session = AskChatSession.start(user);
+        return em.persistAndFlush(session);
+    }
+
+    private AskChatMessage persistMessage(AskChatMessage message) {
+        return em.persistAndFlush(message);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Ask Chat 프론트 화면 연결을 위한 비생성 API를 추가했습니다.
- 홈 진입, 세션 시작, 질문 저장, 히스토리 목록/상세 조회 계약을 정리했습니다.
- 아직 AI 답변 생성, RAG retrieval, 크리스탈/무료 횟수 차감은 포함하지 않았습니다.

### 주요 변경사항
- **세션/홈 API**
  - `GET /ask-chat/home` 추가: ACTIVE 세션만 조회하고, 세션이 없으면 생성하지 않음
  - `POST /ask-chat/sessions` 추가: ACTIVE 세션 재사용 또는 신규 세션 생성
  - 홈 응답은 `activeSession` 하위 DTO만 nullable로 두어 응답 계약을 명확화

- **질문 저장 API**
  - `POST /ask-chat/messages` 추가
  - ACTIVE 세션이 없으면 새 세션을 생성한 뒤 USER 메시지만 저장
  - 질문 내용은 앞뒤 공백 제거 후 1~200자 검증
  - `answeredTurnCount >= 15`인 경우 `ASK_CHAT_TURN_LIMIT_EXCEEDED`로 저장 전 차단
  - 이 단계에서는 ASSISTANT 메시지, follow-up 질문, RAG 근거 문서를 생성하지 않음

- **히스토리 조회**
  - 히스토리 목록은 USER 메시지가 1개 이상 있는 세션만 노출
  - 빈 세션과 assistant-only 세션은 히스토리 목록에서 제외
  - 목록 응답에 `empty`, `createdDate` 추가
  - 상세 응답에 `readOnly=true` 추가
  - 히스토리 전용 조회/count JPQL 추가

- **Swagger/API 문서**
  - 각 API 설명에 화면 ID와 동작 조건을 구체화
  - 세션 생성 여부, nullable 응답, 읽기 전용 상세, 아직 미포함된 AI 생성 범위를 명시

- **테스트**
  - 세션 홈/시작 서비스 테스트 추가
  - 질문 저장/검증/15회 제한 서비스 테스트 추가
  - 히스토리 조회 서비스 테스트 보강
  - 히스토리 전용 repository JPQL 통합 테스트 추가

### 검증
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatMessageCommandServiceTest" --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatSessionServiceTest" --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatHistoryQueryServiceTest"`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepositoryTest" --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatHistoryQueryServiceTest"`
- `git diff --check`

### 참고 / 리스크
- AI 답변 생성 파이프라인은 후속 PR에서 연결 예정입니다.
- 크리스탈/무료 횟수 차감 정책은 이번 PR에 포함하지 않았습니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.