### PR TITLE
fix(infra): 운영 배포 Secret SCP 권한 및 로그 경로 수정

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -116,6 +116,10 @@ jobs:
             printf '%s' "${!name}" | base64 -w 0 > ".deploy-secrets/$name"
           done
 
+          # scp-action Docker 컨테이너가 다른 UID로 파일을 읽을 수 있도록 전송 직전에만 권한 허용
+          chmod 755 .deploy-secrets
+          chmod 644 .deploy-secrets/*
+
       - name: 📤 Upload deployment secrets to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -223,7 +227,7 @@ jobs:
               --spring.profiles.active=prod > app-prod.log 2>&1 &
 
             echo "✅ 배포 완료!"
-            echo "📄 로그: ~/nadab-prod/app-prod.log"
+            echo "📄 로그: ~/nadab/app-prod.log"
 
       - name: 🧹 Cleanup deployment secrets
         if: always()


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 운영 배포 중 SCP 컨테이너가 Secret 파일을 읽지 못하는 권한 문제를 해결했습니다.
- 배포 완료 메시지의 잘못된 로그 경로를 실제 위치와 일치시켰습니다.

### 주요 변경사항
- **Secret 파일 전송**
  - 전송 직전에 `.deploy-secrets` 디렉터리를 `755`, 내부 파일을 `644`로 설정했습니다.
  - 다른 UID로 실행되는 `scp-action` Docker 컨테이너가 파일을 읽을 수 있도록 보완했습니다.
  - EC2 도착 후 기존 스크립트에서 디렉터리 `700`, 파일 `600`으로 다시 제한합니다.
- **배포 로그 안내**
  - 로그 안내 경로를 실제 출력 위치인 `~/nadab/app-prod.log`로 수정했습니다.

### 검증
- 워크플로 YAML 파싱 통과
- Secret 생성·권한 변경·SCP 전송·원격 복원 경로 일치 확인
- 모든 Bash 스크립트 문법 검사 통과
- `git diff --check` 통과
- Java 애플리케이션 변경이 없어 Gradle 테스트는 실행하지 않음

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.