### PR TITLE
fix(report): 월간 리포트 V2 조회 응답 보정

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
@@ -251,6 +251,7 @@ public class MonthlyReportControllerV2 {
                     socialSummary.likeRanking : 내 DailyReport에 좋아요를 많이 누른 친구 최대 3명 </br>
                     socialSummary.commentRanking : 내 DailyReport에 댓글·대댓글을 많이 작성한 친구 최대 3명 </br>
                     - displayOrder : 화면 표시 순서(1~3) </br>
+                    - rank : 동점 처리가 반영된 실제 표시 순위(예: 1, 1, 3 또는 1, 2, 2) </br>
                     - userId : 친구 사용자 ID </br>
                     - nickname : 친구 닉네임 </br>
                     - profileImageUrl : 친구 프로필 이미지 URL </br>

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/MonthlyReportControllerV2.java
@@ -159,10 +159,10 @@ public class MonthlyReportControllerV2 {
     @Operation(
             summary = "나의 월간 리포트 조회 V2",
             description = """
-                    사용자의 지난달·지지난달 월간 리포트 위치 정보를 조회합니다. </br>
+                    사용자의 현재 조회 대상 월간 리포트와 존재하는 직전 완료 리포트 위치 정보를 조회합니다. </br>
                     
                     report: 지난달 리포트이며 존재하지 않으면 null입니다. </br>
-                    previousReport: 지지난달 완료 리포트이며 존재하지 않으면 null입니다. </br>
+                    previousReport: 존재하는 직전 완료 리포트이며 존재하지 않으면 null입니다. </br>
                     두 슬롯은 서로 독립적으로 null일 수 있습니다. </br>
                     각 항목은 reportId, version, month, status를 반환합니다. </br>
                     report.status: PENDING | IN_PROGRESS | TEXT_COMPLETED | COMPLETED | FAILED </br>

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/MonthlySocialRankingItemResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/api/dto/response/MonthlySocialRankingItemResponse.java
@@ -6,6 +6,9 @@ public record MonthlySocialRankingItemResponse(
         @Schema(description = "화면 표시 순서", example = "1")
         int displayOrder,
 
+        @Schema(description = "동점 처리가 반영된 실제 표시 순위", example = "1")
+        int rank,
+
         @Schema(description = "친구 사용자 ID", example = "12")
         Long userId,
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportLocatorResolver.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportLocatorResolver.java
@@ -41,6 +41,31 @@ public class MonthlyReportLocatorResolver {
                         .map(this::toLocatorResponse));
     }
 
+    public Optional<MonthlyReportLocatorResponse> findLatestCompletedBefore(Long userId, LocalDate monthStartDate) {
+        Optional<MonthlyReportV2> v2Report = monthlyReportV2Repository
+                .findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                        userId,
+                        MonthlyReportStatus.COMPLETED,
+                        monthStartDate
+                );
+        Optional<MonthlyReport> v1Report = monthlyReportRepository
+                .findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                        userId,
+                        MonthlyReportStatus.COMPLETED,
+                        monthStartDate
+                );
+
+        if (v2Report.isPresent() && v1Report.isPresent()) {
+            if (v2Report.get().getMonthStartDate().isAfter(v1Report.get().getMonthStartDate())) {
+                return v2Report.map(this::toLocatorResponse);
+            }
+            return v1Report.map(this::toLocatorResponse);
+        }
+
+        return v2Report.map(this::toLocatorResponse)
+                .or(() -> v1Report.map(this::toLocatorResponse));
+    }
+
     private MonthlyReportLocatorResponse toLocatorResponse(MonthlyReportV2 report) {
         return new MonthlyReportLocatorResponse(
                 report.getId(),

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
@@ -217,6 +217,7 @@ public class MonthlyReportQueryServiceV2 {
 
         return new MonthlySocialRankingItemResponse(
                 item.displayOrder(),
+                item.rank(),
                 item.userId(),
                 item.nickname(),
                 profileImageUrl,

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2.java
@@ -155,11 +155,8 @@ public class MonthlyReportQueryServiceV2 {
         MonthlyReportLocatorResponse report = monthlyReportLocatorResolver
                 .findByMonth(userId, range.monthStartDate())
                 .orElse(null);
-        MonthRangeDto previousRange = MonthRangeCalculator.monthRangeOf(
-                range.monthStartDate().minusMonths(1)
-        );
         MonthlyReportLocatorResponse previousReport = monthlyReportLocatorResolver
-                .findCompletedByMonth(userId, previousRange.monthStartDate())
+                .findLatestCompletedBefore(userId, range.monthStartDate())
                 .orElse(null);
 
         return new MyMonthlyReportLookupResponseV2(report, previousReport);

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/helper/MonthlySocialSummaryCalculator.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/application/helper/MonthlySocialSummaryCalculator.java
@@ -79,17 +79,33 @@ public final class MonthlySocialSummaryCalculator {
         long topCount = sorted.getFirst().interactionCount();
 
         return java.util.stream.IntStream.range(0, sorted.size())
-                .mapToObj(index -> toRankingItem(sorted.get(index), index + 1, topCount))
+                .mapToObj(index -> toRankingItem(sorted.get(index), index + 1, rankAt(sorted, index), topCount))
                 .toList();
+    }
+
+    private static int rankAt(List<MonthlySocialInteractionCountDto> sorted, int index) {
+        if (index == 0) {
+            return 1;
+        }
+
+        MonthlySocialInteractionCountDto current = sorted.get(index);
+        MonthlySocialInteractionCountDto previous = sorted.get(index - 1);
+        if (current.interactionCount() == previous.interactionCount()) {
+            return rankAt(sorted, index - 1);
+        }
+
+        return index + 1;
     }
 
     private static MonthlySocialRankingItem toRankingItem(
             MonthlySocialInteractionCountDto item,
             int displayOrder,
+            int rank,
             long topCount
     ) {
         return new MonthlySocialRankingItem(
                 displayOrder,
+                rank,
                 item.userId(),
                 normalizeNickname(item.nickname()),
                 item.profileImageKey(),

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/content/MonthlySocialRankingItem.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/content/MonthlySocialRankingItem.java
@@ -4,6 +4,7 @@ import com.devkor.ifive.nadab.domain.user.core.entity.DefaultProfileType;
 
 public record MonthlySocialRankingItem(
         int displayOrder,
+        int rank,
         Long userId,
         String nickname,
         String profileImageKey,
@@ -13,6 +14,7 @@ public record MonthlySocialRankingItem(
     public MonthlySocialRankingItem normalized() {
         return new MonthlySocialRankingItem(
                 Math.max(1, displayOrder),
+                Math.max(1, rank),
                 userId,
                 nickname == null ? "" : nickname.trim(),
                 profileImageKey,

--- a/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/repository/MonthlyReportRepository.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/monthlyreport/core/repository/MonthlyReportRepository.java
@@ -21,6 +21,12 @@ public interface MonthlyReportRepository extends JpaRepository<MonthlyReport, Lo
             MonthlyReportStatus status
     );
 
+    Optional<MonthlyReport> findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+            Long userId,
+            MonthlyReportStatus status,
+            LocalDate monthStartDate
+    );
+
     List<MonthlyReport> findAllByUserIdAndStatus(Long userId, MonthlyReportStatus status);
 
     /**

--- a/src/main/resources/db/migration/V20260725_1200__IS_update_relationship_interest_name.sql
+++ b/src/main/resources/db/migration/V20260725_1200__IS_update_relationship_interest_name.sql
@@ -1,0 +1,3 @@
+UPDATE interests
+SET name = '관계'
+WHERE code = 'RELATIONSHIP';

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/MonthlyReportV2RepositoryTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/MonthlyReportV2RepositoryTest.java
@@ -70,10 +70,10 @@ class MonthlyReportV2RepositoryTest extends PostgresIntegrationTestSupport {
                 true,
                 5,
                 List.of(
-                        new MonthlySocialRankingItem(1, 10L, "가", null, null, true),
-                        new MonthlySocialRankingItem(2, 11L, "나", null, null, true)
+                        new MonthlySocialRankingItem(1, 1, 10L, "가", null, null, true),
+                        new MonthlySocialRankingItem(2, 1, 11L, "나", null, null, true)
                 ),
-                List.of(new MonthlySocialRankingItem(1, 12L, "다", null, null, true))
+                List.of(new MonthlySocialRankingItem(1, 1, 12L, "다", null, null, true))
         ));
         em.flush();
         em.clear();
@@ -207,7 +207,7 @@ class MonthlyReportV2RepositoryTest extends PostgresIntegrationTestSupport {
                 "{\"totalCount\":10,\"dominantEmotionCode\":\"ACHIEVEMENT\",\"positivePercent\":71,\"emotions\":[]}",
                 "{\"interests\":[]}",
                 emotionComparisonJson,
-                "{\"visible\":true,\"month\":5,\"likeRanking\":[{\"displayOrder\":1,\"userId\":10,\"nickname\":\"가\",\"profileImageKey\":null,\"defaultProfileType\":null,\"topRank\":true}],\"commentRanking\":[{\"displayOrder\":1,\"userId\":11,\"nickname\":\"나\",\"profileImageKey\":null,\"defaultProfileType\":null,\"topRank\":true}]}",
+                "{\"visible\":true,\"month\":5,\"likeRanking\":[{\"displayOrder\":1,\"rank\":1,\"userId\":10,\"nickname\":\"가\",\"profileImageKey\":null,\"defaultProfileType\":null,\"topRank\":true}],\"commentRanking\":[{\"displayOrder\":1,\"rank\":1,\"userId\":11,\"nickname\":\"나\",\"profileImageKey\":null,\"defaultProfileType\":null,\"topRank\":true}]}",
                 MonthlyReportStatus.TEXT_COMPLETED.name()
         );
     }

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportLocatorResolverTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportLocatorResolverTest.java
@@ -91,11 +91,61 @@ class MonthlyReportLocatorResolverTest {
         );
     }
 
+    @Test
+    void resolves_latest_previous_completed_report_across_v1_and_v2() {
+        LocalDate currentMonthStartDate = LocalDate.of(2026, 6, 1);
+        MonthlyReportV2 v2Report = v2ReportWithMonthStartDate(LocalDate.of(2026, 4, 1));
+        MonthlyReport v1Report = v1Report(10L, LocalDate.of(2026, 5, 1), MonthlyReportStatus.COMPLETED);
+        when(monthlyReportV2Repository.findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                1L, MonthlyReportStatus.COMPLETED, currentMonthStartDate
+        )).thenReturn(Optional.of(v2Report));
+        when(monthlyReportRepository.findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                1L, MonthlyReportStatus.COMPLETED, currentMonthStartDate
+        )).thenReturn(Optional.of(v1Report));
+
+        Optional<MonthlyReportLocatorResponse> result = resolver.findLatestCompletedBefore(1L, currentMonthStartDate);
+
+        assertThat(result).contains(new MonthlyReportLocatorResponse(
+                10L, 1, 5, MonthlyReportStatus.COMPLETED
+        ));
+    }
+
+    @Test
+    void resolves_v2_when_it_is_latest_previous_completed_report() {
+        LocalDate currentMonthStartDate = LocalDate.of(2026, 6, 1);
+        MonthlyReportV2 v2Report = v2Report(20L, LocalDate.of(2026, 5, 1), MonthlyReportStatus.COMPLETED);
+        MonthlyReport v1Report = v1ReportWithMonthStartDate(LocalDate.of(2026, 4, 1));
+        when(monthlyReportV2Repository.findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                1L, MonthlyReportStatus.COMPLETED, currentMonthStartDate
+        )).thenReturn(Optional.of(v2Report));
+        when(monthlyReportRepository.findFirstByUserIdAndStatusAndMonthStartDateBeforeOrderByMonthStartDateDesc(
+                1L, MonthlyReportStatus.COMPLETED, currentMonthStartDate
+        )).thenReturn(Optional.of(v1Report));
+
+        Optional<MonthlyReportLocatorResponse> result = resolver.findLatestCompletedBefore(1L, currentMonthStartDate);
+
+        assertThat(result).contains(new MonthlyReportLocatorResponse(
+                20L, 2, 5, MonthlyReportStatus.COMPLETED
+        ));
+    }
+
+    private MonthlyReportV2 v2ReportWithMonthStartDate(LocalDate monthStartDate) {
+        MonthlyReportV2 report = mock(MonthlyReportV2.class);
+        when(report.getMonthStartDate()).thenReturn(monthStartDate);
+        return report;
+    }
+
     private MonthlyReportV2 v2Report(Long id, LocalDate monthStartDate, MonthlyReportStatus status) {
         MonthlyReportV2 report = mock(MonthlyReportV2.class);
         when(report.getId()).thenReturn(id);
         when(report.getMonthStartDate()).thenReturn(monthStartDate);
         when(report.getStatus()).thenReturn(status);
+        return report;
+    }
+
+    private MonthlyReport v1ReportWithMonthStartDate(LocalDate monthStartDate) {
+        MonthlyReport report = mock(MonthlyReport.class);
+        when(report.getMonthStartDate()).thenReturn(monthStartDate);
         return report;
     }
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
@@ -199,18 +199,18 @@ class MonthlyReportQueryServiceV2Test {
     }
 
     @Test
-    void 현재와_지지난달_월간_리포트_위치_정보를_반환한다() {
+    void 현재와_존재하는_직전_월간_리포트_위치_정보를_반환한다() {
         when(userRepository.existsById(1L)).thenReturn(true);
         LocalDate currentMonth = MonthRangeCalculator.getLastMonthRange().monthStartDate();
-        LocalDate previousMonth = MonthRangeCalculator.getTwoMonthsAgoRange().monthStartDate();
+        LocalDate latestPreviousMonth = currentMonth.minusMonths(2);
         MonthlyReportLocatorResponse current = new MonthlyReportLocatorResponse(
                 20L, 2, currentMonth.getMonthValue(), MonthlyReportStatus.IN_PROGRESS
         );
         MonthlyReportLocatorResponse previous = new MonthlyReportLocatorResponse(
-                10L, 1, previousMonth.getMonthValue(), MonthlyReportStatus.COMPLETED
+                10L, 1, latestPreviousMonth.getMonthValue(), MonthlyReportStatus.COMPLETED
         );
         when(monthlyReportLocatorResolver.findByMonth(1L, currentMonth)).thenReturn(Optional.of(current));
-        when(monthlyReportLocatorResolver.findCompletedByMonth(1L, previousMonth))
+        when(monthlyReportLocatorResolver.findLatestCompletedBefore(1L, currentMonth))
                 .thenReturn(Optional.of(previous));
 
         var response = service.getMyMonthlyReport(1L);
@@ -233,7 +233,7 @@ class MonthlyReportQueryServiceV2Test {
         );
         when(monthlyReportLocatorResolver.findByMonth(1L, LocalDate.of(2026, 1, 1)))
                 .thenReturn(Optional.of(current));
-        when(monthlyReportLocatorResolver.findCompletedByMonth(1L, LocalDate.of(2025, 12, 1)))
+        when(monthlyReportLocatorResolver.findLatestCompletedBefore(1L, LocalDate.of(2026, 1, 1)))
                 .thenReturn(Optional.of(previous));
 
         var response = service.getMyMonthlyReport(1L, january);

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/MonthlyReportQueryServiceV2Test.java
@@ -274,8 +274,8 @@ class MonthlyReportQueryServiceV2Test {
         MonthlySocialSummaryContent socialSummary = new MonthlySocialSummaryContent(
                 true,
                 5,
-                List.of(new MonthlySocialRankingItem(1, 2L, "가", "custom-key", null, true)),
-                List.of(new MonthlySocialRankingItem(1, 3L, "나", null, DefaultProfileType.DEFAULT, true))
+                List.of(new MonthlySocialRankingItem(1, 1, 2L, "가", "custom-key", null, true)),
+                List.of(new MonthlySocialRankingItem(1, 1, 3L, "나", null, DefaultProfileType.DEFAULT, true))
         );
         MonthlyReportV2 report = mock(MonthlyReportV2.class);
         when(report.getUser()).thenReturn(user);
@@ -293,6 +293,7 @@ class MonthlyReportQueryServiceV2Test {
         assertThat(response.socialSummary().visible()).isTrue();
         assertThat(response.socialSummary().likeRanking()).singleElement().satisfies(item -> {
             assertThat(item.displayOrder()).isEqualTo(1);
+            assertThat(item.rank()).isEqualTo(1);
             assertThat(item.userId()).isEqualTo(2L);
             assertThat(item.profileImageUrl()).isEqualTo("https://cdn/custom-key");
             assertThat(item.topRank()).isTrue();

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/helper/MonthlySocialSummaryCalculatorTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/application/helper/MonthlySocialSummaryCalculatorTest.java
@@ -53,6 +53,8 @@ class MonthlySocialSummaryCalculatorTest {
                 .containsExactly("나", "다");
         assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::displayOrder)
                 .containsExactly(1, 2);
+        assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::rank)
+                .containsExactly(1, 2);
         assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::topRank)
                 .containsExactly(true, false);
     }
@@ -79,12 +81,38 @@ class MonthlySocialSummaryCalculatorTest {
                 .containsExactly("가", "나", "라");
         assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::displayOrder)
                 .containsExactly(1, 2, 3);
+        assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::rank)
+                .containsExactly(1, 1, 1);
         assertThat(result.likeRanking()).allMatch(MonthlySocialRankingItem::topRank);
 
         assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::nickname)
                 .containsExactly("나", "다", "가");
+        assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::rank)
+                .containsExactly(1, 1, 3);
         assertThat(result.commentRanking()).extracting(MonthlySocialRankingItem::topRank)
                 .containsExactly(true, true, false);
+    }
+
+    @Test
+    void assigns_same_rank_to_second_place_ties() {
+        MonthlySocialSummaryContent result = MonthlySocialSummaryCalculator.calculate(
+                5,
+                List.of(
+                        count(1L, "가", 5),
+                        count(2L, "나", 4),
+                        count(3L, "다", 4)
+                ),
+                List.of(count(4L, "라", 1), count(5L, "마", 1))
+        );
+
+        assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::nickname)
+                .containsExactly("가", "나", "다");
+        assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::displayOrder)
+                .containsExactly(1, 2, 3);
+        assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::rank)
+                .containsExactly(1, 2, 2);
+        assertThat(result.likeRanking()).extracting(MonthlySocialRankingItem::topRank)
+                .containsExactly(true, false, false);
     }
 
     private MonthlySocialInteractionCountDto count(Long userId, String nickname, long count) {

--- a/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/core/content/MonthlySocialSummaryContentTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/monthlyreport/core/content/MonthlySocialSummaryContentTest.java
@@ -22,10 +22,12 @@ class MonthlySocialSummaryContentTest {
         assertThat(normalized.month()).isEqualTo(12);
         assertThat(normalized.likeRanking()).extracting(MonthlySocialRankingItem::displayOrder)
                 .containsExactly(1, 2, 3);
+        assertThat(normalized.likeRanking()).extracting(MonthlySocialRankingItem::rank)
+                .containsExactly(1, 2, 3);
         assertThat(normalized.commentRanking()).isEmpty();
     }
 
     private MonthlySocialRankingItem item(int rank) {
-        return new MonthlySocialRankingItem(rank, (long) rank, "friend" + rank, null, null, rank == 1);
+        return new MonthlySocialRankingItem(rank, rank, (long) rank, "friend" + rank, null, null, rank == 1);
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- **1.4.0버전 QA에서 발견된 수정 필요 사항들에 대한 작업입니다.**
- 월간 리포트 V2 조회에서 `previousReport`가 바로 이전 달만 찾던 문제를 수정해, V1/V2 구분 없이 존재하는 직전 완료 리포트를 반환하도록 보정했습니다.
- monthly_report_v2 소셜 랭킹 응답에 동점 처리가 반영된 `rank` 필드를 추가해 프론트엔드가 `1, 1, 3`, `1, 2, 2` 형태의 넘버링을 그대로 표시할 수 있게 했습니다.
- `RELATIONSHIP` 관심사명을 `인간관계`에서 `관계`로 변경하는 Flyway 마이그레이션을 추가했습니다.

### 주요 변경사항
- **월간 리포트 조회**
  - `MonthlyReportLocatorResolver`에 V1/V2 완료 리포트 중 기준 월 이전의 가장 최신 리포트를 찾는 `findLatestCompletedBefore` 추가
  - `GET /api/v2/monthly-report`의 `previousReport` 조회 기준을 바로 이전 달에서 존재하는 직전 완료 리포트로 변경
  - V1/V2가 함께 존재하는 이전 리포트 후보 중 더 최신 월을 선택하는 테스트 추가

- **소셜 랭킹 응답**
  - `MonthlySocialRankingItem` 및 `MonthlySocialRankingItemResponse`에 `rank` 필드 추가
  - `displayOrder`는 화면 배치 순서로 유지하고, `rank`는 동점 처리된 실제 표시 순위로 분리
  - 공동 1위 및 2위 동점 케이스의 순위 계산 테스트 보강
  - Swagger 설명에 `rank` 필드 의미 추가

- **DB 마이그레이션**
  - `interests.code = 'RELATIONSHIP'` 레코드의 `name`을 `관계`로 변경하는 Flyway SQL 추가

## 검증
- `.\gradlew.bat compileJava`
- `.\gradlew.bat test --tests "com.devkor.ifive.nadab.domain.monthlyreport.application.helper.MonthlySocialSummaryCalculatorTest" --tests "com.devkor.ifive.nadab.domain.monthlyreport.core.content.MonthlySocialSummaryContentTest" --tests "com.devkor.ifive.nadab.domain.monthlyreport.application.MonthlyReportQueryServiceV2Test" --tests "com.devkor.ifive.nadab.domain.monthlyreport.MonthlyReportV2RepositoryTest"`
- `git diff --check`


## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.