### PR TITLE
fix(infra): 운영 배포 Secret SCP 경로 수정

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          mkdir -p .deploy-secrets
+          mkdir -p deploy-secrets
 
           SECRET_NAMES=(
             INSIGHT_PROMPT_B64 INSIGHT_WITH_IMAGE_PROMPT_B64 WEEKLY_PROMPT_B64
@@ -113,7 +113,7 @@ jobs:
           )
 
           for name in "${SECRET_NAMES[@]}"; do
-            printf '%s' "${!name}" | base64 -w 0 > ".deploy-secrets/$name"
+            printf '%s' "${!name}" | base64 -w 0 > "deploy-secrets/$name"
           done
 
       - name: 📤 Upload deployment secrets to EC2
@@ -122,7 +122,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          source: ./.deploy-secrets/*
+          source: ./deploy-secrets
           target: ~/nadab/
           overwrite: true
 
@@ -149,7 +149,7 @@ jobs:
 
             echo "📌 배포할 JAR 선택됨: $JAR_PATH"
 
-            SECRETS_DIR=".deploy-secrets"
+            SECRETS_DIR="deploy-secrets"
             [ -d "$SECRETS_DIR" ] || { echo "❌ 배포 Secret 디렉토리가 존재하지 않습니다"; exit 1; }
             chmod 700 "$SECRETS_DIR"
             chmod 600 "$SECRETS_DIR"/*
@@ -229,7 +229,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          if [ -d .deploy-secrets ]; then
-            rm -f -- .deploy-secrets/*
-            rmdir -- .deploy-secrets
+          if [ -d deploy-secrets ]; then
+            rm -f -- deploy-secrets/*
+            rmdir -- deploy-secrets
           fi


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 운영 Secret 파일 업로드 단계에서 발생한 `tar: empty archive` 오류를 수정했습니다.
- `drone-scp`의 숨김 디렉토리 및 wildcard 해석에 의존하지 않도록 source 경로를 변경했습니다.

### 주요 변경사항
- **SCP source**
  - 숨김 디렉토리 `.deploy-secrets`를 일반 `deploy-secrets` 디렉토리로 변경
  - `source: ./.deploy-secrets/*`를 `source: ./deploy-secrets`로 변경
  - wildcard 대신 디렉토리 자체를 SCP source로 지정
- **경로 일관성**
  - Secret 파일 생성 경로 변경
  - EC2의 Secret 복원 경로 변경
  - 러너의 임시 Secret 정리 경로 변경
  - 기존 파일 권한과 비재귀 정리 방식 유지

### 검증
- 운영 배포 워크플로 YAML 파싱 성공
- SCP source가 `./deploy-secrets` 디렉토리를 직접 가리키는지 확인
- 숨김 Secret 경로 및 Secret 업로드 wildcard 사용 0건 확인
- Secret 선언·생성·복원 목록 50개 일치 확인
- 모든 셸 스크립트 `bash -n` 문법 검사 통과
- `git diff --check` 통과
- Java 애플리케이션 코드는 변경하지 않아 Gradle 테스트 미실행

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.