### PR TITLE
feat(ai): Ask Chat RAG 답변 생성 파이프라인 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -111,6 +111,14 @@ jobs:
             REPAIR_TYPE_PROMPT="$(printf '%s' "$REPAIR_TYPE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export REPAIR_TYPE_PROMPT
 
+            ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64 }}"
+            ASK_CHAT_ANSWER_SYSTEM_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export ASK_CHAT_ANSWER_SYSTEM_PROMPT
+
+            ASK_CHAT_ANSWER_USER_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_USER_PROMPT_B64 }}"
+            ASK_CHAT_ANSWER_USER_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_USER_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export ASK_CHAT_ANSWER_USER_PROMPT
+
             NOTIFICATION_MESSAGES_B64="${{ secrets.NOTIFICATION_MESSAGES_B64 }}"
             NOTIFICATION_MESSAGES="$(printf '%s' "$NOTIFICATION_MESSAGES_B64" | base64 -d | tr -d '\r')"
             export NOTIFICATION_MESSAGES

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -111,6 +111,14 @@ jobs:
             REPAIR_TYPE_PROMPT="$(printf '%s' "$REPAIR_TYPE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export REPAIR_TYPE_PROMPT
 
+            ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64 }}"
+            ASK_CHAT_ANSWER_SYSTEM_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export ASK_CHAT_ANSWER_SYSTEM_PROMPT
+
+            ASK_CHAT_ANSWER_USER_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_USER_PROMPT_B64 }}"
+            ASK_CHAT_ANSWER_USER_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_USER_PROMPT_B64" | base64 -d | tr -d '\r')"
+            export ASK_CHAT_ANSWER_USER_PROMPT
+
             NOTIFICATION_MESSAGES_B64="${{ secrets.NOTIFICATION_MESSAGES_B64 }}"
             NOTIFICATION_MESSAGES="$(printf '%s' "$NOTIFICATION_MESSAGES_B64" | base64 -d | tr -d '\r')"
             export NOTIFICATION_MESSAGES

