### PR TITLE
fix(infra): 운영 배포 Secret 전달 및 CI 안정성 개선

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -39,12 +39,64 @@ jobs:
 
       - name: 🚀 Restart App on EC2 (Prod)
         uses: appleboy/ssh-action@v1
+        env:
+          INSIGHT_PROMPT_B64: ${{ secrets.INSIGHT_PROMPT_B64 }}
+          INSIGHT_WITH_IMAGE_PROMPT_B64: ${{ secrets.INSIGHT_WITH_IMAGE_PROMPT_B64 }}
+          WEEKLY_PROMPT_B64: ${{ secrets.WEEKLY_PROMPT_B64 }}
+          MONTHLY_V1_PROMPT_B64: ${{ secrets.MONTHLY_V1_PROMPT_B64 }}
+          MONTHLY_V2_BASELINE_PROMPT_B64: ${{ secrets.MONTHLY_V2_BASELINE_PROMPT_B64 }}
+          MONTHLY_V2_COMPARISON_PROMPT_B64: ${{ secrets.MONTHLY_V2_COMPARISON_PROMPT_B64 }}
+          EVIDENCE_CARD_PROMPT_B64: ${{ secrets.EVIDENCE_CARD_PROMPT_B64 }}
+          PATTERN_EXTRACT_PROMPT_B64: ${{ secrets.PATTERN_EXTRACT_PROMPT_B64 }}
+          TYPE_SELECT_PROMPT_B64: ${{ secrets.TYPE_SELECT_PROMPT_B64 }}
+          TYPE_PROMPT_B64: ${{ secrets.TYPE_PROMPT_B64 }}
+          REPAIR_TYPE_PROMPT_B64: ${{ secrets.REPAIR_TYPE_PROMPT_B64 }}
+          ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64: ${{ secrets.ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64 }}
+          ASK_CHAT_ANSWER_USER_PROMPT_B64: ${{ secrets.ASK_CHAT_ANSWER_USER_PROMPT_B64 }}
+          NOTIFICATION_MESSAGES_B64: ${{ secrets.NOTIFICATION_MESSAGES_B64 }}
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          FRONTEND_PROD_URL: ${{ secrets.FRONTEND_PROD_URL }}
+          FRONTEND_PROD_URL_2: ${{ secrets.FRONTEND_PROD_URL_2 }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
+          NAVER_REDIRECT_URI: ${{ secrets.NAVER_REDIRECT_URI }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_ANDROID_CLIENT_ID: ${{ secrets.GOOGLE_ANDROID_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+          KAKAO_APP_ID: ${{ secrets.KAKAO_APP_ID }}
+          APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_PRIVATE_KEY: ${{ secrets.APPLE_PRIVATE_KEY }}
+          IAM_ACCESS_KEY: ${{ secrets.IAM_ACCESS_KEY }}
+          IAM_SECRET_KEY: ${{ secrets.IAM_SECRET_KEY }}
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          PROFILE_IMAGE_BASE_URL: ${{ secrets.PROFILE_IMAGE_BASE_URL }}
+          CLOUDFRONT_KEY_PAIR_ID: ${{ secrets.CLOUDFRONT_KEY_PAIR_ID }}
+          CLOUDFRONT_PRIVATE_KEY: ${{ secrets.CLOUDFRONT_PRIVATE_KEY }}
+          KMS_KEY_ID: ${{ secrets.KMS_KEY_ID }}
+          MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}
+          FIREBASE_ADMIN_KEY: ${{ secrets.FIREBASE_ADMIN_KEY }}
+          ADMIN_PAGE_PASSWORD: ${{ secrets.ADMIN_PAGE_PASSWORD }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          envs: INSIGHT_PROMPT_B64,INSIGHT_WITH_IMAGE_PROMPT_B64,WEEKLY_PROMPT_B64,MONTHLY_V1_PROMPT_B64,MONTHLY_V2_BASELINE_PROMPT_B64,MONTHLY_V2_COMPARISON_PROMPT_B64,EVIDENCE_CARD_PROMPT_B64,PATTERN_EXTRACT_PROMPT_B64,TYPE_SELECT_PROMPT_B64,TYPE_PROMPT_B64,REPAIR_TYPE_PROMPT_B64,ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64,ASK_CHAT_ANSWER_USER_PROMPT_B64,NOTIFICATION_MESSAGES_B64,DB_URL,DB_USERNAME,DB_PASSWORD,JWT_SECRET,FRONTEND_PROD_URL,FRONTEND_PROD_URL_2,NAVER_CLIENT_ID,NAVER_CLIENT_SECRET,NAVER_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_ANDROID_CLIENT_ID,GOOGLE_IOS_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,KAKAO_APP_ID,APPLE_CLIENT_ID,APPLE_TEAM_ID,APPLE_KEY_ID,APPLE_PRIVATE_KEY,IAM_ACCESS_KEY,IAM_SECRET_KEY,BUCKET_NAME,PROFILE_IMAGE_BASE_URL,CLOUDFRONT_KEY_PAIR_ID,CLOUDFRONT_PRIVATE_KEY,KMS_KEY_ID,MAIL_ADDRESS,MAIL_PASSWORD,OPENAI_API_KEY,ANTHROPIC_API_KEY,GOOGLE_GENAI_API_KEY,FIREBASE_ADMIN_KEY,ADMIN_PAGE_PASSWORD
           script: |
-            set -euxo pipefail
+            set -euo pipefail
 
             cd ~/nadab
             echo "🔎 현재 서버 디렉토리: $(pwd)"
@@ -67,99 +119,49 @@ jobs:
             echo "🚀 새 버전 실행..."
 
             # base64 프롬프트 디코딩
-            INSIGHT_PROMPT_B64="${{ secrets.INSIGHT_PROMPT_B64 }}"
             INSIGHT_PROMPT="$(printf '%s' "$INSIGHT_PROMPT_B64" | base64 -d | tr -d '\r')"
             export INSIGHT_PROMPT
             
-            INSIGHT_WITH_IMAGE_PROMPT_B64="${{ secrets.INSIGHT_WITH_IMAGE_PROMPT_B64 }}"
             INSIGHT_WITH_IMAGE_PROMPT="$(printf '%s' "$INSIGHT_WITH_IMAGE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export INSIGHT_WITH_IMAGE_PROMPT
 
-            WEEKLY_PROMPT_B64="${{ secrets.WEEKLY_PROMPT_B64 }}"
             WEEKLY_PROMPT="$(printf '%s' "$WEEKLY_PROMPT_B64" | base64 -d | tr -d '\r')"
             export WEEKLY_PROMPT
 
-            MONTHLY_V1_PROMPT_B64="${{ secrets.MONTHLY_V1_PROMPT_B64 }}"
             MONTHLY_V1_PROMPT="$(printf '%s' "$MONTHLY_V1_PROMPT_B64" | base64 -d | tr -d '\r')"
             export MONTHLY_V1_PROMPT
             
-            MONTHLY_V2_BASELINE_PROMPT_B64="${{ secrets.MONTHLY_V2_BASELINE_PROMPT_B64 }}"
             MONTHLY_V2_BASELINE_PROMPT="$(printf '%s' "$MONTHLY_V2_BASELINE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export MONTHLY_V2_BASELINE_PROMPT
 
-            MONTHLY_V2_COMPARISON_PROMPT_B64="${{ secrets.MONTHLY_V2_COMPARISON_PROMPT_B64 }}"
             MONTHLY_V2_COMPARISON_PROMPT="$(printf '%s' "$MONTHLY_V2_COMPARISON_PROMPT_B64" | base64 -d | tr -d '\r')"
             export MONTHLY_V2_COMPARISON_PROMPT
             
-            EVIDENCE_CARD_PROMPT_B64="${{ secrets.EVIDENCE_CARD_PROMPT_B64 }}"
             EVIDENCE_CARD_PROMPT="$(printf '%s' "$EVIDENCE_CARD_PROMPT_B64" | base64 -d | tr -d '\r')"
             export EVIDENCE_CARD_PROMPT
             
-            PATTERN_EXTRACT_PROMPT_B64="${{ secrets.PATTERN_EXTRACT_PROMPT_B64 }}"
             PATTERN_EXTRACT_PROMPT="$(printf '%s' "$PATTERN_EXTRACT_PROMPT_B64" | base64 -d | tr -d '\r')"
             export PATTERN_EXTRACT_PROMPT
             
-            TYPE_SELECT_PROMPT_B64="${{ secrets.TYPE_SELECT_PROMPT_B64 }}"
             TYPE_SELECT_PROMPT="$(printf '%s' "$TYPE_SELECT_PROMPT_B64" | base64 -d | tr -d '\r')"
             export TYPE_SELECT_PROMPT
             
-            TYPE_PROMPT_B64="${{ secrets.TYPE_PROMPT_B64 }}"
             TYPE_PROMPT="$(printf '%s' "$TYPE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export TYPE_PROMPT
             
-            REPAIR_TYPE_PROMPT_B64="${{ secrets.REPAIR_TYPE_PROMPT_B64 }}"
             REPAIR_TYPE_PROMPT="$(printf '%s' "$REPAIR_TYPE_PROMPT_B64" | base64 -d | tr -d '\r')"
             export REPAIR_TYPE_PROMPT
 
-            ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64 }}"
             ASK_CHAT_ANSWER_SYSTEM_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_SYSTEM_PROMPT_B64" | base64 -d | tr -d '\r')"
             export ASK_CHAT_ANSWER_SYSTEM_PROMPT
 
-            ASK_CHAT_ANSWER_USER_PROMPT_B64="${{ secrets.ASK_CHAT_ANSWER_USER_PROMPT_B64 }}"
             ASK_CHAT_ANSWER_USER_PROMPT="$(printf '%s' "$ASK_CHAT_ANSWER_USER_PROMPT_B64" | base64 -d | tr -d '\r')"
             export ASK_CHAT_ANSWER_USER_PROMPT
 
-            NOTIFICATION_MESSAGES_B64="${{ secrets.NOTIFICATION_MESSAGES_B64 }}"
             NOTIFICATION_MESSAGES="$(printf '%s' "$NOTIFICATION_MESSAGES_B64" | base64 -d | tr -d '\r')"
             export NOTIFICATION_MESSAGES
 
             # ✅ prod 환경변수 주입 + 실행
-            DB_URL="${{ secrets.DB_URL }}" \
-            DB_USERNAME="${{ secrets.DB_USERNAME }}" \
-            DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
-            JWT_SECRET="${{ secrets.JWT_SECRET }}" \
-            FRONTEND_PROD_URL="${{ secrets.FRONTEND_PROD_URL }}" \
-            FRONTEND_PROD_URL_2="${{ secrets.FRONTEND_PROD_URL_2 }}" \
-            NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
-            NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
-            NAVER_REDIRECT_URI="${{ secrets.NAVER_REDIRECT_URI }}" \
-            GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
-            GOOGLE_ANDROID_CLIENT_ID="${{ secrets.GOOGLE_ANDROID_CLIENT_ID }}" \
-            GOOGLE_IOS_CLIENT_ID="${{ secrets.GOOGLE_IOS_CLIENT_ID }}" \
-            GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
-            GOOGLE_REDIRECT_URI="${{ secrets.GOOGLE_REDIRECT_URI }}" \
-            KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
-            KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
-            KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
-            KAKAO_APP_ID="${{ secrets.KAKAO_APP_ID }}" \
-            APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
-            APPLE_TEAM_ID="${{ secrets.APPLE_TEAM_ID }}" \
-            APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \
-            APPLE_PRIVATE_KEY="${{ secrets.APPLE_PRIVATE_KEY }}" \
-            IAM_ACCESS_KEY="${{ secrets.IAM_ACCESS_KEY }}" \
-            IAM_SECRET_KEY="${{ secrets.IAM_SECRET_KEY }}" \
-            BUCKET_NAME="${{ secrets.BUCKET_NAME }}" \
-            PROFILE_IMAGE_BASE_URL="${{ secrets.PROFILE_IMAGE_BASE_URL }}" \
-            CLOUDFRONT_KEY_PAIR_ID="${{ secrets.CLOUDFRONT_KEY_PAIR_ID }}" \
-            CLOUDFRONT_PRIVATE_KEY="${{ secrets.CLOUDFRONT_PRIVATE_KEY }}" \
-            KMS_KEY_ID="${{ secrets.KMS_KEY_ID }}" \
-            MAIL_ADDRESS="${{ secrets.MAIL_ADDRESS }}" \
-            MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
-            OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" \
-            ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
-            GOOGLE_GENAI_API_KEY="${{ secrets.GOOGLE_GENAI_API_KEY }}" \
-            FIREBASE_ADMIN_KEY="${{ secrets.FIREBASE_ADMIN_KEY }}" \
-            ADMIN_PAGE_PASSWORD='${{ secrets.ADMIN_PAGE_PASSWORD }}' \
             nohup java -jar "$JAR_PATH" \
               --spring.profiles.active=prod > app-prod.log 2>&1 &
 

--- a/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/dailyreport/application/DailyReportServiceTest.java
@@ -23,6 +23,7 @@ import com.devkor.ifive.nadab.domain.user.infra.ProfileImageUrlBuilder;
 import com.devkor.ifive.nadab.global.infra.llm.LlmGenerationResult;
 import com.devkor.ifive.nadab.global.infra.llm.LlmProvider;
 import com.devkor.ifive.nadab.global.infra.llm.LlmTokenUsage;
+import com.devkor.ifive.nadab.global.shared.util.TodayDateTimeProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,14 +95,15 @@ class DailyReportServiceTest {
         Long generationLogId = 10L;
         User user = user(userId);
         DailyQuestion question = dailyQuestion(20L);
-        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", LocalDate.now(), null);
+        LocalDate today = TodayDateTimeProvider.getTodayDate();
+        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", today, null);
         AiDailyReportResultDto aiResult = new AiDailyReportResultDto("message", "ACHIEVEMENT");
         Emotion emotion = emotion(EmotionCode.ACHIEVEMENT);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(dailyQuestionRepository.findByIdWithInterest(20L)).thenReturn(Optional.of(question));
         when(userDailyQuestionRepository.findByUserIdAndDate(eq(userId), any(LocalDate.class)))
-                .thenReturn(Optional.of(UserDailyQuestion.create(user, LocalDate.now(), question)));
+                .thenReturn(Optional.of(UserDailyQuestion.create(user, today, question)));
         when(dailyReportTxService.prepareDaily(user, question, "answer", false, null))
                 .thenReturn(new PrepareDailyResultDto(answerEntry, reportId, userId));
         when(reportGenerationLogRecorder.start(
@@ -144,14 +146,15 @@ class DailyReportServiceTest {
         Long generationLogId = 10L;
         User user = user(userId);
         DailyQuestion question = dailyQuestion(20L);
-        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", LocalDate.now(), null);
+        LocalDate today = TodayDateTimeProvider.getTodayDate();
+        AnswerEntry answerEntry = AnswerEntry.create(user, question, "answer", today, null);
         AiDailyReportResultDto aiResult = new AiDailyReportResultDto("message", "ACHIEVEMENT");
         Emotion emotion = emotion(EmotionCode.ACHIEVEMENT);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(dailyQuestionRepository.findByIdWithInterest(20L)).thenReturn(Optional.of(question));
         when(userDailyQuestionRepository.findByUserIdAndDate(eq(userId), any(LocalDate.class)))
-                .thenReturn(Optional.of(UserDailyQuestion.create(user, LocalDate.now(), question)));
+                .thenReturn(Optional.of(UserDailyQuestion.create(user, today, question)));
         when(dailyReportTxService.prepareDaily(user, question, "answer", false, null))
                 .thenReturn(new PrepareDailyResultDto(answerEntry, reportId, userId));
         when(reportGenerationLogRecorder.start(any(), any(), any(), any(), any(), any()))


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 운영 EC2 배포에서 SSH 액션 실행 전 발생한 `Argument list too long` 오류를 수정했습니다.
- Secret 값이 하나의 `INPUT_SCRIPT`에 합쳐지지 않도록 환경변수 전달 구조를 개선했습니다.
- UTC 기반 CI에서 특정 시간대에 실패하던 일일 리포트 테스트를 안정화했습니다.

### 주요 변경사항
- **운영 배포**
  - Base64 프롬프트와 애플리케이션 설정 50개를 `env`와 `envs`로 개별 전달
  - SSH 스크립트 내부의 `${{ secrets.* }}` 직접 치환 제거
  - `INPUT_SCRIPT`가 Secret 크기에 비례해 증가하던 구조 개선
- **배포 보안**
  - `set -x`를 제거해 디코딩된 프롬프트와 민감 정보의 로그 노출 위험 완화
  - 기존 프롬프트 디코딩과 Java 환경변수 상속 동작 유지
- **CI 테스트 안정성**
  - `DailyReportServiceTest`의 날짜 기준을 `TodayDateTimeProvider`로 통일
  - UTC 러너와 Asia/Seoul 비즈니스 날짜 차이로 발생하던 Mockito stub 인자 불일치 해결

### 검증
- 운영 배포 워크플로 YAML 파싱 성공
- `env`와 `envs` 전달 변수 50개 일치 및 누락·중복 0건 확인
- SSH 스크립트 내부 Secret 직접 치환 0건 확인
- `DailyReportServiceTest` 집중 테스트 통과
- 전체 Gradle 테스트 256개 통과
- 실패 및 오류 0건

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.