### PR TITLE
feat: Ask Chat 남은 메시지 수 응답 보강

### DIFF
--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionController.java
@@ -4,6 +4,7 @@ import com.devkor.ifive.nadab.domain.askchat.api.dto.request.AskChatQuestionRequ
 import com.devkor.ifive.nadab.domain.askchat.api.dto.request.AskChatSessionStartRequest;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatRemainingMessageCountResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatTurnChargeResponse;
 import com.devkor.ifive.nadab.domain.askchat.application.AskChatMessageCommandService;
 import com.devkor.ifive.nadab.domain.askchat.application.AskChatSessionService;
@@ -155,6 +156,37 @@ public class AskChatSessionController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         AskChatTurnChargeResponse response = askChatWalletChargeService.chargeTurns(principal.getId());
+        return ApiResponseEntity.ok(response);
+    }
+
+    @GetMapping("/turns/remaining")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "물어보기 남은 메시지 횟수 조회",
+            description = """
+                    현재 사용자가 사용할 수 있는 물어보기 남은 메시지 횟수만 조회합니다. </br>
+                    홈 전체 정보를 다시 조회하지 않고 질문 전송/충전 이후 카운터만 갱신할 때 사용할 수 있습니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "남은 메시지 횟수 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AskChatRemainingMessageCountResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "- ErrorCode: ASK_CHAT_WALLET_NOT_FOUND - Ask Chat 대화권 지갑을 찾을 수 없음",
+                            content = @Content
+                    )
+            }
+    )
+    public ResponseEntity<ApiResponseDto<AskChatRemainingMessageCountResponse>> getRemainingTurns(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AskChatRemainingMessageCountResponse response =
+                askChatSessionService.getRemainingMessageCount(principal.getId());
         return ApiResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatQuestionSendResponse.java
@@ -18,6 +18,9 @@ public record AskChatQuestionSendResponse(
         @Schema(description = "답변 생성 성공/실패 상태. 실패 시 프론트에서는 이 값을 기준으로 모달/토스트를 표시합니다.")
         AskChatAnswerGenerationResponse answerGeneration,
 
+        @Schema(description = "답변 생성 처리 이후 사용 가능한 남은 메시지 횟수. 성공 시에는 차감 이후 값, 실패 시에는 환불 이후 값입니다.", example = "8")
+        int remainingMessageCount,
+
         @Schema(description = "AI가 제안한 후속 추천 질문. 생성 실패 시 빈 배열")
         List<String> followUpQuestions
 ) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatRemainingMessageCountResponse.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/api/dto/response/AskChatRemainingMessageCountResponse.java
@@ -1,0 +1,10 @@
+package com.devkor.ifive.nadab.domain.askchat.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물어보기 남은 메시지 횟수 응답")
+public record AskChatRemainingMessageCountResponse(
+        @Schema(description = "사용 가능한 남은 메시지 횟수", example = "9")
+        int remainingMessageCount
+) {
+}

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandService.java
@@ -17,6 +17,7 @@ import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRefer
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatWalletRepository;
 import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
@@ -48,6 +49,7 @@ public class AskChatMessageCommandService {
     private final AskChatAnswerLlmClient askChatAnswerLlmClient;
     private final AskChatAnswerProperties askChatAnswerProperties;
     private final AskChatTurnReservationService askChatTurnReservationService;
+    private final AskChatWalletRepository askChatWalletRepository;
 
     @Transactional
     public AskChatQuestionSendResponse sendQuestion(Long userId, Long sessionId, String content) {
@@ -70,6 +72,7 @@ public class AskChatMessageCommandService {
 
         AskChatMessage assistantMessage;
         AskChatAnswerGenerationResponse answerGeneration;
+        int remainingMessageCount;
         List<String> followUpQuestions;
         try {
             AskChatAnswerGenerationResult generationResult = askChatAnswerLlmClient.generate(context);
@@ -78,12 +81,14 @@ public class AskChatMessageCommandService {
             saveMessageReferences(assistantMessage, generationResult);
             askChatTurnReservationService.confirm(turnReservation);
             session = completeAnsweredTurn(userId, session.getId());
+            remainingMessageCount = getRemainingMessageCount(userId);
             answerGeneration = AskChatAnswerGenerationResponse.completed();
             followUpQuestions = generationResult.answer().followUpQuestions();
         } catch (AiServiceException e) {
             long generationDurationMs = elapsedMillis(generationStartedAt);
             saveFailedAssistantMessage(session, e, generationDurationMs);
             askChatTurnReservationService.refund(userId, session, turnReservation);
+            remainingMessageCount = getRemainingMessageCount(userId);
             assistantMessage = null;
             answerGeneration = AskChatAnswerGenerationResponse.failed(
                     e.getErrorCode(),
@@ -97,6 +102,7 @@ public class AskChatMessageCommandService {
                 AskChatMessageResponse.from(userMessage),
                 assistantMessage == null ? null : AskChatMessageResponse.from(assistantMessage),
                 answerGeneration,
+                remainingMessageCount,
                 followUpQuestions
         );
     }
@@ -157,6 +163,12 @@ public class AskChatMessageCommandService {
     private AskChatSession getSession(Long userId, Long sessionId) {
         return askChatSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ASK_CHAT_SESSION_NOT_FOUND));
+    }
+
+    private int getRemainingMessageCount(Long userId) {
+        return askChatWalletRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ASK_CHAT_WALLET_NOT_FOUND))
+                .getTotalTurnBalance();
     }
 
     private AskChatSession completeAnsweredTurn(Long userId, Long sessionId) {

--- a/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
+++ b/src/main/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionService.java
@@ -2,6 +2,7 @@ package com.devkor.ifive.nadab.domain.askchat.application;
 
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatRemainingMessageCountResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSampleQuestionResponse;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSampleQuestion;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
@@ -68,6 +69,14 @@ public class AskChatSessionService {
     public AskChatQuestionSendResponse startSession(Long userId, String content) {
         AskChatSession session = createSession(userId);
         return askChatMessageCommandService.sendQuestion(userId, session.getId(), content);
+    }
+
+    @Transactional(readOnly = true)
+    public AskChatRemainingMessageCountResponse getRemainingMessageCount(Long userId) {
+        AskChatWallet askChatWallet = askChatWalletRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ASK_CHAT_WALLET_NOT_FOUND));
+
+        return new AskChatRemainingMessageCountResponse(askChatWallet.getTotalTurnBalance());
     }
 
     private void validateMinimumAnswerCount(Long userId) {

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionControllerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionControllerTest.java
@@ -98,6 +98,7 @@ class AskChatSessionControllerTest {
                         ErrorCode.AI_RESPONSE_PARSE_FAILED,
                         "generation failed"
                 ),
+                9,
                 List.of()
         );
         when(askChatSessionService.startSession(1L, "나는 어떤 사람이야?")).thenReturn(sendResponse);
@@ -138,6 +139,7 @@ class AskChatSessionControllerTest {
                         ErrorCode.AI_RESPONSE_PARSE_FAILED,
                         "generation failed"
                 ),
+                9,
                 List.of()
         );
         when(askChatMessageCommandService.sendQuestion(1L, 10L, "question")).thenReturn(sendResponse);

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionControllerTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/api/AskChatSessionControllerTest.java
@@ -6,6 +6,7 @@ import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatAnswerGener
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatHomeResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatMessageResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatQuestionSendResponse;
+import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatRemainingMessageCountResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSampleQuestionResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatSessionResponse;
 import com.devkor.ifive.nadab.domain.askchat.api.dto.response.AskChatTurnChargeResponse;
@@ -174,6 +175,23 @@ class AskChatSessionControllerTest {
         assertThat(response.getBody().getData().crystalBalance()).isEqualTo(70L);
         assertThat(response.getBody().getData().remainingMessageCount()).isEqualTo(12);
         verify(askChatWalletChargeService).chargeTurns(1L);
+    }
+
+    @Test
+    void getRemainingTurns_returns_remaining_message_count_only() {
+        AskChatSessionController controller = controller();
+        UserPrincipal principal = new UserPrincipal(1L);
+        AskChatRemainingMessageCountResponse remainingResponse =
+                new AskChatRemainingMessageCountResponse(9);
+        when(askChatSessionService.getRemainingMessageCount(1L)).thenReturn(remainingResponse);
+
+        ResponseEntity<ApiResponseDto<AskChatRemainingMessageCountResponse>> response =
+                controller.getRemainingTurns(principal);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getData().remainingMessageCount()).isEqualTo(9);
+        verify(askChatSessionService).getRemainingMessageCount(1L);
     }
 
     private AskChatSessionController controller() {

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatMessageCommandServiceTest.java
@@ -11,12 +11,15 @@ import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatMessageStatus;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatRagDocument;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSession;
 import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatSessionStatus;
+import com.devkor.ifive.nadab.domain.askchat.core.entity.AskChatWallet;
 import com.devkor.ifive.nadab.domain.askchat.core.properties.AskChatAnswerProperties;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageReferenceRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatMessageRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatRagDocumentRepository;
 import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatSessionRepository;
+import com.devkor.ifive.nadab.domain.askchat.core.repository.AskChatWalletRepository;
 import com.devkor.ifive.nadab.domain.askchat.infra.AskChatAnswerLlmClient;
+import com.devkor.ifive.nadab.domain.user.core.entity.User;
 import com.devkor.ifive.nadab.global.core.response.ErrorCode;
 import com.devkor.ifive.nadab.global.exception.BadRequestException;
 import com.devkor.ifive.nadab.global.exception.ConflictException;
@@ -75,6 +78,9 @@ class AskChatMessageCommandServiceTest {
     @Mock
     private AskChatTurnReservationService askChatTurnReservationService;
 
+    @Mock
+    private AskChatWalletRepository askChatWalletRepository;
+
     private AskChatMessageCommandService service;
     private AskChatAnswerProperties askChatAnswerProperties;
 
@@ -91,7 +97,8 @@ class AskChatMessageCommandServiceTest {
                 askChatAnswerContextService,
                 askChatAnswerLlmClient,
                 askChatAnswerProperties,
-                askChatTurnReservationService
+                askChatTurnReservationService,
+                askChatWalletRepository
         );
     }
 
@@ -127,11 +134,13 @@ class AskChatMessageCommandServiceTest {
                 eq(AskChatSessionService.MAX_TURN_COUNT),
                 any(OffsetDateTime.class)
         )).thenReturn(1);
+        when(askChatWalletRepository.findByUserId(1L)).thenReturn(Optional.of(wallet(3, 5)));
 
         var response = service.sendQuestion(1L, 10L, "  나는 어떤 사람이야?  ");
 
         assertThat(response.session().sessionId()).isEqualTo(10L);
         assertThat(response.session().answeredTurnCount()).isEqualTo(3);
+        assertThat(response.remainingMessageCount()).isEqualTo(8);
         assertThat(response.userMessage().role()).isEqualTo(AskChatMessageRole.USER);
         assertThat(response.userMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
         assertThat(response.userMessage().content()).isEqualTo("나는 어떤 사람이야?");
@@ -205,11 +214,13 @@ class AskChatMessageCommandServiceTest {
         when(askChatTurnReservationService.reserveTurn(1L, activeSession)).thenReturn(reservation);
         when(askChatAnswerLlmClient.generate(context))
                 .thenThrow(new AiResponseParseException(ErrorCode.AI_RESPONSE_PARSE_FAILED));
+        when(askChatWalletRepository.findByUserId(1L)).thenReturn(Optional.of(wallet(2, 7)));
 
         var response = service.sendQuestion(1L, 11L, "나는 어떤 사람이야?");
 
         assertThat(response.userMessage().status()).isEqualTo(AskChatMessageStatus.COMPLETED);
         assertThat(response.assistantMessage()).isNull();
+        assertThat(response.remainingMessageCount()).isEqualTo(9);
         assertThat(response.answerGeneration().success()).isFalse();
         assertThat(response.answerGeneration().errorCode()).isEqualTo(ErrorCode.AI_RESPONSE_PARSE_FAILED.getCode());
         assertThat(response.answerGeneration().message()).isEqualTo("답변 생성에 오류가 발생했어요. 다시 시도해주세요.");
@@ -329,6 +340,10 @@ class AskChatMessageCommandServiceTest {
 
     private AskChatTurnReservation reservation() {
         return new AskChatTurnReservation(1000L, -1, 0);
+    }
+
+    private AskChatWallet wallet(int freeTurnBalance, int paidTurnBalance) {
+        return AskChatWallet.create(mock(User.class), freeTurnBalance, paidTurnBalance);
     }
 
     private AskChatSession session(

--- a/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
+++ b/src/test/java/com/devkor/ifive/nadab/domain/askchat/application/AskChatSessionServiceTest.java
@@ -147,6 +147,22 @@ class AskChatSessionServiceTest {
     }
 
     @Test
+    void getRemainingMessageCount_returns_total_turn_balance() {
+        User user = mock(User.class);
+        when(askChatWalletRepository.findByUserId(1L))
+                .thenReturn(Optional.of(AskChatWallet.create(user, 2, 7)));
+
+        var response = service.getRemainingMessageCount(1L);
+
+        assertThat(response.remainingMessageCount()).isEqualTo(9);
+        verifyNoInteractions(answerEntryRepository);
+        verifyNoInteractions(userRepository);
+        verifyNoInteractions(userWalletRepository);
+        verifyNoInteractions(askChatSampleQuestionRepository);
+        verify(askChatSessionRepository, never()).save(any());
+    }
+
+    @Test
     void startSession_rejects_missing_user_when_creating_session() {
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Ask Chat 질문 전송/세션 시작 응답에 답변 생성 처리 이후의 남은 메시지 수를 추가했습니다.
- 홈 전체 정보를 다시 조회하지 않아도 남은 메시지 수만 갱신할 수 있는 단독 조회 API를 추가했습니다.
- 답변 생성 성공/실패 케이스별 메시지 수 계산 기준을 테스트로 보강했습니다.

### 주요 변경사항
- **API 응답 계약**
  - `POST /ask-chat/sessions` 응답에 `remainingMessageCount` 추가
  - `POST /ask-chat/messages` 응답에 `remainingMessageCount` 추가
  - 성공 시 차감 확정 이후 값, 실패 시 환불 이후 값을 반환하도록 처리

- **남은 메시지 수 조회 API**
  - `GET /ask-chat/turns/remaining` 추가
  - 무료/유료 대화권을 합산한 `remainingMessageCount`만 반환
  - 홈 전체 데이터 재조회 없이 카운터만 갱신할 수 있도록 구성

- **서비스 로직**
  - `AskChatMessageCommandService`에서 답변 생성 성공/실패 처리 이후 Ask Chat 지갑을 재조회해 최종 잔여 횟수 반환
  - `AskChatSessionService.getRemainingMessageCount()` 추가
  - 단독 조회 API는 홈 진입 조건 검증 없이 Ask Chat 지갑 기준으로 잔여 횟수만 조회

- **테스트**
  - 질문 전송 성공 시 차감 이후 `remainingMessageCount` 검증
  - 답변 생성 실패 시 환불 이후 `remainingMessageCount` 검증
  - 남은 메시지 수 단독 조회 컨트롤러/서비스 테스트 추가

## 🔗 Related Issue
<!--- 열린 issue 중에 관련된 것이 있다면 닫아주세요. (Closes: #xxx)-->
- Closes: 

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.