### PR TITLE
fix(infra): 운영 배포 Secret 권한 경로 수정

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -117,8 +117,8 @@ jobs:
           done
 
           # scp-action Docker 컨테이너가 다른 UID로 파일을 읽을 수 있도록 전송 직전에만 권한 허용
-          chmod 755 .deploy-secrets
-          chmod 644 .deploy-secrets/*
+          chmod 755 deploy-secrets
+          chmod 644 deploy-secrets/*
 
       - name: 📤 Upload deployment secrets to EC2
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 운영 배포의 Secret 생성 경로와 권한 변경 경로가 달라 SCP 실행 전에 실패하던 문제를 수정했습니다.

### 주요 변경사항
- **배포 인프라**
  - Secret 생성 경로에 맞춰 `chmod` 대상을 `deploy-secrets`로 변경했습니다.
  - 생성·파일 기록·권한 변경·SCP·원격 복원·정리 단계가 모두 동일한 디렉터리를 사용하도록 정합성을 확인했습니다.

### 검증
- 워크플로 YAML 파싱 통과
- 전체 `deploy-secrets` 경로 일관성 검사 통과
- 모든 Bash 스크립트 문법 검사 통과
- `git diff --check` 통과
- Java 애플리케이션 변경이 없어 Gradle 테스트는 실행하지 않음

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.