--- a/qa-monthly-report-v2-1.4.0-seed.sql
+++ b/qa-monthly-report-v2-1.4.0-seed.sql
@@ -1,0 +1,513 @@
+-- Monthly report v2 QA seed for app 1.4.0.
+-- Replace the seven qa_*_user_id values below with the user ids you create.
+-- The script is idempotent for the generated QA data range.
+
+BEGIN;
+
+DO $$
+DECLARE
+    qa_01_user_id BIGINT := NULL; -- TODO: qa_01 user_id
+    qa_02_user_id BIGINT := NULL; -- TODO: qa_02 user_id
+    qa_03_user_id BIGINT := NULL; -- TODO: qa_03 user_id
+    qa_04_user_id BIGINT := NULL; -- TODO: qa_04 user_id
+    qa_05_user_id BIGINT := NULL; -- TODO: qa_05 user_id
+    qa_06_user_id BIGINT := NULL; -- TODO: qa_06 user_id
+    qa_07_user_id BIGINT := NULL; -- TODO: qa_07 user_id
+BEGIN
+    CREATE TEMP TABLE qa_seed_users ON COMMIT DROP AS
+    SELECT *
+    FROM (VALUES
+        ('qa_01', qa_01_user_id),
+        ('qa_02', qa_02_user_id),
+        ('qa_03', qa_03_user_id),
+        ('qa_04', qa_04_user_id),
+        ('qa_05', qa_05_user_id),
+        ('qa_06', qa_06_user_id),
+        ('qa_07', qa_07_user_id)
+    ) AS t(qa_key, user_id);
+
+    IF EXISTS (SELECT 1 FROM qa_seed_users WHERE user_id IS NULL) THEN
+        RAISE EXCEPTION 'Set every qa_*_user_id before running this seed SQL.';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM qa_seed_users q
+        LEFT JOIN users u ON u.id = q.user_id
+        WHERE u.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'One or more qa_*_user_id values do not exist in users.';
+    END IF;
+
+    DELETE FROM answer_entries
+    WHERE user_id IN (SELECT user_id FROM qa_seed_users)
+      AND date BETWEEN DATE '2026-01-01' AND DATE '2026-06-30';
+
+    DELETE FROM monthly_reports_v2
+    WHERE user_id IN (SELECT user_id FROM qa_seed_users)
+      AND month_start_date IN (DATE '2026-04-01', DATE '2026-05-01', DATE '2026-06-01');
+
+    DELETE FROM users
+    WHERE email LIKE 'qa_monthly_1_4_0_%@seed.local';
+
+    CREATE TEMP TABLE qa_seed_answers (
+        qa_key TEXT NOT NULL,
+        answer_date DATE NOT NULL,
+        interest_code TEXT NOT NULL,
+        emotion_code TEXT NOT NULL,
+        question_text TEXT NOT NULL,
+        answer_content TEXT NOT NULL
+    ) ON COMMIT DROP;
+
+    INSERT INTO qa_seed_answers VALUES
+        ('qa_01', DATE '2026-06-01', 'LOVE', 'DEPRESSION', '비 올 때 듣고 싶은 노래가 있나요?', '쳇 베이커의 재즈곡들이요. 창밖으로 떨어지는 빗소리랑 트럼펫 소리가 섞이면...'),
+        ('qa_01', DATE '2026-06-02', 'LOVE', 'DEPRESSION', '최근에 나의 한계를 느꼈던 적이 있나요?', '일이 너무 몰려서 제 마음 챙길 여유조차 없을 때요. 예민해진 제 모습을 보면서...'),
+        ('qa_01', DATE '2026-06-03', 'LOVE', 'DEPRESSION', '세상에 오직 나만 알고 있는 내 마음은 어떤 모양인가요?', '구멍이 숭숭 뚫린 하얀 솜사탕 같아요. 달콤하고 부드럽지만 작은 바람에도...'),
+        ('qa_01', DATE '2026-06-04', 'LOVE', 'DEPRESSION', '비 올 때 듣고 싶은 노래가 있나요?', '쳇 베이커의 재즈곡들이요. 창밖으로 떨어지는 빗소리랑 트럼펫 소리가 섞이면...'),
+        ('qa_01', DATE '2026-06-05', 'LOVE', 'DEPRESSION', '최근에 나의 한계를 느꼈던 적이 있나요?', '일이 너무 몰려서 제 마음 챙길 여유조차 없을 때요. 예민해진 제 모습을 보면서...'),
+        ('qa_01', DATE '2026-06-06', 'LOVE', 'DEPRESSION', '세상에 오직 나만 알고 있는 내 마음은 어떤 모양인가요?', '구멍이 숭숭 뚫린 하얀 솜사탕 같아요. 달콤하고 부드럽지만 작은 바람에도...'),
+        ('qa_01', DATE '2026-06-07', 'LOVE', 'DEPRESSION', '비 올 때 듣고 싶은 노래가 있나요?', '쳇 베이커의 재즈곡들이요. 창밖으로 떨어지는 빗소리랑 트럼펫 소리가 섞이면...'),
+        ('qa_01', DATE '2026-06-08', 'LOVE', 'DEPRESSION', '최근에 나의 한계를 느꼈던 적이 있나요?', '일이 너무 몰려서 제 마음 챙길 여유조차 없을 때요. 예민해진 제 모습을 보면서...'),
+        ('qa_01', DATE '2026-06-09', 'LOVE', 'DEPRESSION', '세상에 오직 나만 알고 있는 내 마음은 어떤 모양인가요?', '구멍이 숭숭 뚫린 하얀 솜사탕 같아요. 달콤하고 부드럽지만 작은 바람에도...'),
+        ('qa_01', DATE '2026-06-10', 'LOVE', 'DEPRESSION', '비 올 때 듣고 싶은 노래가 있나요?', '쳇 베이커의 재즈곡들이요. 창밖으로 떨어지는 빗소리랑 트럼펫 소리가 섞이면...'),
+
+        ('qa_02', DATE '2026-06-01', 'PREFERENCE', 'PEACE', '요즘 자주 찾는 색깔은 무엇인가요?', '요즘은 물 빠진 듯한 연한 버터색에 자꾸 손이 가요.'),
+        ('qa_02', DATE '2026-06-02', 'PREFERENCE', 'PEACE', '가장 자주 듣는 노래는 무엇인가요?', '인디 밴드 ''설(SURL)''이나 ''검정치마''의 노래를 반복해서 들어요.'),
+        ('qa_02', DATE '2026-06-03', 'PREFERENCE', 'PEACE', '카페에서 항상 고르는 메뉴는 무엇인가요?', '따뜻한 바닐라 라떼요. 기분이 좋을 때나 가라앉을 때나...'),
+        ('qa_02', DATE '2026-06-04', 'PREFERENCE', 'PLEASURE', '가장 좋아하는 과일은 무엇인가요?', '말랑말랑한 복숭아요. 분홍빛 색깔도 예쁘고 향기도 너무 로맨틱하잖아요.'),
+        ('qa_02', DATE '2026-06-05', 'PREFERENCE', 'PEACE', '빵집에 가면 가장 먼저 집는 빵은 무엇인가요?', '고소한 소금빵요. 화려한 토핑은 없지만 씹을수록 느껴지는 버터 향과...'),
+        ('qa_02', DATE '2026-06-06', 'EMOTION', 'PEACE', '지금 당장 하고 싶은 말이 있다면 무엇인가요?', '오늘 하루도 무사히 잘 버텼다. 이제 아무 생각 안 하고 푹 쉬고 싶어.'),
+        ('qa_02', DATE '2026-06-07', 'EMOTION', 'WILL', '최근 나를 가장 답답하게 만든 일은 무엇인가요?', '마음은 앞서는데 몸이 잘 안 따라줄 때요. 자꾸 게을러지는 것 같은...'),
+
+        ('qa_03', DATE '2026-06-01', 'PREFERENCE', 'PEACE', '요즘 자주 찾는 색깔은 무엇인가요?', '요즘은 물 빠진 듯한 연한 버터색에 자꾸 손이 가요.'),
+        ('qa_03', DATE '2026-06-02', 'PREFERENCE', 'PEACE', '가장 자주 듣는 노래는 무엇인가요?', '인디 밴드 ''설(SURL)''이나 ''검정치마''의 노래를 반복해서 들어요.'),
+        ('qa_03', DATE '2026-06-03', 'PREFERENCE', 'PEACE', '카페에서 항상 고르는 메뉴는 무엇인가요?', '따뜻한 바닐라 라떼요. 기분이 좋을 때나 가라앉을 때나...'),
+        ('qa_03', DATE '2026-06-04', 'PREFERENCE', 'PLEASURE', '가장 좋아하는 과일은 무엇인가요?', '말랑말랑한 복숭아요. 분홍빛 색깔도 예쁘고 향기도 너무 로맨틱하잖아요.'),
+        ('qa_03', DATE '2026-06-05', 'PREFERENCE', 'PEACE', '빵집에 가면 가장 먼저 집는 빵은 무엇인가요?', '고소한 소금빵요. 화려한 토핑은 없지만 씹을수록 느껴지는 버터 향과...'),
+        ('qa_03', DATE '2026-06-06', 'EMOTION', 'PEACE', '지금 당장 하고 싶은 말이 있다면 무엇인가요?', '오늘 하루도 무사히 잘 버텼다. 이제 아무 생각 안 하고 푹 쉬고 싶어.'),
+        ('qa_03', DATE '2026-06-07', 'EMOTION', 'WILL', '최근 나를 가장 답답하게 만든 일은 무엇인가요?', '마음은 앞서는데 몸이 잘 안 따라줄 때요. 자꾸 게을러지는 것 같은...'),
+        ('qa_03', DATE '2026-06-08', 'EMOTION', 'REGRET', '질투라는 감정을 느낀 적이 있나요?', 'SNS에서 저랑 비슷한 고민을 하던 친구가 저보다 먼저 행복을 찾은 것 같을 때...'),
+        ('qa_03', DATE '2026-06-09', 'ROUTINE', 'PEACE', '주말 아침에 가장 하고 싶은 활동은 무엇인가요?', '알람 없이 눈을 떠서 침대 속에서 30분 정도 뒹굴거리는 거요.'),
+
+        ('qa_04', DATE '2026-06-01', 'PREFERENCE', 'PEACE', '요즘 자주 찾는 색깔은 무엇인가요?', '요즘은 물 빠진 듯한 연한 버터색에 자꾸 손이 가요.'),
+        ('qa_04', DATE '2026-06-02', 'PREFERENCE', 'PEACE', '가장 자주 듣는 노래는 무엇인가요?', '인디 밴드 ''설(SURL)''이나 ''검정치마''의 노래를 반복해서 들어요.'),
+        ('qa_04', DATE '2026-06-03', 'PREFERENCE', 'PEACE', '카페에서 항상 고르는 메뉴는 무엇인가요?', '따뜻한 바닐라 라떼요.'),
+        ('qa_04', DATE '2026-06-04', 'PREFERENCE', 'PLEASURE', '가장 좋아하는 과일은 무엇인가요?', '말랑말랑한 복숭아요.'),
+        ('qa_04', DATE '2026-06-05', 'PREFERENCE', 'PEACE', '빵집에 가면 가장 먼저 집는 빵은 무엇인가요?', '고소한 소금빵요.'),
+        ('qa_04', DATE '2026-06-06', 'EMOTION', 'PEACE', '지금 당장 하고 싶은 말이 있다면 무엇인가요?', '오늘 하루도 무사히 잘 버텼다.'),
+        ('qa_04', DATE '2026-06-07', 'EMOTION', 'WILL', '최근 나를 가장 답답하게 만든 일은 무엇인가요?', '마음은 앞서는데 몸이 잘 안 따라줄 때요.'),
+        ('qa_04', DATE '2026-06-08', 'EMOTION', 'REGRET', '질투라는 감정을 느낀 적이 있나요?', 'SNS에서 저랑 비슷한 고민을 하던 친구가...'),
+        ('qa_04', DATE '2026-06-09', 'EMOTION', 'ETC', '최근에 느낀 감정 중 이름 붙이기 힘든 게 있었나요?', '어제 저녁에 노을 보는데 괜히 마음이 벅차면서도...'),
+        ('qa_04', DATE '2026-06-10', 'EMOTION', 'PEACE', '감정을 솔직하게 표현해서 후련했던 적이 있나요?', '친구한테 서운했던 거 용기 내서 말했을 때요.'),
+
+        ('qa_05', DATE '2026-06-01', 'PREFERENCE', 'PEACE', '요즘 자주 찾는 색깔은 무엇인가요?', '요즘은 물 빠진 듯한 연한 버터색에 자꾸 손이 가요.'),
+        ('qa_05', DATE '2026-06-02', 'PREFERENCE', 'PEACE', '가장 자주 듣는 노래는 무엇인가요?', '인디 밴드 ''설(SURL)''이나 ''검정치마''의 노래를 반복해서 들어요.'),
+        ('qa_05', DATE '2026-06-03', 'PREFERENCE', 'PEACE', '카페에서 항상 고르는 메뉴는 무엇인가요?', '따뜻한 바닐라 라떼요.'),
+        ('qa_05', DATE '2026-06-04', 'PREFERENCE', 'PLEASURE', '가장 좋아하는 과일은 무엇인가요?', '말랑말랑한 복숭아요.'),
+        ('qa_05', DATE '2026-06-05', 'PREFERENCE', 'PEACE', '빵집에 가면 가장 먼저 집는 빵은 무엇인가요?', '고소한 소금빵요.'),
+        ('qa_05', DATE '2026-06-06', 'EMOTION', 'PEACE', '지금 당장 하고 싶은 말이 있다면 무엇인가요?', '오늘 하루도 무사히 잘 버텼다.'),
+        ('qa_05', DATE '2026-06-07', 'EMOTION', 'WILL', '최근 나를 가장 답답하게 만든 일은 무엇인가요?', '마음은 앞서는데 몸이 잘 안 따라줄 때요.'),
+        ('qa_05', DATE '2026-06-08', 'ROUTINE', 'PEACE', '주말 아침에 가장 하고 싶은 활동은 무엇인가요?', '알람 없이 눈을 떠서 침대 속에서 30분 정도 뒹굴거리는 거요.'),
+        ('qa_05', DATE '2026-06-09', 'ROUTINE', 'PEACE', '내 감정을 다스리는 나만의 루틴이 있나요?', '방에 불 끄고 좋아하는 인디 음악 틀어놓고 일기 써요.'),
+
+        ('qa_06', DATE '2026-06-01', 'RELATIONSHIP', 'PEACE', '매력을 느끼는 목소리나 말투가 있나요?', '낮고 차분하면서도 끝음이 다정한 목소리요.'),
+        ('qa_06', DATE '2026-06-02', 'RELATIONSHIP', 'WILL', '누군가에게 선물할 때 가장 고려하는 것은 무엇인가요?', '그 사람의 취향이나 요즘 하는 고민요.'),
+        ('qa_06', DATE '2026-06-03', 'RELATIONSHIP', 'PEACE', '내가 좋아하는 사람들의 공통점은 무엇인가요?', '다정하고 조용한 사람들이요.'),
+        ('qa_06', DATE '2026-06-04', 'RELATIONSHIP', 'PLEASURE', '누군가에게 깊은 감동을 받았던 순간은 언제인가요?', '비 오는 날 퇴근하는데 직장 동료가 말없이...'),
+        ('qa_06', DATE '2026-06-05', 'ROUTINE', 'PEACE', '주말 아침에 가장 하고 싶은 활동은 무엇인가요?', '알람 없이 눈을 떠서 침대 속에서...'),
+        ('qa_06', DATE '2026-06-06', 'ROUTINE', 'PEACE', '내 감정을 다스리는 나만의 루틴이 있나요?', '방에 불 끄고 좋아하는 인디 음악...'),
+        ('qa_06', DATE '2026-06-07', 'ROUTINE', 'PEACE', '오늘 하루 중 가장 차분했던 때는 언제인가요?', '퇴근하고 집에 돌아와서 조명 다 끄고...'),
+        ('qa_06', DATE '2026-06-08', 'ROUTINE', 'ACHIEVEMENT', '최근에 가장 뿌듯했던 순간은 언제인가요?', '한 달 동안 매일 빠짐없이 일기 쓰기 성공했을 때요.'),
+        ('qa_06', DATE '2026-06-09', 'LOVE', 'WILL', '사랑이라는 감정을 어떻게 정의하고 싶나요?', '서로의 빈틈을 기꺼이 채워주고 싶어지는 마음요.'),
+        ('qa_06', DATE '2026-06-10', 'LOVE', 'PLEASURE', '내가 가장 아름답다고 느끼는 사람의 모습은 무엇인가요?', '길 잃은 사람한테 먼저 다가가서...'),
+        ('qa_06', DATE '2026-06-11', 'LOVE', 'PEACE', '최근에 누군가를 용서한 적이 있나요?', '약속을 자꾸 어기는 친구를 이해해 보려고...'),
+        ('qa_06', DATE '2026-06-12', 'LOVE', 'ETC', '지금 가장 보고 싶은 사람은 누구인가요?', '멀리 살아서 자주 못 보는 대학교 때 제일 친했던 친구요.'),
+
+        ('qa_07', DATE '2026-06-01', 'PREFERENCE', 'PEACE', '요즘 자주 찾는 색깔은 무엇인가요?', '요즘은 물 빠진 듯한 연한 버터색에 자꾸 손이 가요.'),
+        ('qa_07', DATE '2026-06-02', 'PREFERENCE', 'PLEASURE', '가장 좋아하는 과일은 무엇인가요?', '말랑말랑한 복숭아요.'),
+        ('qa_07', DATE '2026-06-03', 'PREFERENCE', 'INTEREST', '가방 속에 늘 챙기는 물건은 무엇인가요?', '작고 가벼운 메모장과 펜이요.'),
+        ('qa_07', DATE '2026-06-04', 'PREFERENCE', 'INTEREST', '여행지에서 꼭 들르는 곳은 어디인가요?', '현지의 작은 소품샵이나 빈티지 마켓요.'),
+        ('qa_07', DATE '2026-06-05', 'PREFERENCE', 'ACHIEVEMENT', '오늘 나를 기운 나게 한 말은 무엇인가요?', '팀장님이 지나가면서 이번 마케팅 문구...'),
+        ('qa_07', DATE '2026-06-06', 'EMOTION', 'PEACE', '지금 당장 하고 싶은 말이 있다면 무엇인가요?', '오늘 하루도 무사히 잘 버텼다.'),
+        ('qa_07', DATE '2026-06-07', 'EMOTION', 'PLEASURE', '오늘 나를 웃게 만든 장면은 무엇인가요?', '출근길에 길가 담장 밑에서 낮잠 자는 고양이를...'),
+        ('qa_07', DATE '2026-06-08', 'EMOTION', 'ACHIEVEMENT', '두려움을 극복하고 무언가 해낸 적이 있나요?', '혼자서 처음으로 해외여행 갔던 거요!'),
+        ('qa_07', DATE '2026-06-09', 'EMOTION', 'ACHIEVEMENT', '고통스러운 순간이 나에게 준 가르침이 있다면 무엇인가요?', '비 온 뒤에 땅이 굳는 것처럼...'),
+        ('qa_07', DATE '2026-06-10', 'EMOTION', 'INTEREST', '누군가 나에 대해 쓴다면 어떤 제목의 책일까요?', '여전히 꿈을 꾸는 아이라는 제목일 것 같아요.'),
+        ('qa_07', DATE '2026-06-11', 'ROUTINE', 'PEACE', '주말 아침에 가장 하고 싶은 활동은 무엇인가요?', '알람 없이 눈을 떠서...'),
+        ('qa_07', DATE '2026-06-12', 'ROUTINE', 'PLEASURE', '최근에 가장 크게 웃었던 일은 무엇인가요?', '친구랑 카페에서 수다 떨다가 서로 말도 안 되는...');
+
+    INSERT INTO daily_questions (
+        interest_id,
+        question_text,
+        question_level,
+        empathy_guide,
+        hint_guide,
+        leading_question_guide,
+        created_at,
+        updated_at
+    )
+    SELECT i.id, q.question_text, 1, NULL, NULL, NULL, NOW(), NOW()
+    FROM (
+        SELECT DISTINCT interest_code, question_text FROM qa_seed_answers
+        UNION ALL
+        SELECT 'PREFERENCE', 'QA 소셜 집계용 보조 질문'
+    ) q
+    JOIN interests i ON i.code = q.interest_code
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM daily_questions dq
+        WHERE dq.interest_id = i.id
+          AND dq.question_text = q.question_text
+          AND dq.deleted_at IS NULL
+    );
+
+    INSERT INTO answer_entries (
+        user_id,
+        question_id,
+        content,
+        date,
+        image_key,
+        created_at,
+        updated_at
+    )
+    SELECT
+        qsu.user_id,
+        dq.id,
+        a.answer_content,
+        a.answer_date,
+        NULL,
+        a.answer_date::timestamp AT TIME ZONE 'Asia/Seoul',
+        a.answer_date::timestamp AT TIME ZONE 'Asia/Seoul'
+    FROM qa_seed_answers a
+    JOIN qa_seed_users qsu ON qsu.qa_key = a.qa_key
+    JOIN interests i ON i.code = a.interest_code
+    JOIN LATERAL (
+        SELECT id
+        FROM daily_questions
+        WHERE interest_id = i.id
+          AND question_text = a.question_text
+          AND deleted_at IS NULL
+        ORDER BY id DESC
+        LIMIT 1
+    ) dq ON TRUE;
+
+    INSERT INTO daily_reports (
+        answer_entry_id,
+        emotion_id,
+        content,
+        status,
+        analyzed_at,
+        date,
+        is_shared,
+        created_at
+    )
+    SELECT
+        ae.id,
+        e.id,
+        'QA 월간 리포트 테스트용 일일 리포트입니다.',
+        'COMPLETED',
+        ae.date::timestamp AT TIME ZONE 'Asia/Seoul',
+        ae.date,
+        TRUE,
+        ae.date::timestamp AT TIME ZONE 'Asia/Seoul'
+    FROM answer_entries ae
+    JOIN qa_seed_users qsu ON qsu.user_id = ae.user_id
+    JOIN qa_seed_answers a ON a.qa_key = qsu.qa_key AND a.answer_date = ae.date
+    JOIN emotions e ON e.code = a.emotion_code;
+
+    INSERT INTO monthly_reports_v2 (
+        user_id,
+        month_start_date,
+        month_end_date,
+        date,
+        image_key,
+        image_status,
+        content,
+        emotion_summary_content,
+        emotion_stats,
+        interest_stats,
+        emotion_comparison,
+        social_summary,
+        summary,
+        comment_summary,
+        dominant_keyword,
+        comparison_type,
+        status,
+        analyzed_at,
+        created_at
+    )
+    SELECT
+        qsu.user_id,
+        p.month_start_date,
+        p.month_end_date,
+        p.month_end_date,
+        'qa/monthly/previous-placeholder.webp',
+        'COMPLETED',
+        '{
+          "summary": "직전 월간 리포트",
+          "commentSummary": "이전 달의 감정 흐름을 비교하기 위한 QA 데이터입니다.",
+          "dominantKeyword": "평온",
+          "emotionTrend": "지난달은 전반적으로 평온함 속에서 일상을 차분히 채워나간 시간이었습니다.",
+          "discovered": {"segments": [{"text": "지난달은 전반적으로 평온함 속에서 일상을 차분히 채워나간 시간이었습니다.", "marks": []}]},
+          "comment": {"segments": [{"text": "작은 도전과 회복의 흐름을 이어간 점이 인상적입니다.", "marks": []}]}
+        }'::jsonb,
+        '{
+          "styledText": {"segments": [{"text": "지난달은 평온함을 중심으로 긍정 감정 30%가 기록되었습니다.", "marks": []}]}
+        }'::jsonb,
+        '{
+          "totalCount": 20,
+          "dominantEmotionCode": "PEACE",
+          "positivePercent": 30,
+          "emotions": [
+            {"emotionCode": "PEACE", "emotionName": "평온", "count": 7, "percent": 35},
+            {"emotionCode": "PLEASURE", "emotionName": "즐거움", "count": 4, "percent": 20},
+            {"emotionCode": "ACHIEVEMENT", "emotionName": "성취", "count": 3, "percent": 15},
+            {"emotionCode": "INTEREST", "emotionName": "흥미", "count": 2, "percent": 10},
+            {"emotionCode": "WILL", "emotionName": "의지", "count": 2, "percent": 8},
+            {"emotionCode": "DEPRESSION", "emotionName": "우울", "count": 1, "percent": 5},
+            {"emotionCode": "REGRET", "emotionName": "후회", "count": 1, "percent": 4},
+            {"emotionCode": "ETC", "emotionName": "기타", "count": 0, "percent": 3}
+          ]
+        }'::jsonb,
+        '{"interests": []}'::jsonb,
+        NULL,
+        '{"visible": false, "month": 1, "likeRanking": [], "commentRanking": []}'::jsonb,
+        '직전 월간 리포트',
+        '이전 달의 감정 흐름을 비교하기 위한 QA 데이터입니다.',
+        '평온',
+        'BASELINE',
+        'COMPLETED',
+        p.month_end_date::timestamp AT TIME ZONE 'Asia/Seoul',
+        p.month_end_date::timestamp AT TIME ZONE 'Asia/Seoul'
+    FROM (
+        VALUES
+            ('qa_03', DATE '2026-05-01', DATE '2026-05-31'),
+            ('qa_04', DATE '2026-05-01', DATE '2026-05-31'),
+            ('qa_05', DATE '2026-05-01', DATE '2026-05-31'),
+            ('qa_06', DATE '2026-04-01', DATE '2026-04-30'),
+            ('qa_07', DATE '2026-05-01', DATE '2026-05-31')
+    ) p(qa_key, month_start_date, month_end_date)
+    JOIN qa_seed_users qsu ON qsu.qa_key = p.qa_key;
+
+    CREATE TEMP TABLE qa_seed_helper_defs ON COMMIT DROP AS
+    SELECT *
+    FROM (VALUES
+        ('active_minjun', '민준', 'ACTIVE'),
+        ('active_garam', '가람', 'ACTIVE'),
+        ('active_nayeon', '나연', 'ACTIVE'),
+        ('active_dabin', '다빈', 'ACTIVE'),
+        ('active_seoyeon', '서연', 'ACTIVE'),
+        ('active_jiwoo', '지우', 'ACTIVE'),
+        ('active_hyunwoo', '현우', 'ACTIVE'),
+        ('blocked_kim', '김차단', 'BLOCKED'),
+        ('deleted_na', '나삭제', 'DELETED'),
+        ('inactive_lee', '이비활', 'INACTIVE'),
+        ('active_normal', '정상친구', 'ACTIVE')
+    ) AS t(helper_key, nickname, helper_status);
+
+    INSERT INTO users (
+        email,
+        password_hash,
+        nickname,
+        profile_image_key,
+        default_profile_type,
+        signup_status,
+        registered_at,
+        created_at,
+        updated_at,
+        deleted_at
+    )
+    SELECT
+        'qa_monthly_1_4_0_' || helper_key || '@seed.local',
+        NULL,
+        nickname,
+        NULL,
+        'DEFAULT',
+        CASE WHEN helper_status = 'DELETED' THEN 'WITHDRAWN' ELSE 'COMPLETED' END,
+        NOW(),
+        NOW(),
+        NOW(),
+        CASE WHEN helper_status = 'DELETED' THEN NOW() ELSE NULL END
+    FROM qa_seed_helper_defs;
+
+    CREATE TEMP TABLE qa_seed_helpers ON COMMIT DROP AS
+    SELECT d.helper_key, d.nickname, d.helper_status, u.id AS user_id
+    FROM qa_seed_helper_defs d
+    JOIN users u ON u.email = 'qa_monthly_1_4_0_' || d.helper_key || '@seed.local';
+
+    CREATE TEMP TABLE qa_seed_social_rows ON COMMIT DROP AS
+    SELECT *
+    FROM (VALUES
+        ('qa_02', 'active_minjun', 15, 15),
+        ('qa_03', 'active_garam', 15, 15),
+        ('qa_03', 'active_nayeon', 10, 10),
+        ('qa_03', 'active_dabin', 5, 5),
+        ('qa_04', 'active_seoyeon', 10, 10),
+        ('qa_04', 'active_jiwoo', 10, 10),
+        ('qa_05', 'active_minjun', 15, 15),
+        ('qa_05', 'active_seoyeon', 5, 5),
+        ('qa_05', 'active_hyunwoo', 5, 5),
+        ('qa_05', 'active_jiwoo', 5, 5),
+        ('qa_06', 'active_garam', 5, 5),
+        ('qa_06', 'active_nayeon', 5, 5),
+        ('qa_06', 'active_dabin', 5, 5),
+        ('qa_06', 'blocked_kim', 20, 50),
+        ('qa_06', 'deleted_na', 20, 100),
+        ('qa_06', 'inactive_lee', 50, 50),
+        ('qa_07', 'active_normal', 10, 10)
+    ) AS t(qa_key, helper_key, like_count, comment_count);
+
+    INSERT INTO friendships (
+        user_id_1,
+        user_id_2,
+        status,
+        requester_id,
+        created_at,
+        updated_at
+    )
+    SELECT DISTINCT
+        LEAST(qsu.user_id, h.user_id),
+        GREATEST(qsu.user_id, h.user_id),
+        'ACCEPTED',
+        h.user_id,
+        NOW(),
+        NOW()
+    FROM qa_seed_social_rows s
+    JOIN qa_seed_users qsu ON qsu.qa_key = s.qa_key
+    JOIN qa_seed_helpers h ON h.helper_key = s.helper_key
+    WHERE h.helper_status <> 'INACTIVE';
+
+    INSERT INTO user_blocks (
+        blocker_id,
+        blocked_id,
+        created_at,
+        updated_at
+    )
+    SELECT qsu.user_id, h.user_id, NOW(), NOW()
+    FROM qa_seed_social_rows s
+    JOIN qa_seed_users qsu ON qsu.qa_key = s.qa_key
+    JOIN qa_seed_helpers h ON h.helper_key = s.helper_key
+    WHERE h.helper_status = 'BLOCKED';
+
+    CREATE TEMP TABLE qa_seed_social_need ON COMMIT DROP AS
+    SELECT *
+    FROM (VALUES
+        ('qa_02', 15),
+        ('qa_03', 15),
+        ('qa_04', 10),
+        ('qa_05', 15),
+        ('qa_06', 50),
+        ('qa_07', 10)
+    ) AS t(qa_key, report_count);
+
+    INSERT INTO answer_entries (
+        user_id,
+        question_id,
+        content,
+        date,
+        image_key,
+        created_at,
+        updated_at
+    )
+    SELECT
+        qsu.user_id,
+        dq.id,
+        '소셜 집계용 보조 답변입니다.',
+        DATE '2026-01-01' + (gs.n - 1),
+        NULL,
+        (DATE '2026-01-01' + (gs.n - 1))::timestamp AT TIME ZONE 'Asia/Seoul',
+        (DATE '2026-01-01' + (gs.n - 1))::timestamp AT TIME ZONE 'Asia/Seoul'
+    FROM qa_seed_social_need n
+    JOIN qa_seed_users qsu ON qsu.qa_key = n.qa_key
+    CROSS JOIN LATERAL generate_series(1, n.report_count) AS gs(n)
+    JOIN interests i ON i.code = 'PREFERENCE'
+    JOIN LATERAL (
+        SELECT id
+        FROM daily_questions
+        WHERE interest_id = i.id
+          AND question_text = 'QA 소셜 집계용 보조 질문'
+          AND deleted_at IS NULL
+        ORDER BY id DESC
+        LIMIT 1
+    ) dq ON TRUE;
+
+    INSERT INTO daily_reports (
+        answer_entry_id,
+        emotion_id,
+        content,
+        status,
+        analyzed_at,
+        date,
+        is_shared,
+        created_at
+    )
+    SELECT
+        ae.id,
+        e.id,
+        'QA 소셜 집계용 보조 일일 리포트입니다.',
+        'COMPLETED',
+        ae.date::timestamp AT TIME ZONE 'Asia/Seoul',
+        ae.date,
+        TRUE,
+        ae.date::timestamp AT TIME ZONE 'Asia/Seoul'
+    FROM answer_entries ae
+    JOIN qa_seed_users qsu ON qsu.user_id = ae.user_id
+    JOIN qa_seed_social_need n ON n.qa_key = qsu.qa_key
+    JOIN emotions e ON e.code = 'PEACE'
+    WHERE ae.date BETWEEN DATE '2026-01-01' AND DATE '2026-02-19';
+
+    INSERT INTO daily_report_likes (
+        user_id,
+        daily_report_id,
+        created_at
+    )
+    SELECT
+        h.user_id,
+        ranked.daily_report_id,
+        TIMESTAMPTZ '2026-06-15 12:00:00+09'
+    FROM qa_seed_social_rows s
+    JOIN qa_seed_users qsu ON qsu.qa_key = s.qa_key
+    JOIN qa_seed_helpers h ON h.helper_key = s.helper_key
+    JOIN LATERAL (
+        SELECT dr.id AS daily_report_id,
+               ROW_NUMBER() OVER (ORDER BY dr.date ASC, dr.id ASC) AS rn
+        FROM daily_reports dr
+        JOIN answer_entries ae ON ae.id = dr.answer_entry_id
+        WHERE ae.user_id = qsu.user_id
+        ORDER BY dr.date ASC, dr.id ASC
+    ) ranked ON ranked.rn <= s.like_count;
+
+    INSERT INTO comments (
+        daily_report_id,
+        author_id,
+        parent_comment_id,
+        content,
+        is_secret,
+        created_at,
+        updated_at,
+        deleted_at
+    )
+    SELECT
+        target.daily_report_id,
+        h.user_id,
+        NULL,
+        'QA 소셜 집계용 댓글 ' || gs.n,
+        FALSE,
+        TIMESTAMPTZ '2026-06-15 12:00:00+09',
+        TIMESTAMPTZ '2026-06-15 12:00:00+09',
+        NULL
+    FROM qa_seed_social_rows s
+    JOIN qa_seed_users qsu ON qsu.qa_key = s.qa_key
+    JOIN qa_seed_helpers h ON h.helper_key = s.helper_key
+    CROSS JOIN LATERAL generate_series(1, s.comment_count) AS gs(n)
+    JOIN LATERAL (
+        SELECT dr.id AS daily_report_id
+        FROM daily_reports dr
+        JOIN answer_entries ae ON ae.id = dr.answer_entry_id
+        WHERE ae.user_id = qsu.user_id
+        ORDER BY dr.date ASC, dr.id ASC
+        LIMIT 1
+    ) target ON TRUE;
+END $$;
+
+COMMIT;

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatHistoryController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Ask Chat API", description = "물어보기 채팅 히스토리 API")
+@Tag(name = "물어보기 API")
 @RestController
 @RequestMapping("${api_prefix}/ask-chat")
 @RequiredArgsConstructor
@@ -35,10 +35,10 @@ public class AskChatHistoryController {
     @Operation(
             summary = "물어보기 히스토리 목록 조회",
             description = """
-                    ask_history_01 화면에서 사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.
-                    USER 메시지가 1개 이상 저장된 세션만 히스토리로 노출하며, 세션만 생성되고 질문이 없는 대화는 목록에 포함하지 않습니다.
-                    page는 1부터 시작하며, size는 최대 50까지 요청할 수 있습니다.
-                    응답의 empty는 현재 페이지의 목록이 비어 있는지 나타내며, 각 항목의 createdDate는 히스토리 카드 날짜 표시용입니다.
+                    ask_history_01 화면에서 사용자의 물어보기 채팅 세션 목록을 최신순으로 조회합니다.  </br>
+                    USER 메시지가 1개 이상 저장된 세션만 히스토리로 노출하며, 세션만 생성되고 질문이 없는 대화는 목록에 포함하지 않습니다.  </br>
+                    page는 1부터 시작하며, size는 최대 50까지 요청할 수 있습니다.  </br>
+                    응답의 empty는 현재 페이지의 목록이 비어 있는지 나타내며, 각 항목의 createdDate는 히스토리 카드 날짜 표시용입니다.  </br>
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
@@ -73,9 +73,9 @@ public class AskChatHistoryController {
     @Operation(
             summary = "물어보기 히스토리 상세 조회",
             description = """
-                    ask_history_02 화면에서 선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다.
-                    본인의 세션만 조회할 수 있으며, 다른 사용자의 세션이거나 존재하지 않는 세션이면 ASK_CHAT_SESSION_NOT_FOUND를 반환합니다.
-                    과거 대화 상세 화면은 읽기 전용이므로 readOnly=true를 반환하며, 새 질문 입력 UI는 제공하지 않습니다.
+                    ask_history_02 화면에서 선택한 물어보기 채팅 세션의 전체 메시지를 시간순으로 조회합니다.  </br>
+                    본인의 세션만 조회할 수 있으며, 다른 사용자의 세션이거나 존재하지 않는 세션이면 ASK_CHAT_SESSION_NOT_FOUND를 반환합니다.  </br>
+                    과거 대화 상세 화면은 읽기 전용이므로 readOnly=true를 반환하며, 새 질문 입력 UI는 제공하지 않습니다.  </br>
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Ask Chat API", description = "물어보기 채팅 세션 API")
+@Tag(name = "물어보기 API", description = "물어보기 채팅 세션 API")
 @RestController
 @RequestMapping("${api_prefix}/ask-chat")
 @RequiredArgsConstructor
@@ -40,9 +40,9 @@ public class AskChatSessionController {
     @Operation(
             summary = "물어보기 홈 진입",
             description = """
-                    ask_home_01 화면 진입 시 호출합니다.
-                    홈 진입만으로 새 채팅 세션을 생성하지 않고, 이어갈 수 있는 ACTIVE 세션이 있는지만 조회합니다.
-                    ACTIVE 세션이 있으면 activeSession에 세션 정보를 담아 반환하고, 없으면 activeSession만 null로 반환합니다.
+                    ask_home_01 화면 진입 시 호출합니다. </br>
+                    홈 진입만으로 새 채팅 세션을 생성하지 않고, 이어갈 수 있는 ACTIVE 세션이 있는지만 조회합니다. </br>
+                    ACTIVE 세션이 있으면 activeSession에 세션 정보를 담아 반환하고, 없으면 activeSession만 null로 반환합니다. </br>
                     maxTurnCount와 remainingTurnCount는 홈 화면의 잔여 대화 횟수 표시용 값입니다.
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
@@ -68,9 +68,9 @@ public class AskChatSessionController {
     @Operation(
             summary = "물어보기 세션 시작",
             description = """
-                    명시적으로 물어보기 채팅 세션을 준비할 때 호출합니다.
-                    이미 ACTIVE 세션이 있으면 같은 세션을 반환하고, ACTIVE 세션이 없으면 새 세션을 생성합니다.
-                    이 API는 질문 메시지를 저장하지 않으며, 실제 질문 저장은 POST /ask-chat/messages에서 수행합니다.
+                    명시적으로 물어보기 채팅 세션을 준비할 때 호출합니다. </br>
+                    이미 ACTIVE 세션이 있으면 같은 세션을 반환하고, ACTIVE 세션이 없으면 새 세션을 생성합니다. </br>
+                    이 API는 질문 메시지를 저장하지 않으며, 실제 질문 저장은 POST /ask-chat/messages에서 수행합니다. </br>
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
@@ -90,16 +90,45 @@ public class AskChatSessionController {
         return ApiResponseEntity.ok(response);
     }
 
+    @PostMapping("/sessions/new")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 새 대화 시작",
+            description = """
+                    ask_chat_01 화면의 '새로운 대화로 시작하기' 액션에서 호출합니다. </br>
+                    현재 이어가고 있는 ACTIVE 세션이 있으면 ENDED로 종료하고, 새 ACTIVE 세션을 생성해 반환합니다. </br>
+                    기존 대화의 USER/ASSISTANT 메시지는 삭제하지 않고 히스토리에서 조회할 수 있도록 보존합니다. </br>
+                    ACTIVE 세션이 없으면 종료 처리 없이 새 세션만 생성합니다. </br>
+                    이 API는 질문 메시지를 저장하거나 AI 답변을 생성하지 않습니다. </br>
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "새 물어보기 세션 생성 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatSessionResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatSessionResponse>> startNewSession(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AskChatSessionResponse response = askChatSessionService.restartSession(principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+
     @PostMapping("/messages")
     @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "물어보기 질문 전송",
             description = """
-                    ask_home_01 또는 ask_chat_01 화면에서 사용자가 질문을 보낼 때 호출합니다.
-                    ACTIVE 세션이 있으면 해당 세션에 USER 메시지를 저장하고, ACTIVE 세션이 없으면 새 세션을 생성한 뒤 USER 메시지를 저장합니다.
-                    이 PR 단계에서는 AI 답변을 생성하지 않으므로 ASSISTANT 메시지, followUpQuestions, RAG 근거 문서는 반환하지 않습니다.
-                    질문 내용은 앞뒤 공백 제거 후 1자 이상 200자 이하만 허용합니다.
-                    answeredTurnCount가 15 이상인 세션에서는 메시지를 저장하지 않고 ASK_CHAT_TURN_LIMIT_EXCEEDED를 반환합니다.
+                    ask_home_01 또는 ask_chat_01 화면에서 사용자가 질문을 보낼 때 호출합니다. </br>
+                    ACTIVE 세션이 있으면 해당 세션에 USER 메시지를 저장하고, ACTIVE 세션이 없으면 새 세션을 생성한 뒤 USER 메시지를 저장합니다. </br>
+                    이 PR 단계에서는 AI 답변을 생성하지 않으므로 ASSISTANT 메시지, followUpQuestions, RAG 근거 문서는 반환하지 않습니다. </br>
+                    질문 내용은 앞뒤 공백 제거 후 1자 이상 200자 이하만 허용합니다. </br>
+                    answeredTurnCount가 15 이상인 세션에서는 메시지를 저장하지 않고 ASK_CHAT_TURN_LIMIT_EXCEEDED를 반환합니다. </br>
                     """,
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
@@ -2,12 +2,24 @@ package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "물어보기 질문 전송 응답")
 public record AskChatQuestionSendResponse(
         @Schema(description = "질문이 저장된 채팅 세션")
         AskChatSessionResponse session,
 
         @Schema(description = "저장된 사용자 질문 메시지")
-        AskChatMessageResponse userMessage
+        AskChatMessageResponse userMessage,
+
+        @Schema(description = "저장된 AI 답변 메시지. 생성 실패 시 status=FAILED로 반환")
+        AskChatMessageResponse assistantMessage,
+
+        @Schema(description = "AI가 제안한 후속 추천 질문. 생성 실패 시 빈 배열")
+        List<String> followUpQuestions
 ) {
+
+    public AskChatQuestionSendResponse {
+        followUpQuestions = followUpQuestions == null ? List.of() : List.copyOf(followUpQuestions);
+    }
 }

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextService.java
@@ -1,0 +1,75 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerConversationMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatRagSearchResultDto;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagVectorRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatEmbeddingClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AskChatAnswerContextService {
+
+    private final AskChatMessageRepository askChatMessageRepository;
+    private final AskChatEmbeddingClient askChatEmbeddingClient;
+    private final AskChatRagVectorRepository askChatRagVectorRepository;
+    private final AskChatAnswerProperties properties;
+
+    @Transactional(readOnly = true)
+    public AskChatAnswerPromptContext build(Long userId, Long sessionId, String question) {
+        List<AskChatAnswerConversationMessage> recentMessages = findRecentMessages(sessionId);
+        List<AskChatAnswerReferenceDocument> referenceDocuments = searchReferenceDocuments(userId, question);
+
+        return new AskChatAnswerPromptContext(
+                userId,
+                sessionId,
+                question,
+                recentMessages,
+                referenceDocuments
+        );
+    }
+
+    private List<AskChatAnswerConversationMessage> findRecentMessages(Long sessionId) {
+        List<AskChatMessage> messages = new ArrayList<>(askChatMessageRepository
+                .findAllBySessionIdAndStatusOrderByCreatedAtDesc(
+                        sessionId,
+                        AskChatMessageStatus.COMPLETED,
+                        PageRequest.of(0, properties.getRecentMessageLimit())
+                ));
+        Collections.reverse(messages);
+
+        return messages.stream()
+                .map(message -> new AskChatAnswerConversationMessage(
+                        message.getRole(),
+                        message.getContent()
+                ))
+                .toList();
+    }
+
+    private List<AskChatAnswerReferenceDocument> searchReferenceDocuments(Long userId, String question) {
+        List<Double> queryEmbedding = askChatEmbeddingClient.embed(question);
+        List<AskChatRagSearchResultDto> results = askChatRagVectorRepository.search(
+                userId,
+                null,
+                queryEmbedding,
+                askChatEmbeddingClient.retrievalLimit()
+        );
+
+        return results.stream()
+                .map(AskChatAnswerReferenceDocument::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +54,7 @@ public class AskChatMessageCommandService {
         AskChatSession session = getOrCreateActiveSession(userId);
         validateTurnLimit(session);
 
+        long generationStartedAt = System.nanoTime();
         AskChatAnswerPromptContext context = askChatAnswerContextService.build(
                 userId,
                 session.getId(),
@@ -67,12 +69,14 @@ public class AskChatMessageCommandService {
         List<String> followUpQuestions;
         try {
             AskChatAnswerGenerationResult generationResult = askChatAnswerLlmClient.generate(context);
-            assistantMessage = saveCompletedAssistantMessage(session, generationResult);
+            long generationDurationMs = elapsedMillis(generationStartedAt);
+            assistantMessage = saveCompletedAssistantMessage(session, generationResult, generationDurationMs);
             saveMessageReferences(assistantMessage, generationResult);
             session.incrementAnsweredTurnCount();
             followUpQuestions = generationResult.answer().followUpQuestions();
         } catch (AiServiceException e) {
-            assistantMessage = saveFailedAssistantMessage(session, e);
+            long generationDurationMs = elapsedMillis(generationStartedAt);
+            assistantMessage = saveFailedAssistantMessage(session, e, generationDurationMs);
             followUpQuestions = List.of();
         }
 
@@ -86,7 +90,8 @@ public class AskChatMessageCommandService {
 
     private AskChatMessage saveCompletedAssistantMessage(
             AskChatSession session,
-            AskChatAnswerGenerationResult generationResult
+            AskChatAnswerGenerationResult generationResult,
+            long generationDurationMs
     ) {
         LlmTokenUsage tokenUsage = generationResult.tokenUsage();
         return askChatMessageRepository.save(AskChatMessage.createAssistantMessage(
@@ -97,18 +102,28 @@ public class AskChatMessageCommandService {
                 tokenUsage.inputTokens(),
                 tokenUsage.outputTokens(),
                 tokenUsage.totalTokens(),
-                tokenUsage.thinkingTokens()
+                tokenUsage.thinkingTokens(),
+                generationDurationMs
         ));
     }
 
-    private AskChatMessage saveFailedAssistantMessage(AskChatSession session, AiServiceException exception) {
+    private AskChatMessage saveFailedAssistantMessage(
+            AskChatSession session,
+            AiServiceException exception,
+            long generationDurationMs
+    ) {
         return askChatMessageRepository.save(AskChatMessage.createFailedAssistantMessage(
                 session,
                 ANSWER_GENERATION_FAILED_MESSAGE,
                 askChatAnswerProperties.getProvider(),
                 askChatAnswerProperties.getModel(),
-                exception.getErrorCode().getCode()
+                exception.getErrorCode().getCode(),
+                generationDurationMs
         ));
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
     }
 
     private void saveMessageReferences(

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -3,30 +3,43 @@ package com.devkor.ifive.nadab.domain.askchat.application;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatMessageResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationResult;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.exception.ai.AiServiceException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AskChatMessageCommandService {
 
     private static final int MAX_QUESTION_LENGTH = 200;
+    private static final String ANSWER_GENERATION_FAILED_MESSAGE =
+            "답변 생성에 오류가 발생했어요. 다시 시도해주세요.";
 
     private final AskChatSessionRepository askChatSessionRepository;
     private final AskChatMessageRepository askChatMessageRepository;
     private final UserRepository userRepository;
+    private final AskChatAnswerContextService askChatAnswerContextService;
+    private final AskChatAnswerLlmClient askChatAnswerLlmClient;
+    private final AskChatAnswerProperties askChatAnswerProperties;
 
     @Transactional
     public AskChatQuestionSendResponse sendQuestion(Long userId, String content) {
@@ -38,10 +51,57 @@ public class AskChatMessageCommandService {
                 AskChatMessage.createUserMessage(session, normalizedContent)
         );
 
+        AskChatAnswerPromptContext context = askChatAnswerContextService.build(
+                userId,
+                session.getId(),
+                normalizedContent
+        );
+
+        AskChatMessage assistantMessage;
+        List<String> followUpQuestions;
+        try {
+            AskChatAnswerGenerationResult generationResult = askChatAnswerLlmClient.generate(context);
+            assistantMessage = saveCompletedAssistantMessage(session, generationResult);
+            session.incrementAnsweredTurnCount();
+            followUpQuestions = generationResult.answer().followUpQuestions();
+        } catch (AiServiceException e) {
+            assistantMessage = saveFailedAssistantMessage(session, e);
+            followUpQuestions = List.of();
+        }
+
         return new AskChatQuestionSendResponse(
                 AskChatSessionResponse.from(session, AskChatSessionService.MAX_TURN_COUNT),
-                AskChatMessageResponse.from(userMessage)
+                AskChatMessageResponse.from(userMessage),
+                AskChatMessageResponse.from(assistantMessage),
+                followUpQuestions
         );
+    }
+
+    private AskChatMessage saveCompletedAssistantMessage(
+            AskChatSession session,
+            AskChatAnswerGenerationResult generationResult
+    ) {
+        LlmTokenUsage tokenUsage = generationResult.tokenUsage();
+        return askChatMessageRepository.save(AskChatMessage.createAssistantMessage(
+                session,
+                generationResult.answer().answer(),
+                generationResult.provider(),
+                generationResult.model(),
+                tokenUsage.inputTokens(),
+                tokenUsage.outputTokens(),
+                tokenUsage.totalTokens(),
+                tokenUsage.thinkingTokens()
+        ));
+    }
+
+    private AskChatMessage saveFailedAssistantMessage(AskChatSession session, AiServiceException exception) {
+        return askChatMessageRepository.save(AskChatMessage.createFailedAssistantMessage(
+                session,
+                ANSWER_GENERATION_FAILED_MESSAGE,
+                askChatAnswerProperties.getProvider(),
+                askChatAnswerProperties.getModel(),
+                exception.getErrorCode().getCode()
+        ));
     }
 
     private AskChatSession getOrCreateActiveSession(Long userId) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -53,14 +53,14 @@ public class AskChatMessageCommandService {
         AskChatSession session = getOrCreateActiveSession(userId);
         validateTurnLimit(session);
 
-        AskChatMessage userMessage = askChatMessageRepository.save(
-                AskChatMessage.createUserMessage(session, normalizedContent)
-        );
-
         AskChatAnswerPromptContext context = askChatAnswerContextService.build(
                 userId,
                 session.getId(),
                 normalizedContent
+        );
+
+        AskChatMessage userMessage = askChatMessageRepository.save(
+                AskChatMessage.createUserMessage(session, normalizedContent)
         );
 
         AskChatMessage assistantMessage;

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -6,10 +6,14 @@ import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResp
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationResult;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageReference;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
 import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageReferenceRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
 import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
@@ -36,6 +40,8 @@ public class AskChatMessageCommandService {
 
     private final AskChatSessionRepository askChatSessionRepository;
     private final AskChatMessageRepository askChatMessageRepository;
+    private final AskChatMessageReferenceRepository askChatMessageReferenceRepository;
+    private final AskChatRagDocumentRepository askChatRagDocumentRepository;
     private final UserRepository userRepository;
     private final AskChatAnswerContextService askChatAnswerContextService;
     private final AskChatAnswerLlmClient askChatAnswerLlmClient;
@@ -62,6 +68,7 @@ public class AskChatMessageCommandService {
         try {
             AskChatAnswerGenerationResult generationResult = askChatAnswerLlmClient.generate(context);
             assistantMessage = saveCompletedAssistantMessage(session, generationResult);
+            saveMessageReferences(assistantMessage, generationResult);
             session.incrementAnsweredTurnCount();
             followUpQuestions = generationResult.answer().followUpQuestions();
         } catch (AiServiceException e) {
@@ -102,6 +109,21 @@ public class AskChatMessageCommandService {
                 askChatAnswerProperties.getModel(),
                 exception.getErrorCode().getCode()
         ));
+    }
+
+    private void saveMessageReferences(
+            AskChatMessage assistantMessage,
+            AskChatAnswerGenerationResult generationResult
+    ) {
+        List<Long> referenceDocumentIds = generationResult.referenceDocumentIds();
+        for (int i = 0; i < referenceDocumentIds.size(); i++) {
+            AskChatRagDocument ragDocument = askChatRagDocumentRepository.getReferenceById(referenceDocumentIds.get(i));
+            askChatMessageReferenceRepository.save(AskChatMessageReference.of(
+                    assistantMessage,
+                    ragDocument,
+                    i + 1
+            ));
+        }
     }
 
     private AskChatSession getOrCreateActiveSession(Long userId) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
@@ -45,6 +45,17 @@ public class AskChatSessionService {
         return AskChatSessionResponse.from(session, MAX_TURN_COUNT);
     }
 
+    @Transactional
+    public AskChatSessionResponse restartSession(Long userId) {
+        askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                userId,
+                AskChatSessionStatus.ACTIVE
+        ).ifPresent(AskChatSession::end);
+
+        AskChatSession newSession = createSession(userId);
+        return AskChatSessionResponse.from(newSession, MAX_TURN_COUNT);
+    }
+
     private AskChatSession createSession(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptAugmenter.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptAugmenter.java
@@ -1,0 +1,9 @@
+package com.devkor.ifive.nadab.domain.askchat.application.helper;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+
+public interface AskChatAnswerPromptAugmenter {
+
+    AskChatAnswerPrompt augment(AskChatAnswerPromptContext context);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
@@ -1,0 +1,112 @@
+package com.devkor.ifive.nadab.domain.askchat.application.helper;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerConversationMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AskChatAnswerPromptComposer {
+
+    private static final String NO_REFERENCE_DOCUMENT = "검색된 사용자 기록이 없습니다.";
+    private static final String NO_RECENT_MESSAGE = "최근 대화가 없습니다.";
+
+    private final AskChatAnswerProperties properties;
+
+    public AskChatAnswerPrompt compose(AskChatAnswerPromptContext context) {
+        return new AskChatAnswerPrompt(
+                systemPrompt(),
+                userPrompt(context)
+        );
+    }
+
+    private String systemPrompt() {
+        return """
+                당신은 사용자의 누적 답변과 리포트 기록을 바탕으로 자기이해를 돕는 상담형 챗봇입니다.
+                반드시 제공된 사용자 기록과 최근 대화 맥락 안에서만 답변하세요.
+                사용자의 성격, 관계, 가치관, 루틴을 단정하지 말고 근거가 약하면 조심스럽게 표현하세요.
+                답변은 한국어 존댓말로 작성하고, 따뜻하지만 과장되지 않게 말하세요.
+                응답은 아래 JSON 형식만 반환하세요.
+                {
+                  "answer": "사용자에게 보여줄 답변",
+                  "followUpQuestions": ["후속 질문 1", "후속 질문 2"]
+                }
+                """;
+    }
+
+    private String userPrompt(AskChatAnswerPromptContext context) {
+        return """
+                [프롬프트 버전]
+                %d
+
+                [현재 질문]
+                %s
+
+                [최근 대화]
+                %s
+
+                [검색된 사용자 기록]
+                %s
+
+                [작성 조건]
+                - answer는 500자 이내로 작성하세요.
+                - followUpQuestions는 %d개 이하로 작성하세요.
+                - 검색된 사용자 기록이 부족하면 부족하다고 말하고, 현재 질문에 답할 수 있는 범위만 답하세요.
+                - 사용자 기록의 원문을 길게 그대로 복사하지 마세요.
+                """.formatted(
+                properties.getPromptVersion(),
+                context.question(),
+                formatRecentMessages(context.recentMessages()),
+                formatReferenceDocuments(context.referenceDocuments()),
+                properties.getFollowUpQuestionCount()
+        );
+    }
+
+    private String formatRecentMessages(List<AskChatAnswerConversationMessage> messages) {
+        if (messages.isEmpty()) {
+            return NO_RECENT_MESSAGE;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < messages.size(); i++) {
+            AskChatAnswerConversationMessage message = messages.get(i);
+            builder.append(i + 1)
+                    .append(". ")
+                    .append(message.role())
+                    .append(": ")
+                    .append(message.content())
+                    .append(System.lineSeparator());
+        }
+        return builder.toString().trim();
+    }
+
+    private String formatReferenceDocuments(List<AskChatAnswerReferenceDocument> documents) {
+        if (documents.isEmpty()) {
+            return NO_REFERENCE_DOCUMENT;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < documents.size(); i++) {
+            AskChatAnswerReferenceDocument document = documents.get(i);
+            builder.append(i + 1)
+                    .append(". documentId=")
+                    .append(document.documentId())
+                    .append(", sourceType=")
+                    .append(document.sourceType())
+                    .append(", interestCode=")
+                    .append(document.interestCode())
+                    .append(", distance=")
+                    .append(document.distance())
+                    .append(System.lineSeparator())
+                    .append(document.content())
+                    .append(System.lineSeparator());
+        }
+        return builder.toString().trim();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
@@ -22,9 +22,98 @@ public class AskChatAnswerPromptComposer implements AskChatAnswerPromptAugmenter
     @Override
     public AskChatAnswerPrompt augment(AskChatAnswerPromptContext context) {
         return new AskChatAnswerPrompt(
-                systemPrompt(),
-                userPrompt(context)
+                systemPromptV2(),
+                userPromptV2(context)
         );
+    }
+
+    private String systemPromptV2() {
+        return """
+                당신은 사용자의 과거 답변, 리포트 기록, 최근 대화를 바탕으로 자기이해를 돕는 따뜻한 상담형 챗봇입니다.
+                반드시 제공된 사용자 기록과 최근 대화 맥락 안에서만 답변하세요.
+                말투는 친절하고 편안한 한국어 구어체로 작성하세요.
+                "당신은", "사용자께서는", "사용자는" 같은 딱딱하고 AI스러운 표현은 사용하지 마세요.
+                대신 "말해준 걸 보면", "기록을 보면", "지금까지의 흐름으로는"처럼 자연스럽게 말하세요.
+                성격, 관계, 가치관, 루틴을 단정하지 말고 근거가 약하면 조심스럽게 표현하세요.
+                사용자가 "방금", "직전", "이전 질문"을 물으면 [현재 질문]이 아니라 [최근 대화]의 마지막 USER 메시지를 기준으로 답하세요.
+                답변은 아래 JSON 형식만 반환하세요.
+                {
+                  "answer": "사용자에게 보여줄 답변",
+                  "followUpQuestions": ["후속 질문 1", "후속 질문 2"]
+                }
+                """;
+    }
+
+    private String userPromptV2(AskChatAnswerPromptContext context) {
+        return """
+                [프롬프트 버전]
+                %d
+
+                [현재 질문]
+                %s
+
+                [최근 대화]
+                %s
+
+                [검색된 사용자 기록]
+                %s
+
+                [작성 조건]
+                - answer는 500자 이내로 작성하세요.
+                - followUpQuestions는 %d개 이하로 작성하세요.
+                - 현재 질문은 사용자가 방금 보낸 요청입니다. 최근 대화 목록에는 현재 질문을 포함하지 않았습니다.
+                - "방금 한 질문", "직전 질문", "이전 질문"처럼 대화 순서를 묻는 경우 최근 대화의 마지막 USER 메시지를 답하세요.
+                - 검색된 사용자 기록이 부족하면 부족하다고 말하고, 현재 질문에 답할 수 있는 범위만 답하세요.
+                - 사용자 기록 원문을 길게 그대로 복사하지 마세요.
+                """.formatted(
+                properties.getPromptVersion(),
+                context.question(),
+                formatRecentMessagesV2(context.recentMessages()),
+                formatReferenceDocumentsV2(context.referenceDocuments()),
+                properties.getFollowUpQuestionCount()
+        );
+    }
+
+    private String formatRecentMessagesV2(List<AskChatAnswerConversationMessage> messages) {
+        if (messages.isEmpty()) {
+            return "최근 대화가 없습니다.";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < messages.size(); i++) {
+            AskChatAnswerConversationMessage message = messages.get(i);
+            builder.append(i + 1)
+                    .append(". ")
+                    .append(message.role())
+                    .append(": ")
+                    .append(message.content())
+                    .append(System.lineSeparator());
+        }
+        return builder.toString().trim();
+    }
+
+    private String formatReferenceDocumentsV2(List<AskChatAnswerReferenceDocument> documents) {
+        if (documents.isEmpty()) {
+            return "검색된 사용자 기록이 없습니다.";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < documents.size(); i++) {
+            AskChatAnswerReferenceDocument document = documents.get(i);
+            builder.append(i + 1)
+                    .append(". documentId=")
+                    .append(document.documentId())
+                    .append(", sourceType=")
+                    .append(document.sourceType())
+                    .append(", interestCode=")
+                    .append(document.interestCode())
+                    .append(", distance=")
+                    .append(document.distance())
+                    .append(System.lineSeparator())
+                    .append(document.content())
+                    .append(System.lineSeparator());
+        }
+        return builder.toString().trim();
     }
 
     private String systemPrompt() {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
@@ -12,14 +12,15 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class AskChatAnswerPromptComposer {
+public class AskChatAnswerPromptComposer implements AskChatAnswerPromptAugmenter {
 
     private static final String NO_REFERENCE_DOCUMENT = "검색된 사용자 기록이 없습니다.";
     private static final String NO_RECENT_MESSAGE = "최근 대화가 없습니다.";
 
     private final AskChatAnswerProperties properties;
 
-    public AskChatAnswerPrompt compose(AskChatAnswerPromptContext context) {
+    @Override
+    public AskChatAnswerPrompt augment(AskChatAnswerPromptContext context) {
         return new AskChatAnswerPrompt(
                 systemPrompt(),
                 userPrompt(context)

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposer.java
@@ -5,6 +5,7 @@ import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
 import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.global.core.prompt.askchat.AskChatAnswerPromptLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,144 +19,27 @@ public class AskChatAnswerPromptComposer implements AskChatAnswerPromptAugmenter
     private static final String NO_RECENT_MESSAGE = "최근 대화가 없습니다.";
 
     private final AskChatAnswerProperties properties;
+    private final AskChatAnswerPromptLoader promptLoader;
 
     @Override
     public AskChatAnswerPrompt augment(AskChatAnswerPromptContext context) {
         return new AskChatAnswerPrompt(
-                systemPromptV2(),
-                userPromptV2(context)
+                systemPrompt(),
+                userPrompt(context)
         );
-    }
-
-    private String systemPromptV2() {
-        return """
-                당신은 사용자의 과거 답변, 리포트 기록, 최근 대화를 바탕으로 자기이해를 돕는 따뜻한 상담형 챗봇입니다.
-                반드시 제공된 사용자 기록과 최근 대화 맥락 안에서만 답변하세요.
-                말투는 친절하고 편안한 한국어 구어체로 작성하세요.
-                "당신은", "사용자께서는", "사용자는" 같은 딱딱하고 AI스러운 표현은 사용하지 마세요.
-                대신 "말해준 걸 보면", "기록을 보면", "지금까지의 흐름으로는"처럼 자연스럽게 말하세요.
-                성격, 관계, 가치관, 루틴을 단정하지 말고 근거가 약하면 조심스럽게 표현하세요.
-                사용자가 "방금", "직전", "이전 질문"을 물으면 [현재 질문]이 아니라 [최근 대화]의 마지막 USER 메시지를 기준으로 답하세요.
-                답변은 아래 JSON 형식만 반환하세요.
-                {
-                  "answer": "사용자에게 보여줄 답변",
-                  "followUpQuestions": ["후속 질문 1", "후속 질문 2"]
-                }
-                """;
-    }
-
-    private String userPromptV2(AskChatAnswerPromptContext context) {
-        return """
-                [프롬프트 버전]
-                %d
-
-                [현재 질문]
-                %s
-
-                [최근 대화]
-                %s
-
-                [검색된 사용자 기록]
-                %s
-
-                [작성 조건]
-                - answer는 500자 이내로 작성하세요.
-                - followUpQuestions는 %d개 이하로 작성하세요.
-                - 현재 질문은 사용자가 방금 보낸 요청입니다. 최근 대화 목록에는 현재 질문을 포함하지 않았습니다.
-                - "방금 한 질문", "직전 질문", "이전 질문"처럼 대화 순서를 묻는 경우 최근 대화의 마지막 USER 메시지를 답하세요.
-                - 검색된 사용자 기록이 부족하면 부족하다고 말하고, 현재 질문에 답할 수 있는 범위만 답하세요.
-                - 사용자 기록 원문을 길게 그대로 복사하지 마세요.
-                """.formatted(
-                properties.getPromptVersion(),
-                context.question(),
-                formatRecentMessagesV2(context.recentMessages()),
-                formatReferenceDocumentsV2(context.referenceDocuments()),
-                properties.getFollowUpQuestionCount()
-        );
-    }
-
-    private String formatRecentMessagesV2(List<AskChatAnswerConversationMessage> messages) {
-        if (messages.isEmpty()) {
-            return "최근 대화가 없습니다.";
-        }
-
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < messages.size(); i++) {
-            AskChatAnswerConversationMessage message = messages.get(i);
-            builder.append(i + 1)
-                    .append(". ")
-                    .append(message.role())
-                    .append(": ")
-                    .append(message.content())
-                    .append(System.lineSeparator());
-        }
-        return builder.toString().trim();
-    }
-
-    private String formatReferenceDocumentsV2(List<AskChatAnswerReferenceDocument> documents) {
-        if (documents.isEmpty()) {
-            return "검색된 사용자 기록이 없습니다.";
-        }
-
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < documents.size(); i++) {
-            AskChatAnswerReferenceDocument document = documents.get(i);
-            builder.append(i + 1)
-                    .append(". documentId=")
-                    .append(document.documentId())
-                    .append(", sourceType=")
-                    .append(document.sourceType())
-                    .append(", interestCode=")
-                    .append(document.interestCode())
-                    .append(", distance=")
-                    .append(document.distance())
-                    .append(System.lineSeparator())
-                    .append(document.content())
-                    .append(System.lineSeparator());
-        }
-        return builder.toString().trim();
     }
 
     private String systemPrompt() {
-        return """
-                당신은 사용자의 누적 답변과 리포트 기록을 바탕으로 자기이해를 돕는 상담형 챗봇입니다.
-                반드시 제공된 사용자 기록과 최근 대화 맥락 안에서만 답변하세요.
-                사용자의 성격, 관계, 가치관, 루틴을 단정하지 말고 근거가 약하면 조심스럽게 표현하세요.
-                답변은 한국어 존댓말로 작성하고, 따뜻하지만 과장되지 않게 말하세요.
-                응답은 아래 JSON 형식만 반환하세요.
-                {
-                  "answer": "사용자에게 보여줄 답변",
-                  "followUpQuestions": ["후속 질문 1", "후속 질문 2"]
-                }
-                """;
+        return promptLoader.loadSystemPrompt();
     }
 
     private String userPrompt(AskChatAnswerPromptContext context) {
-        return """
-                [프롬프트 버전]
-                %d
-
-                [현재 질문]
-                %s
-
-                [최근 대화]
-                %s
-
-                [검색된 사용자 기록]
-                %s
-
-                [작성 조건]
-                - answer는 500자 이내로 작성하세요.
-                - followUpQuestions는 %d개 이하로 작성하세요.
-                - 검색된 사용자 기록이 부족하면 부족하다고 말하고, 현재 질문에 답할 수 있는 범위만 답하세요.
-                - 사용자 기록의 원문을 길게 그대로 복사하지 마세요.
-                """.formatted(
-                properties.getPromptVersion(),
-                context.question(),
-                formatRecentMessages(context.recentMessages()),
-                formatReferenceDocuments(context.referenceDocuments()),
-                properties.getFollowUpQuestionCount()
-        );
+        return promptLoader.loadUserPrompt()
+                .replace("{promptVersion}", String.valueOf(properties.getPromptVersion()))
+                .replace("{question}", context.question())
+                .replace("{recentMessages}", formatRecentMessages(context.recentMessages()))
+                .replace("{referenceDocuments}", formatReferenceDocuments(context.referenceDocuments()))
+                .replace("{followUpQuestionCount}", String.valueOf(properties.getFollowUpQuestionCount()));
     }
 
     private String formatRecentMessages(List<AskChatAnswerConversationMessage> messages) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerConversationMessage.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerConversationMessage.java
@@ -1,0 +1,9 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+
+public record AskChatAnswerConversationMessage(
+        AskChatMessageRole role,
+        String content
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerGenerationResult.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerGenerationResult.java
@@ -1,0 +1,20 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+
+import java.util.List;
+
+public record AskChatAnswerGenerationResult(
+        AskChatGeneratedAnswer answer,
+        LlmProvider provider,
+        String model,
+        LlmTokenUsage tokenUsage,
+        List<Long> referenceDocumentIds
+) {
+
+    public AskChatAnswerGenerationResult {
+        tokenUsage = tokenUsage == null ? LlmTokenUsage.empty() : tokenUsage;
+        referenceDocumentIds = referenceDocumentIds == null ? List.of() : List.copyOf(referenceDocumentIds);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerPrompt.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerPrompt.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+public record AskChatAnswerPrompt(
+        String systemPrompt,
+        String userPrompt
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerPromptContext.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerPromptContext.java
@@ -1,0 +1,17 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import java.util.List;
+
+public record AskChatAnswerPromptContext(
+        Long userId,
+        Long sessionId,
+        String question,
+        List<AskChatAnswerConversationMessage> recentMessages,
+        List<AskChatAnswerReferenceDocument> referenceDocuments
+) {
+
+    public AskChatAnswerPromptContext {
+        recentMessages = recentMessages == null ? List.of() : List.copyOf(recentMessages);
+        referenceDocuments = referenceDocuments == null ? List.of() : List.copyOf(referenceDocuments);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerReferenceDocument.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatAnswerReferenceDocument.java
@@ -1,0 +1,25 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+
+public record AskChatAnswerReferenceDocument(
+        Long documentId,
+        AskChatRagDocumentSourceType sourceType,
+        Long sourceId,
+        InterestCode interestCode,
+        String content,
+        double distance
+) {
+
+    public static AskChatAnswerReferenceDocument from(AskChatRagSearchResultDto result) {
+        return new AskChatAnswerReferenceDocument(
+                result.documentId(),
+                result.sourceType(),
+                result.sourceId(),
+                result.interestCode(),
+                result.content(),
+                result.distance()
+        );
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatGeneratedAnswer.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/dto/AskChatGeneratedAnswer.java
@@ -1,0 +1,13 @@
+package com.devkor.ifive.nadab.domain.askchat.core.dto;
+
+import java.util.List;
+
+public record AskChatGeneratedAnswer(
+        String answer,
+        List<String> followUpQuestions
+) {
+
+    public AskChatGeneratedAnswer {
+        followUpQuestions = followUpQuestions == null ? List.of() : List.copyOf(followUpQuestions);
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessage.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessage.java
@@ -66,6 +66,9 @@ public class AskChatMessage extends CreatableEntity {
     @Column(name = "thinking_tokens")
     private Long thinkingTokens;
 
+    @Column(name = "generation_duration_ms")
+    private Long generationDurationMs;
+
     @Column(name = "error_code", length = 128)
     private String errorCode;
 
@@ -83,7 +86,8 @@ public class AskChatMessage extends CreatableEntity {
             Long inputTokens,
             Long outputTokens,
             Long totalTokens,
-            Long thinkingTokens
+            Long thinkingTokens,
+            Long generationDurationMs
     ) {
         AskChatMessage message = create(session, AskChatMessageRole.ASSISTANT, content);
         message.status = AskChatMessageStatus.COMPLETED;
@@ -93,6 +97,7 @@ public class AskChatMessage extends CreatableEntity {
         message.outputTokens = outputTokens;
         message.totalTokens = totalTokens;
         message.thinkingTokens = thinkingTokens;
+        message.generationDurationMs = generationDurationMs;
         return message;
     }
 
@@ -101,13 +106,15 @@ public class AskChatMessage extends CreatableEntity {
             String content,
             LlmProvider llmProvider,
             String llmModel,
-            String errorCode
+            String errorCode,
+            Long generationDurationMs
     ) {
         AskChatMessage message = create(session, AskChatMessageRole.ASSISTANT, content);
         message.status = AskChatMessageStatus.FAILED;
         message.llmProvider = llmProvider;
         message.llmModel = llmModel;
         message.errorCode = errorCode;
+        message.generationDurationMs = generationDurationMs;
         return message;
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageReference.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/entity/AskChatMessageReference.java
@@ -1,0 +1,71 @@
+package com.devkor.ifive.nadab.domain.askchat.core.entity;
+
+import com.devkor.ifive.nadab.global.shared.entity.CreatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "ask_chat_message_references",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_ask_chat_message_references_message_document",
+                        columnNames = {"message_id", "rag_document_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uq_ask_chat_message_references_message_order",
+                        columnNames = {"message_id", "display_order"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AskChatMessageReference extends CreatableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "message_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ask_chat_message_references_message")
+    )
+    private AskChatMessage message;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "rag_document_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ask_chat_message_references_rag_document")
+    )
+    private AskChatRagDocument ragDocument;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    public static AskChatMessageReference of(
+            AskChatMessage message,
+            AskChatRagDocument ragDocument,
+            int displayOrder
+    ) {
+        AskChatMessageReference reference = new AskChatMessageReference();
+        reference.message = message;
+        reference.ragDocument = ragDocument;
+        reference.displayOrder = displayOrder;
+        return reference;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/properties/AskChatAnswerProperties.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/properties/AskChatAnswerProperties.java
@@ -1,0 +1,43 @@
+package com.devkor.ifive.nadab.domain.askchat.core.properties;
+
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "ask-chat.answer")
+public class AskChatAnswerProperties {
+
+    @NotNull
+    private LlmProvider provider = LlmProvider.OPENAI;
+
+    @NotBlank
+    private String model = "gpt-4o-mini";
+
+    @DecimalMin("0.0")
+    @DecimalMax("2.0")
+    private double temperature = 0.3;
+
+    @Min(1)
+    private int maxTokens = 700;
+
+    @Min(1)
+    private int recentMessageLimit = 10;
+
+    @Min(0)
+    private int followUpQuestionCount = 2;
+
+    @Min(1)
+    private int promptVersion = 1;
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepository.java
@@ -1,0 +1,11 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AskChatMessageReferenceRepository extends JpaRepository<AskChatMessageReference, Long> {
+
+    List<AskChatMessageReference> findAllByMessageIdOrderByDisplayOrderAsc(Long messageId);
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageRepository.java
@@ -15,6 +15,12 @@ public interface AskChatMessageRepository extends JpaRepository<AskChatMessage, 
 
     List<AskChatMessage> findAllBySessionIdOrderByCreatedAtDesc(Long sessionId, Pageable pageable);
 
+    List<AskChatMessage> findAllBySessionIdAndStatusOrderByCreatedAtDesc(
+            Long sessionId,
+            AskChatMessageStatus status,
+            Pageable pageable
+    );
+
     Optional<AskChatMessage> findFirstBySessionIdAndRoleOrderByCreatedAtDesc(
             Long sessionId,
             AskChatMessageRole role

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagVectorRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagVectorRepository.java
@@ -73,7 +73,7 @@ public class AskChatRagVectorRepository {
                  WHERE user_id = :userId
                    AND embedding_status = 'COMPLETED'
                    AND embedding IS NOT NULL
-                   AND (:interestCode IS NULL OR interest_code = :interestCode)
+                   AND (CAST(:interestCode AS VARCHAR) IS NULL OR interest_code = CAST(:interestCode AS VARCHAR))
                  ORDER BY embedding <=> CAST(:queryEmbedding AS vector)
                  LIMIT :limit
                 """;

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClient.java
@@ -1,0 +1,118 @@
+package com.devkor.ifive.nadab.domain.askchat.infra;
+
+import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposer;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationResult;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatGeneratedAnswer;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmExceptionMapper;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsageExtractor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AskChatAnswerLlmClient {
+
+    private final AskChatAnswerPromptComposer promptComposer;
+    private final AskChatAnswerProperties properties;
+    private final LlmRouter llmRouter;
+    private final ObjectMapper objectMapper;
+
+    public AskChatAnswerGenerationResult generate(AskChatAnswerPromptContext context) {
+        AskChatAnswerPrompt prompt = promptComposer.compose(context);
+        LlmProvider provider = properties.getProvider();
+        ChatClient client = llmRouter.route(provider);
+
+        ChatResponse response;
+        try {
+            response = client.prompt()
+                    .system(prompt.systemPrompt())
+                    .user(prompt.userPrompt())
+                    .options(options())
+                    .call()
+                    .chatResponse();
+        } catch (Exception e) {
+            throw LlmExceptionMapper.toUnavailable(ErrorCode.AI_NO_RESPONSE, e);
+        }
+
+        String content = extractContent(response);
+        if (content == null || content.isBlank()) {
+            throw new AiServiceUnavailableException(ErrorCode.AI_NO_RESPONSE);
+        }
+
+        AskChatGeneratedAnswer answer = parseAnswer(content);
+        validateAnswer(answer);
+
+        return new AskChatAnswerGenerationResult(
+                answer,
+                provider,
+                properties.getModel(),
+                LlmTokenUsageExtractor.extract(response),
+                referenceDocumentIds(context)
+        );
+    }
+
+    private OpenAiChatOptions options() {
+        return OpenAiChatOptions.builder()
+                .model(properties.getModel())
+                .temperature(properties.getTemperature())
+                .maxTokens(properties.getMaxTokens())
+                .build();
+    }
+
+    private AskChatGeneratedAnswer parseAnswer(String content) {
+        try {
+            return objectMapper.readValue(content, AskChatGeneratedAnswer.class);
+        } catch (Exception e) {
+            throw new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
+        }
+    }
+
+    private void validateAnswer(AskChatGeneratedAnswer answer) {
+        if (answer == null || isBlank(answer.answer())) {
+            throw new AiResponseParseException(ErrorCode.AI_RESPONSE_FORMAT_INVALID);
+        }
+
+        if (answer.followUpQuestions().size() > properties.getFollowUpQuestionCount()) {
+            throw new AiResponseParseException(ErrorCode.AI_RESPONSE_FORMAT_INVALID);
+        }
+
+        for (String followUpQuestion : answer.followUpQuestions()) {
+            if (isBlank(followUpQuestion)) {
+                throw new AiResponseParseException(ErrorCode.AI_RESPONSE_FORMAT_INVALID);
+            }
+        }
+    }
+
+    private List<Long> referenceDocumentIds(AskChatAnswerPromptContext context) {
+        return context.referenceDocuments().stream()
+                .map(AskChatAnswerReferenceDocument::documentId)
+                .toList();
+    }
+
+    private String extractContent(ChatResponse response) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return null;
+        }
+        return response.getResult().getOutput().getText();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClient.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClient.java
@@ -1,6 +1,6 @@
 package com.devkor.ifive.nadab.domain.askchat.infra;
 
-import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposer;
+import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptAugmenter;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationResult;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
@@ -28,13 +28,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AskChatAnswerLlmClient {
 
-    private final AskChatAnswerPromptComposer promptComposer;
+    /*
+     * Keep prompt augmentation behind this boundary while evidence documents are stored in
+     * ask_chat_message_references. A future Spring AI Advisor implementation can replace this
+     * collaborator without changing the ChatClient call path.
+     */
+    private final AskChatAnswerPromptAugmenter promptAugmenter;
     private final AskChatAnswerProperties properties;
     private final LlmRouter llmRouter;
     private final ObjectMapper objectMapper;
 
     public AskChatAnswerGenerationResult generate(AskChatAnswerPromptContext context) {
-        AskChatAnswerPrompt prompt = promptComposer.compose(context);
+        AskChatAnswerPrompt prompt = promptAugmenter.augment(context);
         LlmProvider provider = properties.getProvider();
         ChatClient client = llmRouter.route(provider);
 

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/AskChatAnswerPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/AskChatAnswerPromptLoader.java
@@ -1,0 +1,7 @@
+package com.devkor.ifive.nadab.global.core.prompt.askchat;
+
+public interface AskChatAnswerPromptLoader {
+    String loadSystemPrompt();
+
+    String loadUserPrompt();
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/LocalAskChatAnswerPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/LocalAskChatAnswerPromptLoader.java
@@ -1,0 +1,47 @@
+package com.devkor.ifive.nadab.global.core.prompt.askchat;
+
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@Profile("local")
+@Slf4j
+public class LocalAskChatAnswerPromptLoader implements AskChatAnswerPromptLoader {
+
+    private static final String SYSTEM_PROMPT_PATH = "secret/ask-chat-answer-system-prompt-local.txt";
+    private static final String USER_PROMPT_PATH = "secret/ask-chat-answer-user-prompt-local.txt";
+
+    @Override
+    public String loadSystemPrompt() {
+        return load(SYSTEM_PROMPT_PATH);
+    }
+
+    @Override
+    public String loadUserPrompt() {
+        return load(USER_PROMPT_PATH);
+    }
+
+    private String load(String path) {
+        try {
+            ClassPathResource resource = new ClassPathResource(path);
+
+            if (!resource.exists()) {
+                log.error("Ask Chat 답변 프롬프트 파일이 존재하지 않습니다: {}", path);
+                throw new BadRequestException(ErrorCode.PROMPT_ASK_CHAT_FILE_NOT_FOUND);
+            }
+
+            byte[] bytes = resource.getContentAsByteArray();
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("로컬 Ask Chat 답변 프롬프트 파일 읽기 실패: {}", path, e);
+            throw new BadRequestException(ErrorCode.PROMPT_ASK_CHAT_FILE_READ_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/SecretAskChatAnswerPromptLoader.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/prompt/askchat/SecretAskChatAnswerPromptLoader.java
@@ -1,0 +1,42 @@
+package com.devkor.ifive.nadab.global.core.prompt.askchat;
+
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"dev", "prod"})
+@Slf4j
+@RequiredArgsConstructor
+public class SecretAskChatAnswerPromptLoader implements AskChatAnswerPromptLoader {
+
+    @Value("${ASK_CHAT_ANSWER_SYSTEM_PROMPT}")
+    private String systemPrompt;
+
+    @Value("${ASK_CHAT_ANSWER_USER_PROMPT}")
+    private String userPrompt;
+
+    @Override
+    public String loadSystemPrompt() {
+        if (systemPrompt == null || systemPrompt.isBlank()) {
+            log.error("환경 변수 ASK_CHAT_ANSWER_SYSTEM_PROMPT가 비어있습니다.");
+            throw new BadRequestException(ErrorCode.PROMPT_ASK_CHAT_ENV_VAR_NOT_SET);
+        }
+
+        return systemPrompt;
+    }
+
+    @Override
+    public String loadUserPrompt() {
+        if (userPrompt == null || userPrompt.isBlank()) {
+            log.error("환경 변수 ASK_CHAT_ANSWER_USER_PROMPT가 비어있습니다.");
+            throw new BadRequestException(ErrorCode.PROMPT_ASK_CHAT_ENV_VAR_NOT_SET);
+        }
+
+        return userPrompt;
+    }
+}

--- a/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
+++ b/src/main/java/com/devkor/ifive/nadab/global/core/response/ErrorCode.java
@@ -270,6 +270,10 @@ public enum ErrorCode {
     PROMPT_TYPE_REPAIR_FILE_READ_FAILED(HttpStatus.BAD_REQUEST, "로컬 유형 리포트 Repair 프롬프트 파일을 읽을 수 없습니다"),
     PROMPT_TYPE_REPAIR_ENV_VAR_NOT_SET(HttpStatus.BAD_REQUEST, "REPAIR_TYPE_PROMPT 환경 변수에 프롬프트가 설정되어 있지 않습니다"),
 
+    PROMPT_ASK_CHAT_FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "Ask Chat 답변 프롬프트 파일이 존재하지 않습니다"),
+    PROMPT_ASK_CHAT_FILE_READ_FAILED(HttpStatus.BAD_REQUEST, "로컬 Ask Chat 답변 프롬프트 파일을 읽을 수 없습니다"),
+    PROMPT_ASK_CHAT_ENV_VAR_NOT_SET(HttpStatus.BAD_REQUEST, "Ask Chat 답변 프롬프트 환경 변수가 설정되어 있지 않습니다"),
+
     // ==================== NICKNAME (닉네임) ====================
     // 400 Bad Request
     NICKNAME_CHANGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "닉네임 변경 가능 횟수를 초과했습니다 (14일 내 최대 2회)"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,14 @@ admin:
 api_prefix: /api/v1
 
 ask-chat:
+  answer:
+    provider: OPENAI
+    model: gpt-4o-mini
+    temperature: 0.3
+    max-tokens: 700
+    recent-message-limit: 10
+    follow-up-question-count: 2
+    prompt-version: 1
   rag:
     embedding-model: text-embedding-3-small
     embedding-dimensions: 1536

--- a/src/main/resources/db/migration/V20260715_1200__IS_create_ask_chat_message_references.sql
+++ b/src/main/resources/db/migration/V20260715_1200__IS_create_ask_chat_message_references.sql
@@ -1,0 +1,21 @@
+CREATE TABLE ask_chat_message_references (
+    id BIGSERIAL PRIMARY KEY,
+    message_id BIGINT NOT NULL,
+    rag_document_id BIGINT NOT NULL,
+    display_order INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_ask_chat_message_references_message
+        FOREIGN KEY (message_id) REFERENCES ask_chat_messages(id) ON DELETE CASCADE,
+    CONSTRAINT fk_ask_chat_message_references_rag_document
+        FOREIGN KEY (rag_document_id) REFERENCES ask_chat_rag_documents(id) ON DELETE RESTRICT,
+    CONSTRAINT uq_ask_chat_message_references_message_document
+        UNIQUE (message_id, rag_document_id),
+    CONSTRAINT uq_ask_chat_message_references_message_order
+        UNIQUE (message_id, display_order)
+);
+
+CREATE INDEX idx_ask_chat_message_references_message_order
+    ON ask_chat_message_references(message_id, display_order);
+
+CREATE INDEX idx_ask_chat_message_references_rag_document
+    ON ask_chat_message_references(rag_document_id);

--- a/src/main/resources/db/migration/V20260716_1200__IS_add_generation_duration_to_ask_chat_messages.sql
+++ b/src/main/resources/db/migration/V20260716_1200__IS_add_generation_duration_to_ask_chat_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ask_chat_messages
+    ADD COLUMN generation_duration_ms BIGINT;

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextServiceTest.java
@@ -1,0 +1,122 @@
+package com.devkor.ifive.nadab.domain.askchat.application;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatRagSearchResultDto;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagVectorRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatEmbeddingClient;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatAnswerContextServiceTest {
+
+    @Mock
+    private AskChatMessageRepository askChatMessageRepository;
+
+    @Mock
+    private AskChatEmbeddingClient askChatEmbeddingClient;
+
+    @Mock
+    private AskChatRagVectorRepository askChatRagVectorRepository;
+
+    private AskChatAnswerContextService service;
+
+    @BeforeEach
+    void setUp() {
+        AskChatAnswerProperties properties = new AskChatAnswerProperties();
+        properties.setRecentMessageLimit(3);
+        service = new AskChatAnswerContextService(
+                askChatMessageRepository,
+                askChatEmbeddingClient,
+                askChatRagVectorRepository,
+                properties
+        );
+    }
+
+    @Test
+    void build_collects_recent_completed_messages_and_rag_documents() {
+        AskChatSession session = mock(AskChatSession.class);
+        AskChatMessage latestAssistantMessage = AskChatMessage.createAssistantMessage(
+                session,
+                "꾸준함이 보여요.",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        AskChatMessage previousUserMessage = AskChatMessage.createUserMessage(session, "내 강점은 뭐야?");
+        List<Double> queryEmbedding = List.of(0.1, 0.2, 0.3);
+        AskChatRagSearchResultDto searchResult = new AskChatRagSearchResultDto(
+                100L,
+                AskChatRagDocumentSourceType.ANSWER_ENTRY,
+                200L,
+                InterestCode.VALUES,
+                "사용자는 꾸준함과 책임감을 중요하게 말했다.",
+                0.12
+        );
+
+        when(askChatMessageRepository.findAllBySessionIdAndStatusOrderByCreatedAtDesc(
+                10L,
+                com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus.COMPLETED,
+                PageRequest.of(0, 3)
+        )).thenReturn(List.of(latestAssistantMessage, previousUserMessage));
+        when(askChatEmbeddingClient.embed("나는 어떤 사람에 가까워?")).thenReturn(queryEmbedding);
+        when(askChatEmbeddingClient.retrievalLimit()).thenReturn(5);
+        when(askChatRagVectorRepository.search(1L, null, queryEmbedding, 5))
+                .thenReturn(List.of(searchResult));
+
+        var context = service.build(1L, 10L, "나는 어떤 사람에 가까워?");
+
+        assertThat(context.userId()).isEqualTo(1L);
+        assertThat(context.sessionId()).isEqualTo(10L);
+        assertThat(context.question()).isEqualTo("나는 어떤 사람에 가까워?");
+        assertThat(context.recentMessages())
+                .extracting(message -> message.role())
+                .containsExactly(AskChatMessageRole.USER, AskChatMessageRole.ASSISTANT);
+        assertThat(context.recentMessages())
+                .extracting(message -> message.content())
+                .containsExactly("내 강점은 뭐야?", "꾸준함이 보여요.");
+        assertThat(context.referenceDocuments()).hasSize(1);
+        assertThat(context.referenceDocuments().get(0).documentId()).isEqualTo(100L);
+        assertThat(context.referenceDocuments().get(0).content())
+                .isEqualTo("사용자는 꾸준함과 책임감을 중요하게 말했다.");
+    }
+
+    @Test
+    void build_returns_empty_lists_when_recent_messages_and_rag_documents_do_not_exist() {
+        when(askChatMessageRepository.findAllBySessionIdAndStatusOrderByCreatedAtDesc(
+                10L,
+                com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus.COMPLETED,
+                PageRequest.of(0, 3)
+        )).thenReturn(List.of());
+        when(askChatEmbeddingClient.embed("기록이 부족해도 답해줘")).thenReturn(List.of(0.1, 0.2));
+        when(askChatEmbeddingClient.retrievalLimit()).thenReturn(5);
+        when(askChatRagVectorRepository.search(1L, null, List.of(0.1, 0.2), 5))
+                .thenReturn(List.of());
+
+        var context = service.build(1L, 10L, "기록이 부족해도 답해줘");
+
+        assertThat(context.recentMessages()).isEmpty();
+        assertThat(context.referenceDocuments()).isEmpty();
+        verify(askChatEmbeddingClient).embed("기록이 부족해도 답해줘");
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatAnswerContextServiceTest.java
@@ -61,6 +61,7 @@ class AskChatAnswerContextServiceTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         AskChatMessage previousUserMessage = AskChatMessage.createUserMessage(session, "내 강점은 뭐야?");

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -4,12 +4,16 @@ import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationRes
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatGeneratedAnswer;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageReference;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
 import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageReferenceRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
 import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
@@ -53,6 +57,12 @@ class AskChatMessageCommandServiceTest {
     private AskChatMessageRepository askChatMessageRepository;
 
     @Mock
+    private AskChatMessageReferenceRepository askChatMessageReferenceRepository;
+
+    @Mock
+    private AskChatRagDocumentRepository askChatRagDocumentRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -72,6 +82,8 @@ class AskChatMessageCommandServiceTest {
         service = new AskChatMessageCommandService(
                 askChatSessionRepository,
                 askChatMessageRepository,
+                askChatMessageReferenceRepository,
+                askChatRagDocumentRepository,
                 userRepository,
                 askChatAnswerContextService,
                 askChatAnswerLlmClient,
@@ -97,6 +109,8 @@ class AskChatMessageCommandServiceTest {
         AskChatAnswerPromptContext context = mock(AskChatAnswerPromptContext.class);
         when(askChatAnswerContextService.build(any(), any(), any())).thenReturn(context);
         when(askChatAnswerLlmClient.generate(context)).thenReturn(successGeneration());
+        AskChatRagDocument ragDocument = mock(AskChatRagDocument.class);
+        when(askChatRagDocumentRepository.getReferenceById(100L)).thenReturn(ragDocument);
 
         var response = service.sendQuestion(1L, "  나는 어떤 사람이야?  ");
 
@@ -115,6 +129,12 @@ class AskChatMessageCommandServiceTest {
         assertThat(messageCaptor.getAllValues().get(0).getContent()).isEqualTo("나는 어떤 사람이야?");
         assertThat(messageCaptor.getAllValues().get(1).getStatus()).isEqualTo(AskChatMessageStatus.COMPLETED);
         assertThat(messageCaptor.getAllValues().get(1).getInputTokens()).isEqualTo(10L);
+        ArgumentCaptor<AskChatMessageReference> referenceCaptor =
+                ArgumentCaptor.forClass(AskChatMessageReference.class);
+        verify(askChatMessageReferenceRepository).save(referenceCaptor.capture());
+        assertThat(referenceCaptor.getValue().getMessage()).isSameAs(messageCaptor.getAllValues().get(1));
+        assertThat(referenceCaptor.getValue().getRagDocument()).isSameAs(ragDocument);
+        assertThat(referenceCaptor.getValue().getDisplayOrder()).isEqualTo(1);
         verify(activeSession).incrementAnsweredTurnCount();
         verify(userRepository, never()).findById(any());
     }
@@ -140,6 +160,8 @@ class AskChatMessageCommandServiceTest {
         AskChatAnswerPromptContext context = mock(AskChatAnswerPromptContext.class);
         when(askChatAnswerContextService.build(any(), any(), any())).thenReturn(context);
         when(askChatAnswerLlmClient.generate(context)).thenReturn(successGeneration());
+        AskChatRagDocument ragDocument = mock(AskChatRagDocument.class);
+        when(askChatRagDocumentRepository.getReferenceById(100L)).thenReturn(ragDocument);
 
         var response = service.sendQuestion(1L, "궁금한 내용을 적어봐요");
 
@@ -186,6 +208,7 @@ class AskChatMessageCommandServiceTest {
         assertThat(messageCaptor.getAllValues().get(1).getLlmModel()).isEqualTo("gpt-4o-mini");
         assertThat(messageCaptor.getAllValues().get(1).getErrorCode())
                 .isEqualTo(ErrorCode.AI_RESPONSE_PARSE_FAILED.getCode());
+        verify(askChatMessageReferenceRepository, never()).save(any());
         verify(activeSession, never()).incrementAnsweredTurnCount();
     }
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -1,18 +1,26 @@
 package com.devkor.ifive.nadab.domain.askchat.application;
 
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerGenerationResult;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatGeneratedAnswer;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
 import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.domain.user.core.repository.UserRepository;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
 import com.devkor.ifive.nadab.global.exception.NotFoundException;
+import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,14 +55,27 @@ class AskChatMessageCommandServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private AskChatAnswerContextService askChatAnswerContextService;
+
+    @Mock
+    private AskChatAnswerLlmClient askChatAnswerLlmClient;
+
     private AskChatMessageCommandService service;
+    private AskChatAnswerProperties askChatAnswerProperties;
 
     @BeforeEach
     void setUp() {
+        askChatAnswerProperties = new AskChatAnswerProperties();
+        askChatAnswerProperties.setProvider(LlmProvider.OPENAI);
+        askChatAnswerProperties.setModel("gpt-4o-mini");
         service = new AskChatMessageCommandService(
                 askChatSessionRepository,
                 askChatMessageRepository,
-                userRepository
+                userRepository,
+                askChatAnswerContextService,
+                askChatAnswerLlmClient,
+                askChatAnswerProperties
         );
     }
 
@@ -71,19 +94,28 @@ class AskChatMessageCommandServiceTest {
         )).thenReturn(Optional.of(activeSession));
         when(askChatMessageRepository.save(any(AskChatMessage.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        AskChatAnswerPromptContext context = mock(AskChatAnswerPromptContext.class);
+        when(askChatAnswerContextService.build(any(), any(), any())).thenReturn(context);
+        when(askChatAnswerLlmClient.generate(context)).thenReturn(successGeneration());
 
         var response = service.sendQuestion(1L, "  나는 어떤 사람이야?  ");
 
         assertThat(response.session().sessionId()).isEqualTo(10L);
-        assertThat(response.session().remainingTurnCount()).isEqualTo(13);
         assertThat(response.userMessage().role()).isEqualTo(AskChatMessageRole.USER);
         assertThat(response.userMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
         assertThat(response.userMessage().content()).isEqualTo("나는 어떤 사람이야?");
+        assertThat(response.assistantMessage().role()).isEqualTo(AskChatMessageRole.ASSISTANT);
+        assertThat(response.assistantMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
+        assertThat(response.assistantMessage().content()).isEqualTo("꾸준함이 강점으로 보여요.");
+        assertThat(response.followUpQuestions()).containsExactly("언제 꾸준함이 잘 드러났나요?");
 
         ArgumentCaptor<AskChatMessage> messageCaptor = ArgumentCaptor.forClass(AskChatMessage.class);
-        verify(askChatMessageRepository).save(messageCaptor.capture());
-        assertThat(messageCaptor.getValue().getSession()).isEqualTo(activeSession);
-        assertThat(messageCaptor.getValue().getContent()).isEqualTo("나는 어떤 사람이야?");
+        verify(askChatMessageRepository, times(2)).save(messageCaptor.capture());
+        assertThat(messageCaptor.getAllValues().get(0).getSession()).isEqualTo(activeSession);
+        assertThat(messageCaptor.getAllValues().get(0).getContent()).isEqualTo("나는 어떤 사람이야?");
+        assertThat(messageCaptor.getAllValues().get(1).getStatus()).isEqualTo(AskChatMessageStatus.COMPLETED);
+        assertThat(messageCaptor.getAllValues().get(1).getInputTokens()).isEqualTo(10L);
+        verify(activeSession).incrementAnsweredTurnCount();
         verify(userRepository, never()).findById(any());
     }
 
@@ -105,16 +137,56 @@ class AskChatMessageCommandServiceTest {
         when(askChatSessionRepository.save(any(AskChatSession.class))).thenReturn(savedSession);
         when(askChatMessageRepository.save(any(AskChatMessage.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        AskChatAnswerPromptContext context = mock(AskChatAnswerPromptContext.class);
+        when(askChatAnswerContextService.build(any(), any(), any())).thenReturn(context);
+        when(askChatAnswerLlmClient.generate(context)).thenReturn(successGeneration());
 
         var response = service.sendQuestion(1L, "궁금한 내용을 적어봐요");
 
         assertThat(response.session().sessionId()).isEqualTo(11L);
-        assertThat(response.session().remainingTurnCount()).isEqualTo(15);
         assertThat(response.userMessage().content()).isEqualTo("궁금한 내용을 적어봐요");
+        assertThat(response.assistantMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
 
         ArgumentCaptor<AskChatSession> sessionCaptor = ArgumentCaptor.forClass(AskChatSession.class);
         verify(askChatSessionRepository).save(sessionCaptor.capture());
         assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(AskChatSessionStatus.ACTIVE);
+    }
+
+    @Test
+    void sendQuestion_saves_failed_assistant_message_when_answer_generation_fails() {
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                2,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+        when(askChatMessageRepository.save(any(AskChatMessage.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        AskChatAnswerPromptContext context = mock(AskChatAnswerPromptContext.class);
+        when(askChatAnswerContextService.build(any(), any(), any())).thenReturn(context);
+        when(askChatAnswerLlmClient.generate(context))
+                .thenThrow(new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED));
+
+        var response = service.sendQuestion(1L, "나는 어떤 사람이야?");
+
+        assertThat(response.userMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
+        assertThat(response.assistantMessage().role()).isEqualTo(AskChatMessageRole.ASSISTANT);
+        assertThat(response.assistantMessage().status()).isEqualTo(AskChatMessageStatus.FAILED);
+        assertThat(response.assistantMessage().content()).isEqualTo("답변 생성에 오류가 발생했어요. 다시 시도해주세요.");
+        assertThat(response.followUpQuestions()).isEmpty();
+
+        ArgumentCaptor<AskChatMessage> messageCaptor = ArgumentCaptor.forClass(AskChatMessage.class);
+        verify(askChatMessageRepository, times(2)).save(messageCaptor.capture());
+        assertThat(messageCaptor.getAllValues().get(1).getLlmProvider()).isEqualTo(LlmProvider.OPENAI);
+        assertThat(messageCaptor.getAllValues().get(1).getLlmModel()).isEqualTo("gpt-4o-mini");
+        assertThat(messageCaptor.getAllValues().get(1).getErrorCode())
+                .isEqualTo(ErrorCode.AI_RESPONSE_PARSE_FAILED.getCode());
+        verify(activeSession, never()).incrementAnsweredTurnCount();
     }
 
     @Test
@@ -162,6 +234,19 @@ class AskChatMessageCommandServiceTest {
                 .isInstanceOfSatisfying(NotFoundException.class, ex ->
                         assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
         verify(askChatMessageRepository, never()).save(any());
+    }
+
+    private AskChatAnswerGenerationResult successGeneration() {
+        return new AskChatAnswerGenerationResult(
+                new AskChatGeneratedAnswer(
+                        "꾸준함이 강점으로 보여요.",
+                        List.of("언제 꾸준함이 잘 드러났나요?")
+                ),
+                LlmProvider.OPENAI,
+                "gpt-4o-mini",
+                new LlmTokenUsage(10L, 20L, 30L),
+                List.of(100L)
+        );
     }
 
     private AskChatSession session(

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,6 +41,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -135,6 +137,10 @@ class AskChatMessageCommandServiceTest {
         assertThat(referenceCaptor.getValue().getMessage()).isSameAs(messageCaptor.getAllValues().get(1));
         assertThat(referenceCaptor.getValue().getRagDocument()).isSameAs(ragDocument);
         assertThat(referenceCaptor.getValue().getDisplayOrder()).isEqualTo(1);
+        InOrder inOrder = inOrder(askChatAnswerContextService, askChatMessageRepository, askChatAnswerLlmClient);
+        inOrder.verify(askChatAnswerContextService).build(any(), any(), any());
+        inOrder.verify(askChatMessageRepository).save(messageCaptor.getAllValues().get(0));
+        inOrder.verify(askChatAnswerLlmClient).generate(context);
         verify(activeSession).incrementAnsweredTurnCount();
         verify(userRepository, never()).findById(any());
     }

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -129,8 +129,11 @@ class AskChatMessageCommandServiceTest {
         verify(askChatMessageRepository, times(2)).save(messageCaptor.capture());
         assertThat(messageCaptor.getAllValues().get(0).getSession()).isEqualTo(activeSession);
         assertThat(messageCaptor.getAllValues().get(0).getContent()).isEqualTo("나는 어떤 사람이야?");
+        assertThat(messageCaptor.getAllValues().get(0).getGenerationDurationMs()).isNull();
         assertThat(messageCaptor.getAllValues().get(1).getStatus()).isEqualTo(AskChatMessageStatus.COMPLETED);
         assertThat(messageCaptor.getAllValues().get(1).getInputTokens()).isEqualTo(10L);
+        assertThat(messageCaptor.getAllValues().get(1).getGenerationDurationMs()).isNotNull();
+        assertThat(messageCaptor.getAllValues().get(1).getGenerationDurationMs()).isGreaterThanOrEqualTo(0L);
         ArgumentCaptor<AskChatMessageReference> referenceCaptor =
                 ArgumentCaptor.forClass(AskChatMessageReference.class);
         verify(askChatMessageReferenceRepository).save(referenceCaptor.capture());
@@ -214,6 +217,8 @@ class AskChatMessageCommandServiceTest {
         assertThat(messageCaptor.getAllValues().get(1).getLlmModel()).isEqualTo("gpt-4o-mini");
         assertThat(messageCaptor.getAllValues().get(1).getErrorCode())
                 .isEqualTo(ErrorCode.AI_RESPONSE_PARSE_FAILED.getCode());
+        assertThat(messageCaptor.getAllValues().get(1).getGenerationDurationMs()).isNotNull();
+        assertThat(messageCaptor.getAllValues().get(1).getGenerationDurationMs()).isGreaterThanOrEqualTo(0L);
         verify(askChatMessageReferenceRepository, never()).save(any());
         verify(activeSession, never()).incrementAnsweredTurnCount();
     }

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
@@ -157,6 +157,64 @@ class AskChatSessionServiceTest {
         verify(askChatSessionRepository, never()).save(any());
     }
 
+    @Test
+    void restartSession_ends_active_session_and_creates_new_session() {
+        User user = mock(User.class);
+        AskChatSession activeSession = session(
+                10L,
+                AskChatSessionStatus.ACTIVE,
+                4,
+                OffsetDateTime.of(2026, 7, 14, 10, 0, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        AskChatSession savedSession = session(
+                11L,
+                AskChatSessionStatus.ACTIVE,
+                0,
+                OffsetDateTime.of(2026, 7, 14, 10, 5, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.of(activeSession));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(askChatSessionRepository.save(any(AskChatSession.class))).thenReturn(savedSession);
+
+        var response = service.restartSession(1L);
+
+        verify(activeSession).end();
+        assertThat(response.sessionId()).isEqualTo(11L);
+        assertThat(response.status()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(response.answeredTurnCount()).isZero();
+        assertThat(response.remainingTurnCount()).isEqualTo(15);
+    }
+
+    @Test
+    void restartSession_creates_session_when_active_session_does_not_exist() {
+        User user = mock(User.class);
+        AskChatSession savedSession = session(
+                11L,
+                AskChatSessionStatus.ACTIVE,
+                0,
+                OffsetDateTime.of(2026, 7, 14, 10, 5, 0, 0, ZoneOffset.ofHours(9)),
+                null
+        );
+        when(askChatSessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                1L,
+                AskChatSessionStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(askChatSessionRepository.save(any(AskChatSession.class))).thenReturn(savedSession);
+
+        var response = service.restartSession(1L);
+
+        assertThat(response.sessionId()).isEqualTo(11L);
+        assertThat(response.status()).isEqualTo(AskChatSessionStatus.ACTIVE);
+        assertThat(response.answeredTurnCount()).isZero();
+        assertThat(response.remainingTurnCount()).isEqualTo(15);
+    }
+
     private AskChatSession session(
             Long id,
             AskChatSessionStatus status,

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
@@ -7,6 +7,7 @@ import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
 import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
 import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.global.core.prompt.askchat.AskChatAnswerPromptLoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -16,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AskChatAnswerPromptComposerTest {
 
     @Test
-    void augment_builds_prompt_with_friendly_tone_and_conversation_order_rules() {
-        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
+    void augment_builds_prompt_from_loaded_templates() {
+        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties(), promptLoader());
         AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
                 1L,
                 10L,
@@ -38,12 +39,9 @@ class AskChatAnswerPromptComposerTest {
 
         var prompt = composer.augment(context);
 
-        assertThat(prompt.systemPrompt())
-                .contains("친절하고 편안한 한국어 구어체")
-                .contains("\"당신은\", \"사용자께서는\", \"사용자는\" 같은 딱딱하고 AI스러운 표현은 사용하지 마세요")
-                .contains("[최근 대화]의 마지막 USER 메시지를 기준으로 답하세요")
-                .contains("JSON 형식만 반환");
+        assertThat(prompt.systemPrompt()).isEqualTo("system template");
         assertThat(prompt.userPrompt())
+                .contains("프롬프트 버전: 1")
                 .contains("내가 방금 한 질문은 무엇이지?")
                 .contains("USER: 나는 어떤 사람이야?")
                 .contains("ASSISTANT: 말해준 걸 보면 관계를 중요하게 여기는 편으로 보여요.")
@@ -51,14 +49,18 @@ class AskChatAnswerPromptComposerTest {
                 .contains("ANSWER_ENTRY")
                 .contains("VALUES")
                 .contains("사용자는 기록에서 솔직함과 책임감을 중요하게 말한 적이 있다.")
-                .contains("followUpQuestions는 2개 이하")
-                .contains("최근 대화 목록에는 현재 질문을 포함하지 않았습니다")
-                .contains("최근 대화의 마지막 USER 메시지를 답하세요");
+                .contains("followUpQuestions는 2개 이하");
+        assertThat(prompt.userPrompt())
+                .doesNotContain("{promptVersion}")
+                .doesNotContain("{question}")
+                .doesNotContain("{recentMessages}")
+                .doesNotContain("{referenceDocuments}")
+                .doesNotContain("{followUpQuestionCount}");
     }
 
     @Test
     void augment_marks_empty_context_when_recent_messages_and_reference_documents_are_empty() {
-        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
+        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties(), promptLoader());
         AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
                 1L,
                 10L,
@@ -79,5 +81,33 @@ class AskChatAnswerPromptComposerTest {
         properties.setPromptVersion(1);
         properties.setFollowUpQuestionCount(2);
         return properties;
+    }
+
+    private AskChatAnswerPromptLoader promptLoader() {
+        return new AskChatAnswerPromptLoader() {
+            @Override
+            public String loadSystemPrompt() {
+                return "system template";
+            }
+
+            @Override
+            public String loadUserPrompt() {
+                return """
+                        프롬프트 버전: {promptVersion}
+
+                        [현재 질문]
+                        {question}
+
+                        [최근 대화]
+                        {recentMessages}
+
+                        [검색된 사용자 기록]
+                        {referenceDocuments}
+
+                        [이번 답변에서 지켜야 할 세부 조건]
+                        - followUpQuestions는 {followUpQuestionCount}개 이하
+                        """;
+            }
+        };
     }
 }

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AskChatAnswerPromptComposerTest {
 
     @Test
-    void compose_builds_prompt_with_question_recent_messages_and_reference_documents() {
+    void augment_builds_prompt_with_question_recent_messages_and_reference_documents() {
         AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
         AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
                 1L,
@@ -36,7 +36,7 @@ class AskChatAnswerPromptComposerTest {
                 ))
         );
 
-        var prompt = composer.compose(context);
+        var prompt = composer.augment(context);
 
         assertThat(prompt.systemPrompt()).contains("JSON 형식만 반환");
         assertThat(prompt.userPrompt())
@@ -51,7 +51,7 @@ class AskChatAnswerPromptComposerTest {
     }
 
     @Test
-    void compose_marks_empty_context_when_recent_messages_and_reference_documents_are_empty() {
+    void augment_marks_empty_context_when_recent_messages_and_reference_documents_are_empty() {
         AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
         AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
                 1L,
@@ -61,7 +61,7 @@ class AskChatAnswerPromptComposerTest {
                 null
         );
 
-        var prompt = composer.compose(context);
+        var prompt = composer.augment(context);
 
         assertThat(prompt.userPrompt())
                 .contains("최근 대화가 없습니다.")

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
@@ -16,38 +16,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AskChatAnswerPromptComposerTest {
 
     @Test
-    void augment_builds_prompt_with_question_recent_messages_and_reference_documents() {
+    void augment_builds_prompt_with_friendly_tone_and_conversation_order_rules() {
         AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
         AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
                 1L,
                 10L,
-                "나는 어떤 사람에 가까워?",
+                "내가 방금 한 질문은 무엇이지?",
                 List.of(
-                        new AskChatAnswerConversationMessage(AskChatMessageRole.USER, "내 강점은 뭐야?"),
-                        new AskChatAnswerConversationMessage(AskChatMessageRole.ASSISTANT, "꾸준함이 보여요.")
+                        new AskChatAnswerConversationMessage(AskChatMessageRole.USER, "나는 어떤 사람이야?"),
+                        new AskChatAnswerConversationMessage(AskChatMessageRole.ASSISTANT, "말해준 걸 보면 관계를 중요하게 여기는 편으로 보여요.")
                 ),
                 List.of(new AskChatAnswerReferenceDocument(
                         100L,
                         AskChatRagDocumentSourceType.ANSWER_ENTRY,
                         200L,
                         InterestCode.VALUES,
-                        "사용자는 기록에서 꾸준함과 책임감을 중요하게 말했다.",
+                        "사용자는 기록에서 솔직함과 책임감을 중요하게 말한 적이 있다.",
                         0.18
                 ))
         );
 
         var prompt = composer.augment(context);
 
-        assertThat(prompt.systemPrompt()).contains("JSON 형식만 반환");
+        assertThat(prompt.systemPrompt())
+                .contains("친절하고 편안한 한국어 구어체")
+                .contains("\"당신은\", \"사용자께서는\", \"사용자는\" 같은 딱딱하고 AI스러운 표현은 사용하지 마세요")
+                .contains("[최근 대화]의 마지막 USER 메시지를 기준으로 답하세요")
+                .contains("JSON 형식만 반환");
         assertThat(prompt.userPrompt())
-                .contains("나는 어떤 사람에 가까워?")
-                .contains("USER: 내 강점은 뭐야?")
-                .contains("ASSISTANT: 꾸준함이 보여요.")
+                .contains("내가 방금 한 질문은 무엇이지?")
+                .contains("USER: 나는 어떤 사람이야?")
+                .contains("ASSISTANT: 말해준 걸 보면 관계를 중요하게 여기는 편으로 보여요.")
                 .contains("documentId=100")
                 .contains("ANSWER_ENTRY")
                 .contains("VALUES")
-                .contains("사용자는 기록에서 꾸준함과 책임감을 중요하게 말했다.")
-                .contains("followUpQuestions는 2개 이하");
+                .contains("사용자는 기록에서 솔직함과 책임감을 중요하게 말한 적이 있다.")
+                .contains("followUpQuestions는 2개 이하")
+                .contains("최근 대화 목록에는 현재 질문을 포함하지 않았습니다")
+                .contains("최근 대화의 마지막 USER 메시지를 답하세요");
     }
 
     @Test

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/helper/AskChatAnswerPromptComposerTest.java
@@ -1,0 +1,77 @@
+package com.devkor.ifive.nadab.domain.askchat.application.helper;
+
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerConversationMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageRole;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AskChatAnswerPromptComposerTest {
+
+    @Test
+    void compose_builds_prompt_with_question_recent_messages_and_reference_documents() {
+        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
+        AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
+                1L,
+                10L,
+                "나는 어떤 사람에 가까워?",
+                List.of(
+                        new AskChatAnswerConversationMessage(AskChatMessageRole.USER, "내 강점은 뭐야?"),
+                        new AskChatAnswerConversationMessage(AskChatMessageRole.ASSISTANT, "꾸준함이 보여요.")
+                ),
+                List.of(new AskChatAnswerReferenceDocument(
+                        100L,
+                        AskChatRagDocumentSourceType.ANSWER_ENTRY,
+                        200L,
+                        InterestCode.VALUES,
+                        "사용자는 기록에서 꾸준함과 책임감을 중요하게 말했다.",
+                        0.18
+                ))
+        );
+
+        var prompt = composer.compose(context);
+
+        assertThat(prompt.systemPrompt()).contains("JSON 형식만 반환");
+        assertThat(prompt.userPrompt())
+                .contains("나는 어떤 사람에 가까워?")
+                .contains("USER: 내 강점은 뭐야?")
+                .contains("ASSISTANT: 꾸준함이 보여요.")
+                .contains("documentId=100")
+                .contains("ANSWER_ENTRY")
+                .contains("VALUES")
+                .contains("사용자는 기록에서 꾸준함과 책임감을 중요하게 말했다.")
+                .contains("followUpQuestions는 2개 이하");
+    }
+
+    @Test
+    void compose_marks_empty_context_when_recent_messages_and_reference_documents_are_empty() {
+        AskChatAnswerPromptComposer composer = new AskChatAnswerPromptComposer(properties());
+        AskChatAnswerPromptContext context = new AskChatAnswerPromptContext(
+                1L,
+                10L,
+                "요즘 내가 반복하는 패턴이 있어?",
+                null,
+                null
+        );
+
+        var prompt = composer.compose(context);
+
+        assertThat(prompt.userPrompt())
+                .contains("최근 대화가 없습니다.")
+                .contains("검색된 사용자 기록이 없습니다.");
+    }
+
+    private AskChatAnswerProperties properties() {
+        AskChatAnswerProperties properties = new AskChatAnswerProperties();
+        properties.setPromptVersion(1);
+        properties.setFollowUpQuestionCount(2);
+        return properties;
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepositoryTest.java
@@ -41,6 +41,7 @@ class AskChatMessageReferenceRepositoryTest extends PostgresIntegrationTestSuppo
                 null,
                 null,
                 null,
+                null,
                 null
         ));
         AskChatRagDocument firstDocument = persistRagDocument(user, 1L);

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatMessageReferenceRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.devkor.ifive.nadab.domain.askchat.core.repository;
+
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessage;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageReference;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
+import com.devkor.ifive.nadab.infra.db.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AskChatMessageReferenceRepositoryTest extends PostgresIntegrationTestSupport {
+
+    @Autowired
+    private AskChatMessageReferenceRepository askChatMessageReferenceRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findAllByMessageIdOrderByDisplayOrderAsc_returns_references_in_prompt_order() {
+        User user = persistUser("message-reference@test.com");
+        AskChatSession session = em.persistAndFlush(AskChatSession.start(user));
+        AskChatMessage assistantMessage = em.persistAndFlush(AskChatMessage.createAssistantMessage(
+                session,
+                "answer",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        ));
+        AskChatRagDocument firstDocument = persistRagDocument(user, 1L);
+        AskChatRagDocument secondDocument = persistRagDocument(user, 2L);
+        askChatMessageReferenceRepository.save(AskChatMessageReference.of(
+                assistantMessage,
+                secondDocument,
+                2
+        ));
+        askChatMessageReferenceRepository.save(AskChatMessageReference.of(
+                assistantMessage,
+                firstDocument,
+                1
+        ));
+        em.flush();
+        em.clear();
+
+        List<AskChatMessageReference> references =
+                askChatMessageReferenceRepository.findAllByMessageIdOrderByDisplayOrderAsc(assistantMessage.getId());
+
+        assertThat(references)
+                .extracting(AskChatMessageReference::getDisplayOrder)
+                .containsExactly(1, 2);
+        assertThat(references)
+                .extracting(reference -> reference.getRagDocument().getId())
+                .containsExactly(firstDocument.getId(), secondDocument.getId());
+    }
+
+    private User persistUser(String email) {
+        User user = User.createUser(email, "hashed");
+        user.updateNickname(email.substring(0, email.indexOf('@')));
+        return em.persistAndFlush(user);
+    }
+
+    private AskChatRagDocument persistRagDocument(User user, Long sourceId) {
+        AskChatRagDocument document = AskChatRagDocument.createPending(
+                user,
+                AskChatRagDocumentSourceType.ANSWER_ENTRY,
+                sourceId,
+                InterestCode.RELATIONSHIP,
+                "content " + sourceId,
+                Map.of(),
+                "text-embedding-3-small",
+                1
+        );
+        document.markCompleted();
+        return em.persistAndFlush(document);
+    }
+}

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagRepositoryIntegrationTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatRagRepositoryIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.devkor.ifive.nadab.domain.askchat.core.repository;
 
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatRagBackfillTargetDto;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatRagSearchResultDto;
 import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
 import com.devkor.ifive.nadab.infra.db.PostgresIntegrationTestSupport;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,40 @@ class AskChatRagRepositoryIntegrationTest extends PostgresIntegrationTestSupport
         assertThat(findDocumentStatus(failedDocumentId)).isEqualTo("FAILED");
         assertThat(findRetryCount(failedDocumentId)).isEqualTo(1);
         assertThat(hasEmbedding(completedDocumentId)).isTrue();
+    }
+
+    @Test
+    void search_returns_completed_documents_when_interest_filter_is_null() {
+        Long userId = insertUser("vector-search");
+        Long relationshipDocumentId = insertRagDocument(
+                userId,
+                "ANSWER_ENTRY",
+                2000L,
+                InterestCode.RELATIONSHIP,
+                1,
+                "PENDING"
+        );
+        Long routineDocumentId = insertRagDocument(
+                userId,
+                "ANSWER_ENTRY",
+                2001L,
+                InterestCode.ROUTINE,
+                1,
+                "PENDING"
+        );
+        vectorRepository.updateEmbedding(relationshipDocumentId, embedding(1536));
+        vectorRepository.updateEmbedding(routineDocumentId, embedding(1536));
+
+        var results = vectorRepository.search(
+                userId,
+                null,
+                embedding(1536),
+                10
+        );
+
+        assertThat(results)
+                .extracting(AskChatRagSearchResultDto::documentId)
+                .containsExactlyInAnyOrder(relationshipDocumentId, routineDocumentId);
     }
 
     private Long insertUser(String prefix) {

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/core/repository/AskChatSessionRepositoryTest.java
@@ -36,7 +36,8 @@ class AskChatSessionRepositoryTest extends PostgresIntegrationTestSupport {
                 "답변 생성에 실패했습니다.",
                 null,
                 null,
-                "TEST_ERROR"
+                "TEST_ERROR",
+                120L
         ));
         AskChatSession firstHistory = persistSession(user);
         persistMessage(AskChatMessage.createUserMessage(firstHistory, "나는 어떤 사람이야?"));

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClientTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClientTest.java
@@ -1,6 +1,6 @@
 package com.devkor.ifive.nadab.domain.askchat.infra;
 
-import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposer;
+import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptAugmenter;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
 import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 class AskChatAnswerLlmClientTest {
 
     @Mock
-    private AskChatAnswerPromptComposer promptComposer;
+    private AskChatAnswerPromptAugmenter promptAugmenter;
 
     @Mock
     private LlmRouter llmRouter;
@@ -64,13 +64,13 @@ class AskChatAnswerLlmClientTest {
         properties.setMaxTokens(700);
         properties.setFollowUpQuestionCount(2);
         objectMapper = new ObjectMapper();
-        client = new AskChatAnswerLlmClient(promptComposer, properties, llmRouter, objectMapper);
+        client = new AskChatAnswerLlmClient(promptAugmenter, properties, llmRouter, objectMapper);
     }
 
     @Test
     void generate_returns_answer_with_token_usage_and_reference_document_ids() throws Exception {
         AskChatAnswerPromptContext context = context();
-        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(promptAugmenter.augment(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
         when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
         when(chatClient.prompt()).thenReturn(requestSpec);
         when(requestSpec.system("system")).thenReturn(requestSpec);
@@ -100,7 +100,7 @@ class AskChatAnswerLlmClientTest {
     @Test
     void generate_throws_parse_exception_when_response_is_not_json() {
         AskChatAnswerPromptContext context = context();
-        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(promptAugmenter.augment(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
         when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
         when(chatClient.prompt()).thenReturn(requestSpec);
         when(requestSpec.system("system")).thenReturn(requestSpec);
@@ -117,7 +117,7 @@ class AskChatAnswerLlmClientTest {
     @Test
     void generate_throws_format_exception_when_answer_is_blank() throws Exception {
         AskChatAnswerPromptContext context = context();
-        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(promptAugmenter.augment(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
         when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
         when(chatClient.prompt()).thenReturn(requestSpec);
         when(requestSpec.system("system")).thenReturn(requestSpec);
@@ -137,7 +137,7 @@ class AskChatAnswerLlmClientTest {
     @Test
     void generate_throws_unavailable_exception_when_response_is_empty() {
         AskChatAnswerPromptContext context = context();
-        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(promptAugmenter.augment(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
         when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
         when(chatClient.prompt()).thenReturn(requestSpec);
         when(requestSpec.system("system")).thenReturn(requestSpec);

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClientTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/infra/AskChatAnswerLlmClientTest.java
@@ -1,0 +1,179 @@
+package com.devkor.ifive.nadab.domain.askchat.infra;
+
+import com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposer;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPrompt;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerPromptContext;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatAnswerReferenceDocument;
+import com.devkor.ifive.nadab.domain.askchat.core.dto.AskChatGeneratedAnswer;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocumentSourceType;
+import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
+import com.devkor.ifive.nadab.domain.user.core.entity.InterestCode;
+import com.devkor.ifive.nadab.global.core.response.ErrorCode;
+import com.devkor.ifive.nadab.global.exception.ai.AiResponseParseException;
+import com.devkor.ifive.nadab.global.exception.ai.AiServiceUnavailableException;
+import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
+import com.devkor.ifive.nadab.global.infra.llm.LlmRouter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AskChatAnswerLlmClientTest {
+
+    @Mock
+    private AskChatAnswerPromptComposer promptComposer;
+
+    @Mock
+    private LlmRouter llmRouter;
+
+    @Mock
+    private ChatClient chatClient;
+
+    @Mock
+    private ChatClient.ChatClientRequestSpec requestSpec;
+
+    @Mock
+    private ChatClient.CallResponseSpec callResponseSpec;
+
+    private AskChatAnswerProperties properties;
+    private AskChatAnswerLlmClient client;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AskChatAnswerProperties();
+        properties.setProvider(LlmProvider.OPENAI);
+        properties.setModel("gpt-4o-mini");
+        properties.setTemperature(0.3);
+        properties.setMaxTokens(700);
+        properties.setFollowUpQuestionCount(2);
+        objectMapper = new ObjectMapper();
+        client = new AskChatAnswerLlmClient(promptComposer, properties, llmRouter, objectMapper);
+    }
+
+    @Test
+    void generate_returns_answer_with_token_usage_and_reference_document_ids() throws Exception {
+        AskChatAnswerPromptContext context = context();
+        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system("system")).thenReturn(requestSpec);
+        when(requestSpec.user("user")).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse(
+                objectMapper.writeValueAsString(new AskChatGeneratedAnswer(
+                        "꾸준함이 강점으로 보여요.",
+                        List.of("언제 꾸준함이 가장 잘 드러났나요?", "요즘 지키고 싶은 루틴은 무엇인가요?")
+                )),
+                new DefaultUsage(100, 50, 150)
+        ));
+
+        var result = client.generate(context);
+
+        assertThat(result.answer().answer()).isEqualTo("꾸준함이 강점으로 보여요.");
+        assertThat(result.answer().followUpQuestions()).hasSize(2);
+        assertThat(result.provider()).isEqualTo(LlmProvider.OPENAI);
+        assertThat(result.model()).isEqualTo("gpt-4o-mini");
+        assertThat(result.tokenUsage().inputTokens()).isEqualTo(100L);
+        assertThat(result.tokenUsage().outputTokens()).isEqualTo(50L);
+        assertThat(result.tokenUsage().totalTokens()).isEqualTo(150L);
+        assertThat(result.referenceDocumentIds()).containsExactly(100L);
+    }
+
+    @Test
+    void generate_throws_parse_exception_when_response_is_not_json() {
+        AskChatAnswerPromptContext context = context();
+        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system("system")).thenReturn(requestSpec);
+        when(requestSpec.user("user")).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse("not-json", new DefaultUsage(1, 1, 2)));
+
+        assertThatThrownBy(() -> client.generate(context))
+                .isInstanceOfSatisfying(AiResponseParseException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_PARSE_FAILED));
+    }
+
+    @Test
+    void generate_throws_format_exception_when_answer_is_blank() throws Exception {
+        AskChatAnswerPromptContext context = context();
+        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system("system")).thenReturn(requestSpec);
+        when(requestSpec.user("user")).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse(
+                objectMapper.writeValueAsString(new AskChatGeneratedAnswer(" ", List.of())),
+                new DefaultUsage(1, 1, 2)
+        ));
+
+        assertThatThrownBy(() -> client.generate(context))
+                .isInstanceOfSatisfying(AiResponseParseException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_FORMAT_INVALID));
+    }
+
+    @Test
+    void generate_throws_unavailable_exception_when_response_is_empty() {
+        AskChatAnswerPromptContext context = context();
+        when(promptComposer.compose(context)).thenReturn(new AskChatAnswerPrompt("system", "user"));
+        when(llmRouter.route(LlmProvider.OPENAI)).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system("system")).thenReturn(requestSpec);
+        when(requestSpec.user("user")).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse("", new DefaultUsage(1, 1, 2)));
+
+        assertThatThrownBy(() -> client.generate(context))
+                .isInstanceOfSatisfying(AiServiceUnavailableException.class, ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.AI_NO_RESPONSE));
+    }
+
+    private AskChatAnswerPromptContext context() {
+        return new AskChatAnswerPromptContext(
+                1L,
+                10L,
+                "나는 어떤 사람에 가까워?",
+                List.of(),
+                List.of(new AskChatAnswerReferenceDocument(
+                        100L,
+                        AskChatRagDocumentSourceType.ANSWER_ENTRY,
+                        200L,
+                        InterestCode.VALUES,
+                        "사용자는 꾸준함을 중요하게 말했다.",
+                        0.1
+                ))
+        );
+    }
+
+    private ChatResponse chatResponse(String content, DefaultUsage usage) {
+        return new ChatResponse(
+                List.of(new Generation(new AssistantMessage(content))),
+                ChatResponseMetadata.builder()
+                        .usage(usage)
+                        .build()
+        );
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,6 +17,14 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: off
 
 ask-chat:
+  answer:
+    provider: OPENAI
+    model: gpt-4o-mini
+    temperature: 0.3
+    max-tokens: 700
+    recent-message-limit: 10
+    follow-up-question-count: 2
+    prompt-version: 1
   rag:
     embedding-retry-enabled: false
     embedding-retry-fixed-delay-ms: 60000


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- Ask Chat 질문 전송 시 최근 대화 맥락과 사용자 RAG 기록을 바탕으로 AI 답변을 생성하고, USER/ASSISTANT 메시지와 사용 근거 문서를 저장하도록 구현했습니다.
- 답변 품질 개선을 위해 프롬프트 계약을 고도화하고, report 도메인과 유사하게 PromptLoader 기반으로 프롬프트 원문 관리 책임을 분리했습니다.
- “새로운 대화로 시작하기” API와 답변 생성 소요 시간 기록, dev/prod 배포 환경 변수 주입까지 포함해 Ask Chat 답변 생성 기능을 운영 가능한 형태로 정리했습니다.

### 주요 변경사항
- **RAG 답변 생성**
  - 최근 세션 메시지와 RAG 검색 결과를 조합하는 `AskChatAnswerContextService` 추가
  - Spring AI `ChatClient` 기반 `AskChatAnswerLlmClient` 추가
  - AI 응답 JSON 파싱 및 `answer`, `followUpQuestions` 반환 처리
  - provider/model/token usage를 ASSISTANT 메시지에 저장

- **질문 전송 플로우**
  - `POST /ask-chat/messages`에서 USER 메시지 저장 후 AI 답변 생성 및 ASSISTANT 메시지 저장 연결
  - 답변 생성 실패 시 FAILED ASSISTANT 메시지 저장
  - 성공한 답변에 대해서만 `answeredTurnCount` 증가
  - RAG 검색 SQL의 nullable `interestCode` 타입 추론 오류 보정

- **근거 문서와 운영 지표**
  - `ask_chat_message_references` 테이블 및 엔티티/레포지토리 추가
  - 답변 생성에 사용된 RAG document id를 assistant message와 displayOrder로 매핑
  - `ask_chat_messages.generation_duration_ms` 컬럼 추가
  - RAG 컨텍스트 구성부터 LLM 답변 생성까지의 소요 시간을 ASSISTANT 메시지에 기록

- **프롬프트 품질 및 관리 구조**
  - 답변 말투, 직전 질문 참조, 후속 질문 화자, 현재 질문 중복 방지 규칙 보강
  - `AskChatAnswerPromptLoader` 인터페이스 추가
  - local/dev/prod용 PromptLoader 구현체 추가
  - `AskChatAnswerPromptComposer`는 템플릿 치환과 컨텍스트 직렬화만 담당하도록 책임 분리

- **세션 API**
  - `POST /ask-chat/sessions/new` 추가
  - 기존 ACTIVE 세션을 ENDED로 종료하고 새 ACTIVE 세션 생성
  - 기존 메시지는 삭제하지 않고 히스토리 조회 가능 상태로 보존

- **배포/설정**
  - Ask Chat 답변 생성 설정을 `application.yml`, `application-test.yml`에 추가
  - dev/prod GitHub Actions 배포 워크플로우에 `ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64`, `ASK_CHAT_ANSWER_USER_PROMPT_B64` 디코딩 및 export 추가

- **테스트**
  - 답변 컨텍스트 구성 테스트 추가
  - LLM 응답 파싱/검증 테스트 추가
  - 질문 전송 성공/실패/턴 제한/생성 소요 시간 기록 테스트 보강
  - 근거 문서 매핑 repository 테스트 추가
  - 프롬프트 템플릿 치환 테스트 추가
  - 새 대화 시작 세션 테스트 추가

### 검증
- `./gradlew.bat compileJava`
- `./gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposerTest" --tests "com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClientTest"`
- `./gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatSessionServiceTest" --tests "com.devkor.ifive.nadab.domain.askchat.application.helper.AskChatAnswerPromptComposerTest" --tests "com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClientTest"`
- `./gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatMessageCommandServiceTest" --tests "com.devkor.ifive.nadab.domain.askchat.application.AskChatAnswerContextServiceTest"`
- `./gradlew.bat test --tests "com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageReferenceRepositoryTest" --tests "com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepositoryTest"`
- `git diff --check`

### 참고 / 리스크
- dev/prod 배포 전 GitHub environment secrets에 `ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64`, `ASK_CHAT_ANSWER_USER_PROMPT_B64` 등록이 필요하여 등록할 예정입니다.
- local 프롬프트 파일은 기존 report 프롬프트와 동일하게 `src/main/resources/secret/` 아래에서 관리되며 git 추적 대상이 아닙니다.
- 이 PR부터 Ask Chat 질문 전송 경로에서 외부 LLM API 호출이 발생합니다.

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.